### PR TITLE
fix: 注文一覧 TableBody の map に key prop を付与

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { AlertCircle, AlertTriangle, MoreHorizontal, Plus } from "lucide-react"
 import { toast } from "sonner"
@@ -450,8 +450,8 @@ export default function OrdersPage() {
               </TableHeader>
               <TableBody>
                 {pagedOrders.map((order) => (
-                  <>
-                    <TableRow key={order.id}>
+                  <Fragment key={order.id}>
+                    <TableRow>
                       <TableCell className="font-medium">{order.order_no}</TableCell>
                       <TableCell>{getProductName(order.product_id, products)}</TableCell>
                       <TableCell>
@@ -581,7 +581,7 @@ export default function OrdersPage() {
                         </TableCell>
                       </TableRow>
                     )}
-                  </>
+                  </Fragment>
                 ))}
               </TableBody>
             </Table>


### PR DESCRIPTION
## Summary

- `pagedOrders.map()` の直下が `<>` フラグメントになっており、`key` を受け取れないため React の key prop 警告が発生していた
- `<>` → `<Fragment key={order.id}>` に置き換え、内側の `<TableRow>` から重複していた `key` を除去

## Test plan

- [ ] 注文一覧ページ（`/orders`）を開き、ブラウザコンソールに `Each child in a list should have a unique "key" prop.` が出ないことを確認
- [ ] 注文の表示・ソート・フィルタが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)