### PR TITLE
feat: SaaS管理者向け週次納期確認件数ダッシュボード (#102)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routers.admin import admin_router
 from app.routers.master import (
     calendar_router,
     customer_router,
@@ -50,6 +51,7 @@ app.include_router(customer_router)
 app.include_router(orders_router)
 app.include_router(production_schedules_router)
 app.include_router(member_router)
+app.include_router(admin_router)
 
 
 @app.get("/health")

--- a/backend/app/routers/admin/__init__.py
+++ b/backend/app/routers/admin/__init__.py
@@ -1,0 +1,3 @@
+from app.routers.admin.metrics import admin_router
+
+__all__ = ["admin_router"]

--- a/backend/app/routers/admin/metrics.py
+++ b/backend/app/routers/admin/metrics.py
@@ -1,0 +1,81 @@
+import os
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies import get_current_user_id, get_supabase_admin_client
+from app.utils.logger import get_logger
+from supabase import Client  # type: ignore
+
+admin_router = APIRouter(prefix="/admin", tags=["Admin"])
+
+logger = get_logger(__name__)
+
+
+def _require_platform_admin(user_id: str, admin_client: Client) -> None:
+    """ログインユーザーが PLATFORM_ADMIN_EMAIL と一致することを検証する。"""
+    res = admin_client.auth.admin.get_user_by_id(user_id)
+    email = res.user.email if res.user else None
+    platform_admin_email = os.environ.get("PLATFORM_ADMIN_EMAIL")
+    if not platform_admin_email or email != platform_admin_email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この操作はプラットフォーム管理者のみ実行できます",
+        )
+
+
+def _iso_week_start(dt: datetime) -> str:
+    """datetime を ISO 週開始日（月曜日）の date 文字列に変換する。"""
+    monday = dt - timedelta(days=dt.weekday())
+    return monday.date().isoformat()
+
+
+@admin_router.get("/metrics/weekly-confirmations")
+def get_weekly_confirmations(
+    current_user_id: str = Depends(get_current_user_id),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """
+    テナント別・週次の納期確認件数を返す（直近12週分）。
+    PLATFORM_ADMIN_EMAIL のユーザーのみアクセス可。
+    """
+    _require_platform_admin(current_user_id, admin_client)
+
+    logger.info(f"Fetching weekly confirmations (requested by {current_user_id})")
+
+    cutoff = (datetime.now(UTC) - timedelta(weeks=12)).isoformat()
+
+    orders_res = (
+        admin_client.table("orders")
+        .select("tenant_id, confirmed_at")
+        .not_.is_("confirmed_at", "null")
+        .gte("confirmed_at", cutoff)
+        .execute()
+    )
+
+    tenants_res = admin_client.table("tenants").select("id, name").execute()
+    tenant_rows: list[dict[str, Any]] = cast(
+        list[dict[str, Any]], tenants_res.data or []
+    )
+    tenant_map: dict[str, str] = {str(t["id"]): str(t["name"]) for t in tenant_rows}
+
+    counts: dict[tuple[str, str], int] = defaultdict(int)
+    order_rows: list[dict[str, Any]] = cast(list[dict[str, Any]], orders_res.data or [])
+    for order in order_rows:
+        tenant_id = str(order["tenant_id"])
+        confirmed_at_str = str(order["confirmed_at"]).replace("Z", "+00:00")
+        dt = datetime.fromisoformat(confirmed_at_str)
+        week_start = _iso_week_start(dt)
+        counts[(tenant_id, week_start)] += 1
+
+    return [
+        {
+            "tenant_id": tenant_id,
+            "tenant_name": tenant_map.get(tenant_id, tenant_id),
+            "week_start": week_start,
+            "count": count,
+        }
+        for (tenant_id, week_start), count in sorted(counts.items())
+    ]

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -1,4 +1,6 @@
 # routers/transaction/orders.py
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.dependencies import (
@@ -195,7 +197,14 @@ def confirm_order(
         )
 
         # 2. ステータス更新 & is_scheduled フラグ更新
-        order_repo.update(order_id, {"status": "confirmed", "is_scheduled": True})
+        order_repo.update(
+            order_id,
+            {
+                "status": "confirmed",
+                "is_scheduled": True,
+                "confirmed_at": datetime.now(UTC).isoformat(),
+            },
+        )
 
         return {"status": "confirmed", "schedules": result}
     except ValueError as e:

--- a/docs/features/admin-metrics.md
+++ b/docs/features/admin-metrics.md
@@ -1,0 +1,41 @@
+# SaaS管理者向け週次納期確認件数ダッシュボード
+
+## 概要
+
+SaaS管理者がテナント別の週次納期確認件数をグラフで確認できる管理機能。
+
+## 実装内容
+
+### データモデル
+
+`orders` テーブルに `confirmed_at timestamptz` カラムを追加。
+`POST /orders/{id}/confirm` 実行時に記録される。
+入力手段（手入力・メール・カメラ）に関わらず同一エンドポイントを通るため、全入力経路を一元カウントできる。
+
+### API
+
+`GET /admin/metrics/weekly-confirmations`
+
+- 認可: JWT のユーザーが `PLATFORM_ADMIN_EMAIL` 環境変数と一致する場合のみ
+- レスポンス: `[{ tenant_id, tenant_name, week_start, count }]`（直近12週分）
+- 非管理者は 403 を返す
+
+### フロントエンド
+
+- `/admin` ページにテナント別・週次棒グラフ（Recharts）を表示
+- テナントプルダウンで個別テナントの推移を確認可能
+- 直近12週の全テナント合計サマリーカードを表示
+
+## 環境変数
+
+| 変数名 | 説明 | 設定場所 |
+|--------|------|----------|
+| `PLATFORM_ADMIN_EMAIL` | プラットフォーム管理者のメールアドレス | `backend/.env`、本番環境の環境変数 |
+
+## 関連ファイル
+
+- `supabase/migrations/20260608000000_add_confirmed_at_to_orders.sql`
+- `backend/app/routers/admin/metrics.py`
+- `backend/app/routers/transaction/orders.py`（confirm エンドポイント）
+- `frontend/src/app/admin/page.tsx`
+- `frontend/src/hooks/use-admin-metrics.ts`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "react": "19.2.3",
         "react-day-picker": "^9.13.0",
         "react-dom": "19.2.3",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6"
@@ -3029,11 +3030,59 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -3445,6 +3494,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3500,6 +3612,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4639,6 +4757,127 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4733,6 +4972,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5025,6 +5270,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5472,6 +5727,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5947,6 +6208,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5987,6 +6258,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7634,6 +7914,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -7703,6 +8006,51 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7746,6 +8094,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -8356,6 +8710,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8752,6 +9112,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "react": "19.2.3",
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { useWeeklyConfirmations } from "@/hooks/use-admin-metrics"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+
+export default function AdminPage() {
+  const { data, isLoading, error } = useWeeklyConfirmations()
+  const [selectedTenantId, setSelectedTenantId] = useState<string>("all")
+
+  const tenants = useMemo(() => {
+    if (!data) return []
+    const map = new Map<string, string>()
+    for (const row of data) {
+      map.set(row.tenant_id, row.tenant_name)
+    }
+    return Array.from(map.entries()).map(([id, name]) => ({ id, name }))
+  }, [data])
+
+  const chartData = useMemo(() => {
+    if (!data) return []
+
+    const weekMap = new Map<string, number>()
+    const filtered =
+      selectedTenantId === "all"
+        ? data
+        : data.filter((row) => row.tenant_id === selectedTenantId)
+
+    for (const row of filtered) {
+      weekMap.set(row.week_start, (weekMap.get(row.week_start) ?? 0) + row.count)
+    }
+
+    return Array.from(weekMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([week_start, count]) => ({
+        week: format(new Date(week_start), "M/d週", { locale: ja }),
+        count,
+      }))
+  }, [data, selectedTenantId])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        読み込み中...
+      </div>
+    )
+  }
+
+  if (error) {
+    const is403 = error.message?.includes("403") || error.message?.includes("プラットフォーム管理者")
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center">
+        <p className="text-sm text-destructive font-medium">
+          {is403 ? "アクセス権限がありません（プラットフォーム管理者専用）" : error.message}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">週次納期確認件数</h1>
+          <p className="text-sm text-muted-foreground mt-1">直近12週のテナント別納期確認数</p>
+        </div>
+        <select
+          value={selectedTenantId}
+          onChange={(e) => setSelectedTenantId(e.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <option value="all">全テナント合計</option>
+          {tenants.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="rounded-xl border bg-card p-6">
+        {chartData.length === 0 ? (
+          <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+            データがありません
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={320}>
+            <BarChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="week"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={32}
+              />
+              <Tooltip
+                formatter={(value) => [`${value}件`, "納期確認数"]}
+                labelFormatter={(label) => `${label}`}
+              />
+              <Bar dataKey="count" fill="#3b82f6" radius={[4, 4, 0, 0]} maxBarSize={48} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {selectedTenantId === "all" && tenants.length > 0 && (
+        <div className="rounded-xl border bg-card p-6">
+          <h2 className="text-sm font-medium mb-4">テナント別サマリー（直近12週合計）</h2>
+          <div className="grid gap-3">
+            {tenants.map((tenant) => {
+              const total = data!
+                .filter((row) => row.tenant_id === tenant.id)
+                .reduce((sum, row) => sum + row.count, 0)
+              return (
+                <div key={tenant.id} className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">{tenant.name}</span>
+                  <span className="font-medium tabular-nums">{total}件</span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Calendar,
   Users,
   Settings,
+  BarChart2,
 } from "lucide-react"
 
 import {
@@ -99,6 +100,11 @@ const menuItems = [
         icon: Users,
       },
     ],
+  },
+  {
+    title: "利用状況",
+    url: "/admin",
+    icon: BarChart2,
   },
 ]
 

--- a/frontend/src/components/layout/authenticated-layout.tsx
+++ b/frontend/src/components/layout/authenticated-layout.tsx
@@ -18,6 +18,7 @@ const pageTitleMap: Record<string, string> = {
   "/master/equipment-groups": "設備グループ",
   "/master/calendar": "稼働カレンダー",
   "/settings/members": "メンバー管理",
+  "/admin": "利用状況",
 }
 
 interface AuthenticatedLayoutProps {

--- a/frontend/src/hooks/use-admin-metrics.ts
+++ b/frontend/src/hooks/use-admin-metrics.ts
@@ -1,0 +1,14 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api-client"
+import type { WeeklyConfirmation } from "@/types/admin"
+
+export function useWeeklyConfirmations() {
+  return useQuery<WeeklyConfirmation[]>({
+    queryKey: ["admin", "weekly-confirmations"],
+    queryFn: () => apiClient<WeeklyConfirmation[]>("/admin/metrics/weekly-confirmations"),
+    staleTime: 1000 * 60 * 5,
+    retry: false,
+  })
+}

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,0 +1,6 @@
+export interface WeeklyConfirmation {
+  tenant_id: string
+  tenant_name: string
+  week_start: string
+  count: number
+}

--- a/supabase/migrations/20260608000000_add_confirmed_at_to_orders.sql
+++ b/supabase/migrations/20260608000000_add_confirmed_at_to_orders.sql
@@ -1,0 +1,3 @@
+ALTER TABLE orders ADD COLUMN confirmed_at timestamptz;
+
+COMMENT ON COLUMN orders.confirmed_at IS '納期確認日時（confirm操作を行った日時）';


### PR DESCRIPTION
## Summary

- `orders` テーブルに `confirmed_at timestamptz` を追加し、`POST /orders/{id}/confirm` 実行時にタイムスタンプを記録
- `GET /admin/metrics/weekly-confirmations` エンドポイントを新設（`PLATFORM_ADMIN_EMAIL` 環境変数で認可、直近12週のテナント別確認件数を返す）
- `/admin` ページに Recharts 棒グラフを実装（テナントプルダウン・全テナント合計サマリー付き）
- サイドバーに「利用状況」リンクを追加

## Closes

Closes #102

## Test plan

- [ ] `supabase db reset` でマイグレーション適用確認
- [ ] 既存注文を confirm → `orders.confirmed_at` が記録されることを確認
- [ ] `GET /admin/metrics/weekly-confirmations` が正しい集計を返すことを確認
- [ ] 非管理者ユーザーで同エンドポイントを呼ぶと 403 になることを確認
- [ ] `/admin` ページでテナント別・週次棒グラフが表示されることを確認

## 環境変数（ローカル）

`backend/.env` に追加済み:
```
PLATFORM_ADMIN_EMAIL=happy.flight@gmail.com
```
本番環境にも同変数の設定が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)