### PR TITLE
fix: 注文一覧ソートの created_at undefined TypeError を修正 (Issue #125)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -104,8 +104,15 @@ function filterOrder(order: Order, statusFilter: StatusFilter): boolean {
 }
 
 function compareOrders(a: Order, b: Order, sortKey: SortKey): number {
-  if (sortKey === "created_at_desc") return b.created_at.localeCompare(a.created_at)
-  if (sortKey === "created_at_asc") return a.created_at.localeCompare(b.created_at)
+  if (sortKey === "created_at_desc" || sortKey === "created_at_asc") {
+    // created_at が null の場合は末尾に
+    if (!a.created_at && !b.created_at) return 0
+    if (!a.created_at) return 1
+    if (!b.created_at) return -1
+    return sortKey === "created_at_desc"
+      ? b.created_at.localeCompare(a.created_at)
+      : a.created_at.localeCompare(b.created_at)
+  }
   // desired_deadline_asc: null を末尾に
   if (!a.desired_deadline && !b.desired_deadline) return 0
   if (!a.desired_deadline) return 1

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -53,13 +53,13 @@ export default function Home() {
   }, [orders])
 
   const weeklyOrdersCount = useMemo(() => {
-    return orders?.filter((order) => new Date(order.created_at) >= weekStart).length ?? 0
+    return orders?.filter((order) => order.created_at && new Date(order.created_at) >= weekStart).length ?? 0
   }, [orders, weekStart])
 
   const recentOrders = useMemo(() => {
     if (!orders) return []
     return [...orders]
-      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime())
       .slice(0, 5)
   }, [orders])
 

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -12,8 +12,8 @@ export interface Order {
   status: 'draft' | 'confirmed' | 'completed' | 'canceled'
   is_scheduled: boolean
   tenant_id: string
-  created_at: string
-  updated_at: string
+  created_at: string | null
+  updated_at: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary

- `compareOrders` 関数（`frontend/src/app/orders/page.tsx`）で `b.created_at.localeCompare()` を呼ぶ際、`created_at` が `null` / `undefined` のときに TypeError が発生していた
- `desired_deadline` の null ガードと同じパターンで `created_at` にも null チェックを追加
- `Order` 型の `created_at` / `updated_at` を `string | null` に修正し、型定義と実態を一致させた
- 型変更の影響で `frontend/src/app/page.tsx` の `new Date(order.created_at)` にも null ガードを追加

## Test plan

- [ ] 注文一覧ページ（`/orders`）を開き、登録日ソート（新しい順・古い順）でエラーが発生しないことを確認
- [ ] `created_at` が null の注文がある場合、一覧の末尾に表示されることを確認
- [ ] ダッシュボードの週間受注数・最新受注一覧が正常に表示されることを確認

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)