### PR TITLE
feat: ダッシュボード UI 改善・ナビゲーション日本語化

### DIFF
--- a/docs/features/dashboard-ui-improvement.md
+++ b/docs/features/dashboard-ui-improvement.md
@@ -1,0 +1,174 @@
+# ダッシュボード UI 改善・ナビゲーション日本語化 計画
+
+## 背景と目的
+
+現在のダッシュボードおよびサイドバーナビゲーションは英語表記が残っており、
+中小製造業の生産管理者（現場・事務所勤務）が直感的に操作できない状態にある。
+
+本改善では以下の 2 点を同時に実施する。
+
+1. **ナビゲーション全項目の日本語化** — 英語ラベルを現場用語に合わせた日本語へ統一
+2. **ダッシュボードの大幅デザイン改善** — KPI の視認性・情報量・視覚的完成度を向上
+
+---
+
+## 対象ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `frontend/src/components/layout/app-sidebar.tsx` | メニュー項目を日本語化、グループラベル変更 |
+| `frontend/src/components/layout/authenticated-layout.tsx` | ヘッダーの "Dashboard" をルートに応じた動的タイトルへ変更 |
+| `frontend/src/app/page.tsx` | ダッシュボード全体のリデザイン |
+
+---
+
+## 1. ナビゲーション日本語化
+
+### 変更マッピング
+
+| 現在（英語） | 変更後（日本語） | 備考 |
+|---|---|---|
+| `Navigation`（グループラベル） | `メニュー` | SidebarGroupLabel |
+| `Dashboard` | `ダッシュボード` | トップページ |
+| `Orders` | `受注管理` | 製造業らしい用語 |
+| `Schedule` | `生産スケジュール` | ガントチャート画面 |
+| `Master Data` | `マスタデータ` | 親メニュー |
+| `Products` | `製品マスタ` | サブメニュー |
+| `Customers` | `顧客マスタ` | サブメニュー |
+| `Equipments` | `設備マスタ` | サブメニュー |
+| `Equipment Groups` | `設備グループ` | サブメニュー |
+| `Work Calendar` | `稼働カレンダー` | サブメニュー |
+| `Settings` | `設定` | 親メニュー |
+| `Members` | `メンバー管理` | サブメニュー |
+
+### Collapsible の defaultOpen 条件
+
+`item.title` の比較を日本語変更後の値に合わせて更新する必要がある（現在は英語で条件分岐）。
+
+```tsx
+// 変更前
+defaultOpen={
+  (item.title === "Master Data" && pathname.startsWith("/master")) ||
+  (item.title === "Settings" && pathname.startsWith("/settings"))
+}
+
+// 変更後
+defaultOpen={
+  (item.title === "マスタデータ" && pathname.startsWith("/master")) ||
+  (item.title === "設定" && pathname.startsWith("/settings"))
+}
+```
+
+### ヘッダーの動的タイトル
+
+`authenticated-layout.tsx` の `<div className="font-semibold">Dashboard</div>` を、
+現在のパスに対応する日本語タイトルを返すユーティリティに置き換える。
+
+```tsx
+// ページタイトルマッピング（authenticated-layout.tsx 内に定義）
+const pageTitleMap: Record<string, string> = {
+  "/": "ダッシュボード",
+  "/orders": "受注管理",
+  "/schedule": "生産スケジュール",
+  "/master/products": "製品マスタ",
+  "/master/customers": "顧客マスタ",
+  "/master/equipments": "設備マスタ",
+  "/master/equipment-groups": "設備グループ",
+  "/master/calendar": "稼働カレンダー",
+  "/settings/members": "メンバー管理",
+}
+```
+
+---
+
+## 2. ダッシュボード デザイン改善
+
+### 2-1. ヘッダーセクション
+
+**現状**: シンプルな h1 + サブテキスト
+
+**改善後**:
+- 今日の日付を右側に表示（例: `2026年6月8日（月）`）
+- サブテキストを `今日の生産状況` など具体的な表現へ
+
+```tsx
+<div className="mb-8 flex items-start justify-between">
+  <div>
+    <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
+    <p className="text-muted-foreground mt-1">今日の生産状況をご確認ください</p>
+  </div>
+  <div className="text-right text-sm text-muted-foreground">
+    <p>{format(new Date(), "yyyy年M月d日（E）", { locale: ja })}</p>
+  </div>
+</div>
+```
+
+### 2-2. KPI カード（上段）
+
+**現状**: 2 枚（今日の納期、Draft 未確定）のみ
+
+**改善後**: 4 枚に拡張し、アイコン・カラーを整理
+
+| カード | データソース | アイコン | アクセントカラー |
+|---|---|---|---|
+| 今日の納期 | `confirmed_deadline` が今日の注文数 | `Clock` | `blue` |
+| 未確定注文 | `status === "draft"` の件数 | `FileText` | `orange` |
+| 確定済み注文 | `status === "confirmed"` の件数 | `CheckCircle` | `green` |
+| 今週の受注 | 今週作成された注文の件数 | `TrendingUp` | `purple` |
+
+各カードのデザイン仕様:
+- ボーダーあり、`shadow-sm`
+- 上部にカラーラインアクセント（`border-t-4 border-t-blue-500` など）
+- アイコンを右上に配置（現在と同様）
+- 件数下に補足テキスト（例: `前日比 +2件` ）は将来拡張用として `—` で仮置き
+
+### 2-3. クイックアクション
+
+**現状**: カード内に単一ボタン
+
+**改善後**: 2 ボタン構成で頻度高い操作を並列配置
+
+| ボタン | 遷移先 | スタイル |
+|---|---|---|
+| 新規注文を入力する | `/orders/new` | Primary (filled) |
+| 生産スケジュールを確認する | `/schedule` | Outline |
+
+### 2-4. 最新の注文リスト
+
+**現状**: フラットなリスト、ステータスバッジが `bg-primary/10` 一色
+
+**改善後**:
+- ステータスバッジを色分け: `draft` → 黄 / `confirmed` → 緑 / `in_progress` → 青 / `completed` → グレー
+- 注文番号に `→` リンクを追加して詳細画面へ遷移可能にする
+- 空状態のデザインをアイコン付きで改善
+
+ステータスバッジ色定義（`getStatusLabel` は既存の `@/lib/order-utils` を流用）:
+
+```tsx
+const statusBadgeClass: Record<string, string> = {
+  draft: "bg-yellow-100 text-yellow-800",
+  confirmed: "bg-green-100 text-green-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  completed: "bg-gray-100 text-gray-700",
+}
+```
+
+---
+
+## 実装順序
+
+1. `app-sidebar.tsx` のメニュータイトル・グループラベルを日本語化（Collapsible 条件も合わせて修正）
+2. `authenticated-layout.tsx` のヘッダーを動的タイトルに変更
+3. `page.tsx` を改善版ダッシュボードへ書き換え
+
+---
+
+## 検証方法
+
+1. `cd frontend && npm run dev` でローカル起動
+2. サイドバーの全メニュー項目が日本語表示されていることを確認
+3. 各メニューをクリックし、ヘッダータイトルがページに合わせて切り替わることを確認
+4. マスタデータ・設定の折りたたみが正常に動作することを確認
+5. ダッシュボードの 4 枚の KPI カードが正しい件数を表示していることを確認（注文データが存在する状態で）
+6. 注文リストのステータスバッジが色分けされていることを確認
+7. クイックアクションの 2 ボタンがそれぞれ正しいページへ遷移することを確認

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,37 +2,60 @@
 
 import { useMemo } from "react"
 import { useRouter } from "next/navigation"
