### PR TITLE
fix: ログイン後のリダイレクト先を修正 (Issue #126)

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -53,7 +53,7 @@ export default function LoginPage() {
 
             // 4. リダイレクト (ルーターキャッシュをクリアして遷移)
             router.refresh()
-            router.push('/master/equipment-groups') // 最初の画面へ
+            router.push('/')
 
         } catch (error: any) {
             console.error(error)


### PR DESCRIPTION
## Summary

- ログイン成功後のリダイレクト先が `/master/equipment-groups`（存在しないパス）に設定されており、404 Not Found になっていた
- トーストの文言「ダッシュボードへ移動します」に合わせ、リダイレクト先を `/` に変更

## Test plan

- [ ] ログインページ（`/login`）からログインし、404 にならず `/` へ遷移することを確認
- [ ] ログアウト後に再ログインしても同様に遷移することを確認

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)