### PR TITLE
[Refactor] orders/page.tsx を責務単位に分割し可読性・保守性を向上 (#130)

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -315,6 +315,40 @@ export function useUpdateOrder() {
 
 ---
 
+## フロントエンド コード構成
+
+### orders/page.tsx リファクタリング後の構成 (#130)
+
+`page.tsx` の肥大化（645行）を解消するため、責務ごとにファイルを分割。
+
+```
+frontend/src/
+  app/orders/
+    page.tsx                              # エントリーポイント（~160行）
+  components/orders/
+    edit-order-dialog.tsx                 # 注文編集ダイアログ
+    delete-order-dialog.tsx               # 削除確認 AlertDialog
+    order-notification-cards.tsx          # 下書き/情報不足サマリーカード
+    orders-filter-bar.tsx                 # ステータスタブ + ソートセレクト
+    order-table-row.tsx                   # テーブル行 + Sim展開行
+  hooks/
+    use-orders-page.ts                    # URL state・データ取得・ハンドラー一式
+  lib/
+    order-utils.ts                        # filterOrder / compareOrders / 定数・型
+```
+
+**`use-orders-page.ts` が提供する値**
+
+| カテゴリ | 主な内容 |
+|---|---|
+| URL state | `statusFilter`, `sortKey`, `page`, `setParam()` |
+| データ | `orders`, `products`, `customers`, `isLoading` |
+| 派生値 | `draftCount`, `incompleteCount`, `filteredOrders`, `pagedOrders` |
+| ダイアログ state | `selectedOrder`, `deleteTargetOrder`, `expandedOrderId`, `expandedSimResult` |
+| ハンドラー | `handleSimulate`, `handleConfirmFromRow`, `handleOpenEditDialog`, `handleConfirmDelete`, `closeSimResult` |
+
+---
+
 ## 実装状況
 
 | 機能 | 優先度 | 状況 |
@@ -334,4 +368,5 @@ export function useUpdateOrder() {
 | 新規注文: 3ステップインジケーター | 中 | ✅ 実装済 (#117) |
 | 新規注文: 入力促進ヒント | 中 | ✅ 実装済 (#117) |
 | 新規注文: 確定前サマリー表示 | 中 | ✅ 実装済 (#117) |
+| 一覧ページ: コード分割リファクタリング | - | ✅ 実装済 (#130) |
 | キャンセル専用エンドポイント | 低 | ❌ 未実装 |

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -1,359 +1,52 @@
 "use client"
 
-import { Fragment, useMemo, useState } from "react"
-import { useSearchParams, useRouter } from "next/navigation"
-import { AlertCircle, AlertTriangle, MoreHorizontal, Plus } from "lucide-react"
-import { toast } from "sonner"
-import { Card, CardContent } from "@/components/ui/card"
-import { Button, buttonVariants } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import {
   Table,
   TableBody,
-  TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { MasterPagination } from "@/components/master-pagination"
-import { ProductSelector } from "@/components/product-selector"
-import { CustomerSelector } from "@/components/customer-selector"
-import { SimulationResult } from "@/components/simulation-result"
-import {
-  useConfirmOrder,
-  useDeleteOrder,
-  useOrders,
-  useSimulateOrderById,
-  useUpdateOrder,
-} from "@/hooks/use-orders"
-import { useProducts } from "@/hooks/use-products"
-import { useCustomers } from "@/hooks/use-customers"
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
-import {
-  getProductName,
-  getCustomerName,
-  getStatusLabel,
-  getStatusBadgeClass,
-} from "@/lib/order-utils"
-import type { Order, OrderSimulateResponse } from "@/types/order"
+import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
+import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
+import { OrderNotificationCards } from "@/components/orders/order-notification-cards"
+import { OrdersFilterBar } from "@/components/orders/orders-filter-bar"
+import { OrderTableRow } from "@/components/orders/order-table-row"
+import { useOrdersPage, PAGE_SIZE } from "@/hooks/use-orders-page"
 
-const PAGE_SIZE = 20
-
-type StatusFilter = "" | "draft" | "confirmed" | "incomplete" | "completed" | "canceled"
-type SortKey = "created_at_desc" | "created_at_asc" | "desired_deadline_asc"
-
-const STATUS_TABS: { label: string; value: StatusFilter }[] = [
-  { label: "すべて", value: "" },
-  { label: "下書き", value: "draft" },
-  { label: "確定済", value: "confirmed" },
-  { label: "情報不足", value: "incomplete" },
-  { label: "完了", value: "completed" },
-  { label: "キャンセル", value: "canceled" },
-]
-
-const SORT_OPTIONS: { label: string; value: SortKey }[] = [
-  { label: "登録日（新しい順）", value: "created_at_desc" },
-  { label: "登録日（古い順）", value: "created_at_asc" },
-  { label: "希望納期（近い順）", value: "desired_deadline_asc" },
-]
-
-function filterOrder(order: Order, statusFilter: StatusFilter): boolean {
-  if (statusFilter === "incomplete") return !order.customer_id || !order.desired_deadline
-  if (statusFilter) return order.status === statusFilter
-  return true
-}
-
-function compareOrders(a: Order, b: Order, sortKey: SortKey): number {
-  if (sortKey === "created_at_desc" || sortKey === "created_at_asc") {
-    // created_at が null の場合は末尾に
-    if (!a.created_at && !b.created_at) return 0
-    if (!a.created_at) return 1
-    if (!b.created_at) return -1
-    return sortKey === "created_at_desc"
-      ? b.created_at.localeCompare(a.created_at)
-      : a.created_at.localeCompare(b.created_at)
-  }
-  // desired_deadline_asc: null を末尾に
-  if (!a.desired_deadline && !b.desired_deadline) return 0
-  if (!a.desired_deadline) return 1
-  if (!b.desired_deadline) return -1
-  return a.desired_deadline.localeCompare(b.desired_deadline)
-}
-
-interface EditOrderDialogProps {
-  order: Order
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}
-
-function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogProps) {
-  const updateOrder = useUpdateOrder()
-
-  const [orderNo, setOrderNo] = useState(order.order_no)
-  const [productId, setProductId] = useState(order.product_id.toString())
-  const [customerId, setCustomerId] = useState(order.customer_id?.toString() ?? "")
-  const [quantity, setQuantity] = useState(order.quantity.toString())
-  const [desiredDeadline, setDesiredDeadline] = useState(
-    order.desired_deadline ? order.desired_deadline.slice(0, 16) : ""
-  )
-  const [duplicateError, setDuplicateError] = useState("")
-
-  const productChanged = productId !== order.product_id.toString()
-  const quantityChanged = quantity !== order.quantity.toString()
-  const showScheduleWarning = order.is_scheduled && (productChanged || quantityChanged)
-
-  const handleSubmit = () => {
-    setDuplicateError("")
-    const parsedQuantity = parseInt(quantity, 10)
-    if (!orderNo.trim() || !productId || isNaN(parsedQuantity) || parsedQuantity <= 0) return
-
-    updateOrder.mutate(
-      {
-        id: order.id,
-        data: {
-          order_no: orderNo.trim(),
-          product_id: parseInt(productId, 10),
-          customer_id: customerId ? parseInt(customerId, 10) : undefined,
-          quantity: parsedQuantity,
-          desired_deadline: desiredDeadline || undefined,
-        },
-      },
-      {
-        onSuccess: () => {
-          toast.success("注文情報を更新しました")
-          onOpenChange(false)
-        },
-        onError: (error: Error) => {
-          if (error.message.includes("400") || error.message.toLowerCase().includes("duplicate") || error.message.includes("already")) {
-            setDuplicateError("この注文番号はすでに使用されています")
-          } else {
-            toast.error(`更新に失敗しました: ${error.message}`)
-          }
-        },
-      }
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
-        <DialogHeader>
-          <DialogTitle>注文の編集</DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          {showScheduleWarning && (
-            <div className="flex items-start gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                スケジュールが無効になります。保存後に再シミュレーションが必要です。
-              </span>
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <Label htmlFor="order-no">注文番号 *</Label>
-            <Input
-              id="order-no"
-              value={orderNo}
-              onChange={(e) => {
-                setOrderNo(e.target.value)
-                setDuplicateError("")
-              }}
-            />
-            {duplicateError && (
-              <p className="text-sm text-destructive">{duplicateError}</p>
-            )}
-          </div>
-
-          <ProductSelector value={productId} onValueChange={setProductId} />
-
-          <CustomerSelector value={customerId} onValueChange={setCustomerId} />
-
-          <div className="space-y-2">
-            <Label htmlFor="quantity">数量 *</Label>
-            <Input
-              id="quantity"
-              type="number"
-              min={1}
-              value={quantity}
-              onChange={(e) => setQuantity(e.target.value)}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="desired-deadline">希望納期</Label>
-            <Input
-              id="desired-deadline"
-              type="datetime-local"
-              value={desiredDeadline}
-              onChange={(e) => setDesiredDeadline(e.target.value)}
-            />
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            キャンセル
-          </Button>
-          <Button onClick={handleSubmit} disabled={updateOrder.isPending}>
-            {updateOrder.isPending ? "保存中..." : "保存"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-/**
- * 注文一覧画面
- * URL: /orders
- */
 export default function OrdersPage() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-
-  const statusFilter = (searchParams.get("status") ?? "") as StatusFilter
-  const sortKey = (searchParams.get("sort") ?? "created_at_desc") as SortKey
-  const page = Number(searchParams.get("page") ?? "1")
-
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
-  const [deleteTargetOrder, setDeleteTargetOrder] = useState<Order | null>(null)
-  const [expandedOrderId, setExpandedOrderId] = useState<number | null>(null)
-  const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
-
-  const { data: orders, isLoading: ordersLoading } = useOrders()
-  const { data: products, isLoading: productsLoading } = useProducts()
-  const { data: customers, isLoading: customersLoading } = useCustomers()
-  const confirmOrder = useConfirmOrder()
-  const deleteOrder = useDeleteOrder()
-  const simulateOrderById = useSimulateOrderById()
-
-  const setParam = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString())
-    if (value) {
-      params.set(key, value)
-    } else {
-      params.delete(key)
-    }
-    // ステータスやソート変更時はページを1に戻す
-    if (key !== "page") params.delete("page")
-    router.push(`?${params.toString()}`)
-  }
-
-  const draftCount = useMemo(
-    () => orders?.filter((o) => o.status === "draft").length ?? 0,
-    [orders]
-  )
-  const incompleteCount = useMemo(
-    () => orders?.filter((o) => !o.customer_id || !o.desired_deadline).length ?? 0,
-    [orders]
-  )
-
-  const filteredOrders = useMemo(() => {
-    if (!orders) return []
-    return orders
-      .filter((order) => filterOrder(order, statusFilter))
-      .sort((a, b) => compareOrders(a, b, sortKey))
-  }, [orders, statusFilter, sortKey])
-
-  const pagedOrders = useMemo(() => {
-    const offset = (page - 1) * PAGE_SIZE
-    return filteredOrders.slice(offset, offset + PAGE_SIZE)
-  }, [filteredOrders, page])
-
-  const handleConfirmFromRow = (orderId: number, orderNo: string) => {
-    confirmOrder.mutate(orderId, {
-      onSuccess: () => {
-        toast.success(`注文「${orderNo}」を確定し、スケジュールを作成しました`)
-        setExpandedOrderId(null)
-        setExpandedSimResult(null)
-      },
-      onError: (error: Error) => {
-        toast.error(`確定に失敗しました: ${error.message}`)
-      },
-    })
-  }
-
-  const handleSimulate = async (order: Order) => {
-    try {
-      const result = await simulateOrderById.mutateAsync(order.id)
-      setExpandedOrderId(order.id)
-      setExpandedSimResult(result)
-      toast.success("シミュレーションが完了しました")
-    } catch (error) {
-      console.error("Simulation error:", error)
-      toast.error("シミュレーションに失敗しました")
-    }
-  }
-
-  const handleOpenEditDialog = (order: Order) => {
-    setSelectedOrder(order)
-    setIsEditDialogOpen(true)
-  }
-
-  const handleConfirmDelete = () => {
-    if (!deleteTargetOrder) return
-    const targetId = deleteTargetOrder.id
-    const targetNo = deleteTargetOrder.order_no
-    deleteOrder.mutate(targetId, {
-      onSuccess: () => {
-        toast.success(`注文「${targetNo}」を削除しました`)
-        setDeleteTargetOrder(null)
-        if (expandedOrderId === targetId) {
-          setExpandedOrderId(null)
-          setExpandedSimResult(null)
-        }
-      },
-      onError: (error: Error) => {
-        toast.error(`削除に失敗しました: ${error.message}`)
-        setDeleteTargetOrder(null)
-      },
-    })
-  }
-
-  const isLoading = ordersLoading || productsLoading || customersLoading
+  const {
+    statusFilter,
+    sortKey,
+    router,
+    isLoading,
+    products,
+    customers,
+    draftCount,
+    incompleteCount,
+    filteredOrders,
+    pagedOrders,
+    isEditDialogOpen,
+    setIsEditDialogOpen,
+    selectedOrder,
+    deleteTargetOrder,
+    setDeleteTargetOrder,
+    expandedOrderId,
+    expandedSimResult,
+    confirmOrder,
+    deleteOrder,
+    simulateOrderById,
+    setParam,
+    handleConfirmFromRow,
+    handleSimulate,
+    handleOpenEditDialog,
+    handleConfirmDelete,
+    closeSimResult,
+  } = useOrdersPage()
 
   return (
     <TooltipProvider>
@@ -361,9 +54,7 @@ export default function OrdersPage() {
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold">注文一覧</h1>
-            <p className="text-muted-foreground mt-2">
-              登録された注文の一覧を表示します
-            </p>
+            <p className="text-muted-foreground mt-2">登録された注文の一覧を表示します</p>
           </div>
           <Button onClick={() => router.push("/orders/new")}>
             <Plus className="mr-2 h-4 w-4" />
@@ -371,69 +62,25 @@ export default function OrdersPage() {
           </Button>
         </div>
 
-        {!isLoading && (draftCount > 0 || incompleteCount > 0) && (
-          <div className="mb-4 grid grid-cols-2 gap-4">
-            {draftCount > 0 && (
-              <Card
-                className="cursor-pointer border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-colors"
-                onClick={() => setParam("status", "draft")}
-              >
-                <CardContent className="pt-6">
-                  <p className="text-2xl font-bold text-yellow-800">{draftCount}件 未確定</p>
-                  <p className="text-sm text-yellow-700 mt-1">下書きを見る →</p>
-                </CardContent>
-              </Card>
-            )}
-            {incompleteCount > 0 && (
-              <Card
-                className="cursor-pointer border-orange-300 bg-orange-50 hover:bg-orange-100 transition-colors"
-                onClick={() => setParam("status", "incomplete")}
-              >
-                <CardContent className="pt-6">
-                  <p className="text-2xl font-bold text-orange-800">{incompleteCount}件 情報不足</p>
-                  <p className="text-sm text-orange-700 mt-1">確認する →</p>
-                </CardContent>
-              </Card>
-            )}
-          </div>
+        {!isLoading && (
+          <OrderNotificationCards
+            draftCount={draftCount}
+            incompleteCount={incompleteCount}
+            onDraftClick={() => setParam("status", "draft")}
+            onIncompleteClick={() => setParam("status", "incomplete")}
+          />
         )}
 
-        <div className="mb-4 flex items-center justify-between gap-4 flex-wrap">
-          <Tabs
-            value={statusFilter}
-            onValueChange={(v) => setParam("status", v)}
-          >
-            <TabsList>
-              {STATUS_TABS.map((tab) => (
-                <TabsTrigger key={tab.value} value={tab.value}>
-                  {tab.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
-
-          <Select
-            value={sortKey}
-            onValueChange={(v) => setParam("sort", v)}
-          >
-            <SelectTrigger className="w-[200px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {SORT_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <OrdersFilterBar
+          statusFilter={statusFilter}
+          sortKey={sortKey}
+          onStatusChange={(v) => setParam("status", v)}
+          onSortChange={(v) => setParam("sort", v)}
+        />
 
         <div className="rounded-lg border bg-card shadow-sm">
           {isLoading ? (
-            <div className="p-8 text-center text-muted-foreground">
-              読み込み中...
-            </div>
+            <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
           ) : pagedOrders.length > 0 ? (
             <Table>
               <TableHeader>
@@ -450,138 +97,21 @@ export default function OrdersPage() {
               </TableHeader>
               <TableBody>
                 {pagedOrders.map((order) => (
-                  <Fragment key={order.id}>
-                    <TableRow>
-                      <TableCell className="font-medium">{order.order_no}</TableCell>
-                      <TableCell>{getProductName(order.product_id, products)}</TableCell>
-                      <TableCell>
-                        {order.customer_id == null ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="flex items-center gap-1 text-yellow-500 text-sm cursor-default">
-                                <AlertCircle className="h-4 w-4" />
-                                未設定
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>顧客が設定されていません</TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          getCustomerName(order.customer_id, customers)
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right">{order.quantity}</TableCell>
-                      <TableCell>
-                        {order.desired_deadline ? (
-                          format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", {
-                            locale: ja,
-                          })
-                        ) : (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="flex items-center gap-1 text-yellow-500 text-sm cursor-default">
-                                <AlertCircle className="h-4 w-4" />
-                                未設定
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>希望納期が設定されていません</TooltipContent>
-                          </Tooltip>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {order.confirmed_deadline
-                          ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", {
-                              locale: ja,
-                            })
-                          : "-"}
-                      </TableCell>
-                      <TableCell>
-                        <Badge className={getStatusBadgeClass(order.status)}>
-                          {getStatusLabel(order.status)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          {order.status === "draft" && !order.is_scheduled && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleSimulate(order)}
-                              disabled={simulateOrderById.isPending}
-                            >
-                              シミュレーション実行
-                            </Button>
-                          )}
-                          {order.status === "draft" && order.is_scheduled && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleConfirmFromRow(order.id, order.order_no)}
-                              disabled={confirmOrder.isPending}
-                            >
-                              確定
-                            </Button>
-                          )}
-                          {order.status !== "completed" && (
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button size="sm" variant="ghost" className="h-8 w-8 p-0">
-                                  <MoreHorizontal className="h-4 w-4" />
-                                  <span className="sr-only">メニューを開く</span>
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end">
-                                {order.status === "draft" && order.is_scheduled && (
-                                  <DropdownMenuItem onClick={() => handleSimulate(order)}>
-                                    再シミュレーション
-                                  </DropdownMenuItem>
-                                )}
-                                {order.status === "draft" && (
-                                  <DropdownMenuItem onClick={() => handleOpenEditDialog(order)}>
-                                    編集
-                                  </DropdownMenuItem>
-                                )}
-                                <DropdownMenuItem
-                                  className="text-destructive"
-                                  onClick={() => setDeleteTargetOrder(order)}
-                                >
-                                  削除
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                    {expandedOrderId === order.id && expandedSimResult && (
-                      <TableRow key={`${order.id}-sim`}>
-                        <TableCell colSpan={8} className="bg-muted/30 p-4">
-                          <SimulationResult
-                            result={expandedSimResult}
-                            desiredDeadline={order.desired_deadline}
-                          />
-                          <div className="flex justify-end gap-2 mt-4">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                setExpandedOrderId(null)
-                                setExpandedSimResult(null)
-                              }}
-                            >
-                              閉じる
-                            </Button>
-                            <Button
-                              size="sm"
-                              onClick={() => handleConfirmFromRow(order.id, order.order_no)}
-                              disabled={confirmOrder.isPending}
-                            >
-                              この内容で確定
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </Fragment>
+                  <OrderTableRow
+                    key={order.id}
+                    order={order}
+                    products={products}
+                    customers={customers}
+                    expandedOrderId={expandedOrderId}
+                    expandedSimResult={expandedSimResult}
+                    simulateIsPending={simulateOrderById.isPending}
+                    confirmIsPending={confirmOrder.isPending}
+                    onSimulate={handleSimulate}
+                    onConfirm={handleConfirmFromRow}
+                    onEdit={handleOpenEditDialog}
+                    onDelete={setDeleteTargetOrder}
+                    onCloseSimResult={closeSimResult}
+                  />
                 ))}
               </TableBody>
             </Table>
@@ -616,29 +146,12 @@ export default function OrdersPage() {
           />
         )}
 
-        <AlertDialog
-          open={deleteTargetOrder !== null}
+        <DeleteOrderDialog
+          order={deleteTargetOrder}
+          isPending={deleteOrder.isPending}
+          onConfirm={handleConfirmDelete}
           onOpenChange={(open) => { if (!open) setDeleteTargetOrder(null) }}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>注文の削除</AlertDialogTitle>
-              <AlertDialogDescription>
-                注文「{deleteTargetOrder?.order_no}」を削除しますか？この操作は取り消せません。
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>キャンセル</AlertDialogCancel>
-              <AlertDialogAction
-                className={buttonVariants({ variant: "destructive" })}
-                onClick={handleConfirmDelete}
-                disabled={deleteOrder.isPending}
-              >
-                {deleteOrder.isPending ? "削除中..." : "削除"}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        />
       </div>
     </TooltipProvider>
   )

--- a/frontend/src/components/orders/delete-order-dialog.tsx
+++ b/frontend/src/components/orders/delete-order-dialog.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { buttonVariants } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import type { Order } from "@/types/order"
+
+interface DeleteOrderDialogProps {
+  order: Order | null
+  isPending: boolean
+  onConfirm: () => void
+  onOpenChange: (open: boolean) => void
+}
+
+export function DeleteOrderDialog({ order, isPending, onConfirm, onOpenChange }: DeleteOrderDialogProps) {
+  return (
+    <AlertDialog
+      open={order !== null}
+      onOpenChange={(open) => { if (!open) onOpenChange(open) }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>注文の削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            注文「{order?.order_no}」を削除しますか？この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: "destructive" })}
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "削除中..." : "削除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/components/orders/edit-order-dialog.tsx
+++ b/frontend/src/components/orders/edit-order-dialog.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ProductSelector } from "@/components/product-selector"
+import { CustomerSelector } from "@/components/customer-selector"
+import { useUpdateOrder } from "@/hooks/use-orders"
+import type { Order } from "@/types/order"
+
+interface EditOrderDialogProps {
+  order: Order
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogProps) {
+  const updateOrder = useUpdateOrder()
+
+  const [orderNo, setOrderNo] = useState(order.order_no)
+  const [productId, setProductId] = useState(order.product_id.toString())
+  const [customerId, setCustomerId] = useState(order.customer_id?.toString() ?? "")
+  const [quantity, setQuantity] = useState(order.quantity.toString())
+  const [desiredDeadline, setDesiredDeadline] = useState(
+    order.desired_deadline ? order.desired_deadline.slice(0, 16) : ""
+  )
+  const [duplicateError, setDuplicateError] = useState("")
+
+  const productChanged = productId !== order.product_id.toString()
+  const quantityChanged = quantity !== order.quantity.toString()
+  const showScheduleWarning = order.is_scheduled && (productChanged || quantityChanged)
+
+  const handleSubmit = () => {
+    setDuplicateError("")
+    const parsedQuantity = parseInt(quantity, 10)
+    if (!orderNo.trim() || !productId || isNaN(parsedQuantity) || parsedQuantity <= 0) return
+
+    updateOrder.mutate(
+      {
+        id: order.id,
+        data: {
+          order_no: orderNo.trim(),
+          product_id: parseInt(productId, 10),
+          customer_id: customerId ? parseInt(customerId, 10) : undefined,
+          quantity: parsedQuantity,
+          desired_deadline: desiredDeadline || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success("注文情報を更新しました")
+          onOpenChange(false)
+        },
+        onError: (error: Error) => {
+          if (
+            error.message.includes("400") ||
+            error.message.toLowerCase().includes("duplicate") ||
+            error.message.includes("already")
+          ) {
+            setDuplicateError("この注文番号はすでに使用されています")
+          } else {
+            toast.error(`更新に失敗しました: ${error.message}`)
+          }
+        },
+      }
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>注文の編集</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {showScheduleWarning && (
+            <div className="flex items-start gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                スケジュールが無効になります。保存後に再シミュレーションが必要です。
+              </span>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="order-no">注文番号 *</Label>
+            <Input
+              id="order-no"
+              value={orderNo}
+              onChange={(e) => {
+                setOrderNo(e.target.value)
+                setDuplicateError("")
+              }}
+            />
+            {duplicateError && (
+              <p className="text-sm text-destructive">{duplicateError}</p>
+            )}
+          </div>
+
+          <ProductSelector value={productId} onValueChange={setProductId} />
+
+          <CustomerSelector value={customerId} onValueChange={setCustomerId} />
+
+          <div className="space-y-2">
+            <Label htmlFor="quantity">数量 *</Label>
+            <Input
+              id="quantity"
+              type="number"
+              min={1}
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="desired-deadline">希望納期</Label>
+            <Input
+              id="desired-deadline"
+              type="datetime-local"
+              value={desiredDeadline}
+              onChange={(e) => setDesiredDeadline(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} disabled={updateOrder.isPending}>
+            {updateOrder.isPending ? "保存中..." : "保存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/orders/order-notification-cards.tsx
+++ b/frontend/src/components/orders/order-notification-cards.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+
+interface OrderNotificationCardsProps {
+  draftCount: number
+  incompleteCount: number
+  onDraftClick: () => void
+  onIncompleteClick: () => void
+}
+
+export function OrderNotificationCards({
+  draftCount,
+  incompleteCount,
+  onDraftClick,
+  onIncompleteClick,
+}: OrderNotificationCardsProps) {
+  if (draftCount === 0 && incompleteCount === 0) return null
+
+  return (
+    <div className="mb-4 grid grid-cols-2 gap-4">
+      {draftCount > 0 && (
+        <Card
+          className="cursor-pointer border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-colors"
+          onClick={onDraftClick}
+        >
+          <CardContent className="pt-6">
+            <p className="text-2xl font-bold text-yellow-800">{draftCount}件 未確定</p>
+            <p className="text-sm text-yellow-700 mt-1">下書きを見る →</p>
+          </CardContent>
+        </Card>
+      )}
+      {incompleteCount > 0 && (
+        <Card
+          className="cursor-pointer border-orange-300 bg-orange-50 hover:bg-orange-100 transition-colors"
+          onClick={onIncompleteClick}
+        >
+          <CardContent className="pt-6">
+            <p className="text-2xl font-bold text-orange-800">{incompleteCount}件 情報不足</p>
+            <p className="text-sm text-orange-700 mt-1">確認する →</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { Fragment } from "react"
+import { AlertCircle, MoreHorizontal } from "lucide-react"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { TableCell, TableRow } from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { SimulationResult } from "@/components/simulation-result"
+import {
+  getProductName,
+  getCustomerName,
+  getStatusLabel,
+  getStatusBadgeClass,
+} from "@/lib/order-utils"
+import type { Order, OrderSimulateResponse } from "@/types/order"
+import type { Product } from "@/types/product"
+import type { Customer } from "@/types/customer"
+
+interface OrderTableRowProps {
+  order: Order
+  products?: Product[]
+  customers?: Customer[]
+  expandedOrderId: number | null
+  expandedSimResult: OrderSimulateResponse | null
+  simulateIsPending: boolean
+  confirmIsPending: boolean
+  onSimulate: (order: Order) => void
+  onConfirm: (orderId: number, orderNo: string) => void
+  onEdit: (order: Order) => void
+  onDelete: (order: Order) => void
+  onCloseSimResult: () => void
+}
+
+export function OrderTableRow({
+  order,
+  products,
+  customers,
+  expandedOrderId,
+  expandedSimResult,
+  simulateIsPending,
+  confirmIsPending,
+  onSimulate,
+  onConfirm,
+  onEdit,
+  onDelete,
+  onCloseSimResult,
+}: OrderTableRowProps) {
+  const isExpanded = expandedOrderId === order.id
+
+  return (
+    <Fragment key={order.id}>
+      <TableRow>
+        <TableCell className="font-medium">{order.order_no}</TableCell>
+        <TableCell>{getProductName(order.product_id, products)}</TableCell>
+        <TableCell>
+          {order.customer_id == null ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-1 text-yellow-500 text-sm cursor-default">
+                  <AlertCircle className="h-4 w-4" />
+                  未設定
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>顧客が設定されていません</TooltipContent>
+            </Tooltip>
+          ) : (
+            getCustomerName(order.customer_id, customers)
+          )}
+        </TableCell>
+        <TableCell className="text-right">{order.quantity}</TableCell>
+        <TableCell>
+          {order.desired_deadline ? (
+            format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-1 text-yellow-500 text-sm cursor-default">
+                  <AlertCircle className="h-4 w-4" />
+                  未設定
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>希望納期が設定されていません</TooltipContent>
+            </Tooltip>
+          )}
+        </TableCell>
+        <TableCell>
+          {order.confirmed_deadline
+            ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", { locale: ja })
+            : "-"}
+        </TableCell>
+        <TableCell>
+          <Badge className={getStatusBadgeClass(order.status)}>
+            {getStatusLabel(order.status)}
+          </Badge>
+        </TableCell>
+        <TableCell className="text-right">
+          <div className="flex items-center justify-end gap-2">
+            {order.status === "draft" && !order.is_scheduled && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onSimulate(order)}
+                disabled={simulateIsPending}
+              >
+                シミュレーション実行
+              </Button>
+            )}
+            {order.status === "draft" && order.is_scheduled && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onConfirm(order.id, order.order_no)}
+                disabled={confirmIsPending}
+              >
+                確定
+              </Button>
+            )}
+            {order.status !== "completed" && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="sm" variant="ghost" className="h-8 w-8 p-0">
+                    <MoreHorizontal className="h-4 w-4" />
+                    <span className="sr-only">メニューを開く</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {order.status === "draft" && order.is_scheduled && (
+                    <DropdownMenuItem onClick={() => onSimulate(order)}>
+                      再シミュレーション
+                    </DropdownMenuItem>
+                  )}
+                  {order.status === "draft" && (
+                    <DropdownMenuItem onClick={() => onEdit(order)}>
+                      編集
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    className="text-destructive"
+                    onClick={() => onDelete(order)}
+                  >
+                    削除
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        </TableCell>
+      </TableRow>
+      {isExpanded && expandedSimResult && (
+        <TableRow key={`${order.id}-sim`}>
+          <TableCell colSpan={8} className="bg-muted/30 p-4">
+            <SimulationResult
+              result={expandedSimResult}
+              desiredDeadline={order.desired_deadline}
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <Button variant="outline" size="sm" onClick={onCloseSimResult}>
+                閉じる
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => onConfirm(order.id, order.order_no)}
+                disabled={confirmIsPending}
+              >
+                この内容で確定
+              </Button>
+            </div>
+          </TableCell>
+        </TableRow>
+      )}
+    </Fragment>
+  )
+}

--- a/frontend/src/components/orders/orders-filter-bar.tsx
+++ b/frontend/src/components/orders/orders-filter-bar.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { STATUS_TABS, SORT_OPTIONS, type StatusFilter, type SortKey } from "@/lib/order-utils"
+
+interface OrdersFilterBarProps {
+  statusFilter: StatusFilter
+  sortKey: SortKey
+  onStatusChange: (value: string) => void
+  onSortChange: (value: string) => void
+}
+
+export function OrdersFilterBar({
+  statusFilter,
+  sortKey,
+  onStatusChange,
+  onSortChange,
+}: OrdersFilterBarProps) {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-4 flex-wrap">
+      <Tabs value={statusFilter} onValueChange={onStatusChange}>
+        <TabsList>
+          {STATUS_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <Select value={sortKey} onValueChange={onSortChange}>
+        <SelectTrigger className="w-[200px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SORT_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -1,0 +1,170 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
+import { toast } from "sonner"
+import {
+  useConfirmOrder,
+  useDeleteOrder,
+  useOrders,
+  useSimulateOrderById,
+} from "@/hooks/use-orders"
+import { useProducts } from "@/hooks/use-products"
+import { useCustomers } from "@/hooks/use-customers"
+import {
+  filterOrder,
+  compareOrders,
+  type StatusFilter,
+  type SortKey,
+} from "@/lib/order-utils"
+import type { Order, OrderSimulateResponse } from "@/types/order"
+
+const PAGE_SIZE = 20
+
+export { PAGE_SIZE }
+
+export function useOrdersPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const statusFilter = (searchParams.get("status") ?? "") as StatusFilter
+  const sortKey = (searchParams.get("sort") ?? "created_at_desc") as SortKey
+  const page = Number(searchParams.get("page") ?? "1")
+
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
+  const [deleteTargetOrder, setDeleteTargetOrder] = useState<Order | null>(null)
+  const [expandedOrderId, setExpandedOrderId] = useState<number | null>(null)
+  const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
+
+  const { data: orders, isLoading: ordersLoading } = useOrders()
+  const { data: products, isLoading: productsLoading } = useProducts()
+  const { data: customers, isLoading: customersLoading } = useCustomers()
+  const confirmOrder = useConfirmOrder()
+  const deleteOrder = useDeleteOrder()
+  const simulateOrderById = useSimulateOrderById()
+
+  const setParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    if (value) {
+      params.set(key, value)
+    } else {
+      params.delete(key)
+    }
+    if (key !== "page") params.delete("page")
+    router.push(`?${params.toString()}`)
+  }
+
+  const draftCount = useMemo(
+    () => orders?.filter((o) => o.status === "draft").length ?? 0,
+    [orders]
+  )
+  const incompleteCount = useMemo(
+    () => orders?.filter((o) => !o.customer_id || !o.desired_deadline).length ?? 0,
+    [orders]
+  )
+
+  const filteredOrders = useMemo(() => {
+    if (!orders) return []
+    return orders
+      .filter((order) => filterOrder(order, statusFilter))
+      .sort((a, b) => compareOrders(a, b, sortKey))
+  }, [orders, statusFilter, sortKey])
+
+  const pagedOrders = useMemo(() => {
+    const offset = (page - 1) * PAGE_SIZE
+    return filteredOrders.slice(offset, offset + PAGE_SIZE)
+  }, [filteredOrders, page])
+
+  const handleConfirmFromRow = (orderId: number, orderNo: string) => {
+    confirmOrder.mutate(orderId, {
+      onSuccess: () => {
+        toast.success(`注文「${orderNo}」を確定し、スケジュールを作成しました`)
+        setExpandedOrderId(null)
+        setExpandedSimResult(null)
+      },
+      onError: (error: Error) => {
+        toast.error(`確定に失敗しました: ${error.message}`)
+      },
+    })
+  }
+
+  const handleSimulate = async (order: Order) => {
+    try {
+      const result = await simulateOrderById.mutateAsync(order.id)
+      setExpandedOrderId(order.id)
+      setExpandedSimResult(result)
+      toast.success("シミュレーションが完了しました")
+    } catch (error) {
+      console.error("Simulation error:", error)
+      toast.error("シミュレーションに失敗しました")
+    }
+  }
+
+  const handleOpenEditDialog = (order: Order) => {
+    setSelectedOrder(order)
+    setIsEditDialogOpen(true)
+  }
+
+  const handleConfirmDelete = () => {
+    if (!deleteTargetOrder) return
+    const targetId = deleteTargetOrder.id
+    const targetNo = deleteTargetOrder.order_no
+    deleteOrder.mutate(targetId, {
+      onSuccess: () => {
+        toast.success(`注文「${targetNo}」を削除しました`)
+        setDeleteTargetOrder(null)
+        if (expandedOrderId === targetId) {
+          setExpandedOrderId(null)
+          setExpandedSimResult(null)
+        }
+      },
+      onError: (error: Error) => {
+        toast.error(`削除に失敗しました: ${error.message}`)
+        setDeleteTargetOrder(null)
+      },
+    })
+  }
+
+  const closeSimResult = () => {
+    setExpandedOrderId(null)
+    setExpandedSimResult(null)
+  }
+
+  return {
+    // URL state
+    statusFilter,
+    sortKey,
+    page,
+    setParam,
+    router,
+    // Data
+    orders,
+    products,
+    customers,
+    isLoading: ordersLoading || productsLoading || customersLoading,
+    // Derived
+    draftCount,
+    incompleteCount,
+    filteredOrders,
+    pagedOrders,
+    // Dialog state
+    isEditDialogOpen,
+    setIsEditDialogOpen,
+    selectedOrder,
+    deleteTargetOrder,
+    setDeleteTargetOrder,
+    expandedOrderId,
+    expandedSimResult,
+    // Mutation state
+    confirmOrder,
+    deleteOrder,
+    simulateOrderById,
+    // Handlers
+    handleConfirmFromRow,
+    handleSimulate,
+    handleOpenEditDialog,
+    handleConfirmDelete,
+    closeSimResult,
+  }
+}

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -2,6 +2,45 @@ import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
 import type { Customer } from "@/types/customer"
 
+export type StatusFilter = "" | "draft" | "confirmed" | "incomplete" | "completed" | "canceled"
+export type SortKey = "created_at_desc" | "created_at_asc" | "desired_deadline_asc"
+
+export const STATUS_TABS: { label: string; value: StatusFilter }[] = [
+  { label: "すべて", value: "" },
+  { label: "下書き", value: "draft" },
+  { label: "確定済", value: "confirmed" },
+  { label: "情報不足", value: "incomplete" },
+  { label: "完了", value: "completed" },
+  { label: "キャンセル", value: "canceled" },
+]
+
+export const SORT_OPTIONS: { label: string; value: SortKey }[] = [
+  { label: "登録日（新しい順）", value: "created_at_desc" },
+  { label: "登録日（古い順）", value: "created_at_asc" },
+  { label: "希望納期（近い順）", value: "desired_deadline_asc" },
+]
+
+export function filterOrder(order: Order, statusFilter: StatusFilter): boolean {
+  if (statusFilter === "incomplete") return !order.customer_id || !order.desired_deadline
+  if (statusFilter) return order.status === statusFilter
+  return true
+}
+
+export function compareOrders(a: Order, b: Order, sortKey: SortKey): number {
+  if (sortKey === "created_at_desc" || sortKey === "created_at_asc") {
+    if (!a.created_at && !b.created_at) return 0
+    if (!a.created_at) return 1
+    if (!b.created_at) return -1
+    return sortKey === "created_at_desc"
+      ? b.created_at.localeCompare(a.created_at)
+      : a.created_at.localeCompare(b.created_at)
+  }
+  if (!a.desired_deadline && !b.desired_deadline) return 0
+  if (!a.desired_deadline) return 1
+  if (!b.desired_deadline) return -1
+  return a.desired_deadline.localeCompare(b.desired_deadline)
+}
+
 /**
  * 製品IDから製品名を取得
  */


### PR DESCRIPTION
## Summary

- `frontend/src/app/orders/page.tsx`（645行）を責務ごとにファイル分割し、158行のエントリーポイントに簡素化
- URL state・データ取得・ダイアログ状態・ハンドラーを `hooks/use-orders-page.ts` に抽出
- `filterOrder` / `compareOrders` / 定数・型を `lib/order-utils.ts` へ移行
- `components/orders/` を新設し 5 つのコンポーネントに分割

**新ファイル構成**
```
frontend/src/
  app/orders/
    page.tsx                        # 158行（エントリーポイントのみ）
  components/orders/
    edit-order-dialog.tsx
    delete-order-dialog.tsx
    order-notification-cards.tsx
    orders-filter-bar.tsx
    order-table-row.tsx
  hooks/
    use-orders-page.ts
  lib/
    order-utils.ts                  # filterOrder, compareOrders 等追記
```

**機能的な挙動に変更はありません。**

## Test plan

- [ ] `cd frontend && npm run dev` で `/orders` を開き、フィルター・ソート・ページネーションが動作すること
- [ ] シミュレーション実行 → 行展開 → 「この内容で確定」が動作すること
- [ ] 編集ダイアログ・削除確認ダイアログが正常に開閉すること
- [ ] 下書き/情報不足カードのクリックでフィルターが切り替わること
- [ ] `npx tsc --noEmit` でエラーが出ないこと（CI 確認済み）

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)