-import { Plus, ClipboardList, Clock, FileText } from "lucide-react"
+import {
+  Plus,
+  ClipboardList,
+  Clock,
+  FileText,
+  CheckCircle2,
+  TrendingUp,
+  ArrowRight,
+  CalendarDays,
+  PackageSearch,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useOrders } from "@/hooks/use-orders"
 import { useProducts } from "@/hooks/use-products"
-import { format, startOfDay, addDays } from "date-fns"
+import { format, startOfDay, addDays, startOfWeek } from "date-fns"
 import { ja } from "date-fns/locale"
 import { getProductName, getStatusLabel } from "@/lib/order-utils"
+
+const statusBadgeClass: Record<string, string> = {
+  draft: "bg-yellow-100 text-yellow-800 border border-yellow-200",
+  confirmed: "bg-green-100 text-green-800 border border-green-200",
+  in_progress: "bg-blue-100 text-blue-800 border border-blue-200",
+  completed: "bg-gray-100 text-gray-600 border border-gray-200",
+}
 
 export default function Home() {
   const router = useRouter()
   const { data: orders, isLoading: ordersLoading } = useOrders()
   const { data: products, isLoading: productsLoading } = useProducts()
 
-  // 今日の日付範囲
   const today = useMemo(() => startOfDay(new Date()), [])
   const tomorrow = useMemo(() => addDays(today, 1), [today])
+  const weekStart = useMemo(() => startOfWeek(today, { locale: ja }), [today])
 
-  // KPI集計: 今日が納期の注文数
   const todayDueCount = useMemo(() => {
     return orders?.filter((order) => {
       if (!order.confirmed_deadline) return false
       const deadline = new Date(order.confirmed_deadline)
       return deadline >= today && deadline < tomorrow
-    }).length || 0
+    }).length ?? 0
   }, [orders, today, tomorrow])
 
   const draftOrdersCount = useMemo(() => {
-    return orders?.filter((order) => order.status === "draft").length || 0
+    return orders?.filter((order) => order.status === "draft").length ?? 0
   }, [orders])
 
