### PR TITLE
feat: 受注一覧画面にアテンションカード（サマリー）を追加する (Issue #113)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { AlertTriangle, CheckCircle, MoreHorizontal, Plus } from "lucide-react"
 import { toast } from "sonner"
+import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -240,6 +241,15 @@ export default function OrdersPage() {
     router.push(`?${params.toString()}`)
   }
 
+  const draftCount = useMemo(
+    () => orders?.filter((o) => o.status === "draft").length ?? 0,
+    [orders]
+  )
+  const incompleteCount = useMemo(
+    () => orders?.filter((o) => !o.customer_id || !o.desired_deadline).length ?? 0,
+    [orders]
+  )
+
   const filteredOrders = useMemo(() => {
     if (!orders) return []
     return orders
@@ -288,6 +298,33 @@ export default function OrdersPage() {
           新規注文
         </Button>
       </div>
+
+      {!isLoading && (draftCount > 0 || incompleteCount > 0) && (
+        <div className="mb-4 grid grid-cols-2 gap-4">
+          {draftCount > 0 && (
+            <Card
+              className="cursor-pointer border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-colors"
+              onClick={() => setParam("status", "draft")}
+            >
+              <CardContent className="pt-6">
+                <p className="text-2xl font-bold text-yellow-800">{draftCount}件 未確定</p>
+                <p className="text-sm text-yellow-700 mt-1">下書きを見る →</p>
+              </CardContent>
+            </Card>
+          )}
+          {incompleteCount > 0 && (
+            <Card
+              className="cursor-pointer border-orange-300 bg-orange-50 hover:bg-orange-100 transition-colors"
+              onClick={() => setParam("status", "incomplete")}
+            >
+              <CardContent className="pt-6">
+                <p className="text-2xl font-bold text-orange-800">{incompleteCount}件 情報不足</p>
+                <p className="text-sm text-orange-700 mt-1">確認する →</p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
 
       <div className="mb-4 flex items-center justify-between gap-4 flex-wrap">
         <Tabs

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
## Summary
- 受注一覧ページ（`/orders`）の上部に下書き件数・情報不足件数を示すサマリーカードを追加
- shadcn/ui `Card` コンポーネントを新規追加（`frontend/src/components/ui/card.tsx`）
- 件数が 0 の場合はカードを非表示、ローディング中も非表示

## 変更内容
- `frontend/src/components/ui/card.tsx` — shadcn/ui Card コンポーネントを新規作成
- `frontend/src/app/orders/page.tsx` — アテンションカードセクションを追加（Card インポート、draftCount/incompleteCount useMemo、カード JSX）

## Test plan
- [ ] 下書き注文が 1 件以上ある場合、黄色の「X件 未確定」カードが表示される
- [ ] 「下書きを見る →」クリックで URL が `?status=draft` に遷移し一覧が絞り込まれる
- [ ] 情報不足注文が 1 件以上ある場合、オレンジの「X件 情報不足」カードが表示される
- [ ] 「確認する →」クリックで URL が `?status=incomplete` に遷移し一覧が絞り込まれる
- [ ] 各件数が 0 の場合はカードが非表示になる
- [ ] ローディング中はカードが表示されない

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)