-  // 最新5件の注文
+  const confirmedOrdersCount = useMemo(() => {
+    return orders?.filter((order) => order.status === "confirmed").length ?? 0
+  }, [orders])
+
+  const weeklyOrdersCount = useMemo(() => {
+    return orders?.filter((order) => new Date(order.created_at) >= weekStart).length ?? 0
+  }, [orders, weekStart])
+
   const recentOrders = useMemo(() => {
     if (!orders) return []
     return [...orders]
@@ -40,120 +63,160 @@ export default function Home() {
       .slice(0, 5)
   }, [orders])
 
+  const kpiCards = [
+    {
+      label: "今日の納期",
+      value: ordersLoading ? "…" : todayDueCount,
+      unit: "件",
+      icon: Clock,
+      accent: "border-t-blue-500",
+      iconBg: "bg-blue-50",
+      iconColor: "text-blue-600",
+    },
+    {
+      label: "未確定注文",
+      value: ordersLoading ? "…" : draftOrdersCount,
+      unit: "件",
+      icon: FileText,
+      accent: "border-t-orange-400",
+      iconBg: "bg-orange-50",
+      iconColor: "text-orange-500",
+    },
+    {
+      label: "確定済み注文",
+      value: ordersLoading ? "…" : confirmedOrdersCount,
+      unit: "件",
+      icon: CheckCircle2,
+      accent: "border-t-green-500",
+      iconBg: "bg-green-50",
+      iconColor: "text-green-600",
+    },
+    {
+      label: "今週の受注",
+      value: ordersLoading ? "…" : weeklyOrdersCount,
+      unit: "件",
+      icon: TrendingUp,
+      accent: "border-t-purple-500",
+      iconBg: "bg-purple-50",
+      iconColor: "text-purple-600",
+    },
+  ]
+
   return (
-    <div className="container mx-auto py-6 px-4">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold">ダッシュボード</h1>
-        <p className="text-muted-foreground mt-2">
-          Product Planner へようこそ
-        </p>
-      </div>
-
-      {/* KPI Cards */}
-      <div className="grid gap-4 md:grid-cols-2 mb-6">
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-muted-foreground mb-1">
-                今日の納期
-              </p>
-              <p className="text-3xl font-bold">
-                {ordersLoading ? "..." : todayDueCount}
-              </p>
-              <p className="text-sm text-muted-foreground mt-1">件</p>
-            </div>
-            <div className="rounded-full bg-primary/10 p-3">
-              <Clock className="h-6 w-6 text-primary" />
-            </div>
-          </div>
+    <div className="container mx-auto py-6 px-4 max-w-6xl">
+      {/* ページヘッダー */}
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">ダッシュボード</h1>
+          <p className="text-muted-foreground mt-1">今日の生産状況をご確認ください</p>
         </div>
-
-        <div className="rounded-lg border bg-card p-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-muted-foreground mb-1">
-                Draft（未確定）
-              </p>
-              <p className="text-3xl font-bold">
-                {ordersLoading ? "..." : draftOrdersCount}
-              </p>
-              <p className="text-sm text-muted-foreground mt-1">件</p>
-            </div>
-            <div className="rounded-full bg-orange-500/10 p-3">
-              <FileText className="h-6 w-6 text-orange-500" />
-            </div>
+        <div className="text-right text-sm text-muted-foreground pt-1">
+          <div className="flex items-center gap-1.5 justify-end">
+            <CalendarDays className="h-4 w-4" />
+            <span>{format(new Date(), "yyyy年M月d日（E）", { locale: ja })}</span>
           </div>
         </div>
       </div>
 
-      {/* Quick Actions */}
-      <div className="rounded-lg border bg-card p-6 shadow-sm mb-6">
-        <h2 className="text-lg font-semibold mb-4">クイックアクション</h2>
-        <Button onClick={() => router.push("/orders/new")} size="lg">
-          <Plus className="mr-2 h-5 w-5" />
-          新規注文を入力する
-        </Button>
-      </div>
-
-      {/* Recent Orders */}
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold">最新の注文</h2>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => router.push("/orders")}
+      {/* KPI カード */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+        {kpiCards.map((card) => (
+          <div
+            key={card.label}
+            className={`rounded-lg border-t-4 ${card.accent} border border-border bg-card p-5 shadow-sm`}
           >
-            <ClipboardList className="mr-2 h-4 w-4" />
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground mb-2">{card.label}</p>
+                <div className="flex items-baseline gap-1">
+                  <span className="text-4xl font-bold">{card.value}</span>
+                  <span className="text-sm text-muted-foreground">{card.unit}</span>
+                </div>
+              </div>
+              <div className={`rounded-lg ${card.iconBg} p-2.5`}>
+                <card.icon className={`h-5 w-5 ${card.iconColor}`} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* クイックアクション */}
+      <div className="rounded-lg border bg-card p-6 shadow-sm mb-6">
+        <h2 className="text-base font-semibold mb-4">クイックアクション</h2>
+        <div className="flex flex-wrap gap-3">
+          <Button onClick={() => router.push("/orders/new")} size="lg" className="gap-2">
+            <Plus className="h-5 w-5" />
+            新規注文を入力する
+          </Button>
+          <Button
+            onClick={() => router.push("/schedule")}
+            size="lg"
+            variant="outline"
+            className="gap-2"
+          >
+            <ClipboardList className="h-5 w-5" />
+            生産スケジュールを確認する
+          </Button>
+        </div>
+      </div>
+
+      {/* 最新の注文 */}
+      <div className="rounded-lg border bg-card shadow-sm">
+        <div className="flex items-center justify-between px-6 py-4 border-b">
+          <h2 className="text-base font-semibold">最新の注文</h2>
+          <Button variant="ghost" size="sm" onClick={() => router.push("/orders")} className="gap-1 text-sm">
             すべて表示
+            <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
 
         {ordersLoading || productsLoading ? (
-          <div className="py-8 text-center text-muted-foreground">
-            読み込み中...
+          <div className="py-12 text-center text-muted-foreground">
+            <div className="animate-pulse">読み込み中...</div>
           </div>
         ) : recentOrders.length > 0 ? (
-          <div className="space-y-3">
+          <div className="divide-y">
             {recentOrders.map((order) => (
               <div
                 key={order.id}
-                className="flex items-center justify-between p-4 rounded-lg border bg-background hover:bg-accent/50 transition-colors"
+                onClick={() => router.push(`/orders/${order.id}`)}
+                className="flex items-center justify-between px-6 py-4 hover:bg-accent/40 transition-colors cursor-pointer"
               >
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="font-medium">{order.order_no}</span>
-                    <span className="text-sm px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className="font-medium text-sm">{order.order_no}</span>
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                        statusBadgeClass[order.status] ?? "bg-gray-100 text-gray-600"
+                      }`}
+                    >
                       {getStatusLabel(order.status)}
                     </span>
                   </div>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-sm text-muted-foreground truncate">
                     {getProductName(order.product_id, products)} × {order.quantity}
                   </p>
                 </div>
-                <div className="text-right text-sm text-muted-foreground">
+                <div className="text-right text-sm text-muted-foreground ml-4 shrink-0">
                   {order.confirmed_deadline
-                    ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd HH:mm", {
-                        locale: ja,
-                      })
+                    ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", { locale: ja })
                     : "納期未確定"}
                 </div>
               </div>
             ))}
           </div>
         ) : (
-          <div className="py-8 text-center text-muted-foreground">
-            <p className="mb-4">まだ注文がありません</p>
-            <Button
-              variant="outline"
-              onClick={() => router.push("/orders/new")}
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              新規注文を作成
+          <div className="py-16 text-center">
+            <PackageSearch className="h-12 w-12 text-muted-foreground/40 mx-auto mb-4" />
+            <p className="text-muted-foreground mb-4">まだ注文がありません</p>
+            <Button variant="outline" onClick={() => router.push("/orders/new")} className="gap-2">
+              <Plus className="h-4 w-4" />
+              最初の注文を作成する
             </Button>
           </div>
         )}
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -44,57 +44,57 @@ import { logout } from "@/lib/auth-server-actions"
 
 const menuItems = [
   {
-    title: "Dashboard",
+    title: "ダッシュボード",
     url: "/",
     icon: LayoutDashboard,
   },
   {
-    title: "Orders",
+    title: "受注管理",
     url: "/orders",
     icon: ShoppingCart,
   },
   {
-    title: "Schedule",
+    title: "生産スケジュール",
     url: "/schedule",
     icon: Calendar,
   },
   {
-    title: "Master Data",
+    title: "マスタデータ",
     icon: Database,
     items: [
       {
-        title: "Products",
+        title: "製品マスタ",
         url: "/master/products",
         icon: Package,
       },
       {
-        title: "Customers",
+        title: "顧客マスタ",
         url: "/master/customers",
         icon: Users,
       },
       {
-        title: "Equipments",
+        title: "設備マスタ",
         url: "/master/equipments",
         icon: Cpu,
       },
       {
-        title: "Equipment Groups",
+        title: "設備グループ",
         url: "/master/equipment-groups",
         icon: Layers,
       },
       {
-        title: "Work Calendar",
+        title: "稼働カレンダー",
         url: "/master/calendar",
         icon: Calendar,
       },
     ],
   },
   {
-    title: "Settings",
+    title: "設定",
     icon: Settings,
     items: [
       {
-        title: "Members",
+        title: "メンバー管理",
         url: "/settings/members",
         icon: Users,
       },
@@ -130,7 +130,7 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+          <SidebarGroupLabel>メニュー</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {menuItems.map((item) =>
@@ -138,8 +138,8 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
                   <Collapsible
                     key={item.title}
                     defaultOpen={
-                      (item.title === "Master Data" && pathname.startsWith("/master")) ||
-                      (item.title === "Settings" && pathname.startsWith("/settings"))
+                      (item.title === "マスタデータ" && pathname.startsWith("/master")) ||
+                      (item.title === "設定" && pathname.startsWith("/settings"))
                     }
                   >
                     <SidebarMenuItem>

--- a/frontend/src/components/layout/authenticated-layout.tsx
+++ b/frontend/src/components/layout/authenticated-layout.tsx
@@ -2,9 +2,23 @@
 "use client"
 
 import * as React from "react"
+import { usePathname } from "next/navigation"
 import { SidebarProvider, SidebarTrigger, SidebarInset } from "@/components/ui/sidebar"
 import { AppSidebar } from "./app-sidebar"
 import { Separator } from "@/components/ui/separator"
+
+const pageTitleMap: Record<string, string> = {
+  "/": "ダッシュボード",
+  "/orders": "受注管理",
+  "/orders/new": "新規注文",
+  "/schedule": "生産スケジュール",
+  "/master/products": "製品マスタ",
+  "/master/customers": "顧客マスタ",
+  "/master/equipments": "設備マスタ",
+  "/master/equipment-groups": "設備グループ",
+  "/master/calendar": "稼働カレンダー",
+  "/settings/members": "メンバー管理",
+}
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode
@@ -19,6 +33,9 @@ interface AuthenticatedLayoutProps {
  * SidebarProviderで全体をラップして状態を共有可能にする
  */
 export function AuthenticatedLayout({ children, user }: AuthenticatedLayoutProps) {
+  const pathname = usePathname()
+  const pageTitle = pageTitleMap[pathname] ?? "Product Planner"
+
   return (
     <SidebarProvider style={{ overflowX: 'hidden'}}>
       {/* サイドバー本体 */}
@@ -32,8 +49,7 @@ export function AuthenticatedLayout({ children, user }: AuthenticatedLayoutProps
         </div>
 
         <header className="flex h-15 shrink-0 items-center gap-2 border-b px-4">
-          {/* パンくずリストなど、ヘッダーに残したい要素があればここに記述 */}
-          <div className="font-semibold">Dashboard</div> 
+          <div className="font-semibold">{pageTitle}</div>
         </header>
 
         <div className="flex flex-1 flex-col px-4 py-6 space-y-6">


### PR DESCRIPTION
## 概要

- ナビゲーションメニューの全項目を日本語化し、中小製造業の生産管理者が迷わず使えるメニュー表記へ統一
- ダッシュボードのデザインを大幅リデザインし、KPI の視認性・情報量を向上

Closes #100

## 変更内容

### ナビゲーション日本語化
- `app-sidebar.tsx`: 全メニュー項目・グループラベルを日本語へ変更
- `authenticated-layout.tsx`: `pageTitleMap` を追加し、ヘッダータイトルを現在のパスに連動した動的表示へ変更

| 変更前 | 変更後 |
|---|---|
| Dashboard | ダッシュボード |
| Orders | 受注管理 |
| Schedule | 生産スケジュール |
| Master Data | マスタデータ |
| Products / Customers / Equipments / Equipment Groups / Work Calendar | 製品マスタ / 顧客マスタ / 設備マスタ / 設備グループ / 稼働カレンダー |
| Settings / Members | 設定 / メンバー管理 |

### ダッシュボード リデザイン（`page.tsx`）
- KPI カードを **2 枚 → 4 枚**に拡張（今日の納期 / 未確定注文 / 確定済み注文 / 今週の受注）
- カード上部にカラーラインアクセント（青・橙・緑・紫）で種別を視覚化
- ヘッダーに今日の日付を表示
- クイックアクションに「生産スケジュールを確認する」ボタンを追加
- ステータスバッジを色分け（draft=黄 / confirmed=緑 / in_progress=青 / completed=グレー）
- 注文行クリックで詳細画面へ遷移
- 空状態にアイコン付きデザインを適用

## テスト計画

- [x] サイドバーの全メニューが日本語表示されることを確認
- [x] マスタデータ・設定メニューの折りたたみが正常動作することを確認
- [x] 各ページ遷移時にヘッダータイトルが正しく切り替わることを確認
- [x] ダッシュボードに 4 枚の KPI カードが正しい件数で表示されることを確認
- [x] ステータスバッジが色分けされることを確認
- [ ] クイックアクションの各ボタンが正しいページへ遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)