### PR TITLE
feat: シミュレーション結果表示をサイドシート方式に変更

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -111,7 +111,7 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 | `completed` | (なし) | 詳細確認 |
 | `canceled` | (なし) | 削除 |
 
-**シミュレーション実行**（`POST /orders/{order_id}/simulate`）の結果は、行展開またはサイドシート（右側パネル）で表示する。シミュレーション結果を確認後、「この内容で確定」ボタンで confirm へ移行する。
+**シミュレーション実行**（`POST /orders/{order_id}/simulate`）の結果は、画面右からスライドインするサイドシート（shadcn/ui `Sheet`）で表示する。Sheet フッターに「閉じる」「この内容で確定」ボタンを固定表示し、シミュレーション結果を確認後に confirm へ移行する。同時に開けるシートは 1 件のみで、別の注文のシミュレーション実行で自動的に切り替わる。
 
 ### 入力不足の警告表示
 
@@ -330,7 +330,8 @@ frontend/src/
     delete-order-dialog.tsx               # 削除確認 AlertDialog
     order-notification-cards.tsx          # 下書き/情報不足サマリーカード
     orders-filter-bar.tsx                 # ステータスタブ + ソートセレクト
-    order-table-row.tsx                   # テーブル行 + Sim展開行
+    order-table-row.tsx                   # テーブル行
+    simulation-side-sheet.tsx             # シミュレーション結果サイドシート
   hooks/
     use-orders-page.ts                    # URL state・データ取得・ハンドラー一式
   lib/
@@ -363,6 +364,7 @@ frontend/src/
 | 一覧ページ: ステータスバッジのカラーコード化 | 高 | ✅ 実装済 (#115) |
 | 一覧ページ: アクション体系の整備（is_scheduled連動） | 高 | ✅ 実装済 (#115) |
 | 一覧ページ: シミュレーション結果の行内展開 | 高 | ✅ 実装済 (#115) |
+| 一覧ページ: シミュレーション結果をサイドシート方式に変更 | 高 | ✅ 実装済 (#132) |
 | 一覧ページ: AlertDialogによる削除確認 | 高 | ✅ 実装済 (#115) |
 | 注文編集ダイアログ | 中 | ✅ 実装済 (#116) |
 | 新規注文: 3ステップインジケーター | 中 | ✅ 実装済 (#117) |

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -16,6 +16,7 @@ import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
 import { OrderNotificationCards } from "@/components/orders/order-notification-cards"
 import { OrdersFilterBar } from "@/components/orders/orders-filter-bar"
 import { OrderTableRow } from "@/components/orders/order-table-row"
+import { SimulationSideSheet } from "@/components/orders/simulation-side-sheet"
 import { useOrdersPage, PAGE_SIZE } from "@/hooks/use-orders-page"
 
 export default function OrdersPage() {
@@ -24,6 +25,7 @@ export default function OrdersPage() {
     sortKey,
     router,
     isLoading,
+    orders,
     products,
     customers,
     draftCount,
@@ -47,6 +49,8 @@ export default function OrdersPage() {
     handleConfirmDelete,
     closeSimResult,
   } = useOrdersPage()
+
+  const expandedOrder = orders?.find((o) => o.id === expandedOrderId) ?? null
 
   return (
     <TooltipProvider>
@@ -102,15 +106,12 @@ export default function OrdersPage() {
                     order={order}
                     products={products}
                     customers={customers}
-                    expandedOrderId={expandedOrderId}
-                    expandedSimResult={expandedSimResult}
                     simulateIsPending={simulateOrderById.isPending}
                     confirmIsPending={confirmOrder.isPending}
                     onSimulate={handleSimulate}
                     onConfirm={handleConfirmFromRow}
                     onEdit={handleOpenEditDialog}
                     onDelete={setDeleteTargetOrder}
-                    onCloseSimResult={closeSimResult}
                   />
                 ))}
               </TableBody>
@@ -151,6 +152,15 @@ export default function OrdersPage() {
           isPending={deleteOrder.isPending}
           onConfirm={handleConfirmDelete}
           onOpenChange={(open) => { if (!open) setDeleteTargetOrder(null) }}
+        />
+
+        <SimulationSideSheet
+          open={expandedSimResult !== null}
+          order={expandedOrder}
+          result={expandedSimResult}
+          confirmIsPending={confirmOrder.isPending}
+          onClose={closeSimResult}
+          onConfirm={handleConfirmFromRow}
         />
       </div>
     </TooltipProvider>

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Fragment } from "react"
 import { AlertCircle, MoreHorizontal } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
@@ -18,14 +17,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { SimulationResult } from "@/components/simulation-result"
 import {
   getProductName,
   getCustomerName,
   getStatusLabel,
   getStatusBadgeClass,
 } from "@/lib/order-utils"
-import type { Order, OrderSimulateResponse } from "@/types/order"
+import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
 import type { Customer } from "@/types/customer"
 
@@ -33,35 +31,26 @@ interface OrderTableRowProps {
   order: Order
   products?: Product[]
   customers?: Customer[]
-  expandedOrderId: number | null
-  expandedSimResult: OrderSimulateResponse | null
   simulateIsPending: boolean
   confirmIsPending: boolean
   onSimulate: (order: Order) => void
   onConfirm: (orderId: number, orderNo: string) => void
   onEdit: (order: Order) => void
   onDelete: (order: Order) => void
-  onCloseSimResult: () => void
 }
 
 export function OrderTableRow({
   order,
   products,
   customers,
-  expandedOrderId,
-  expandedSimResult,
   simulateIsPending,
   confirmIsPending,
   onSimulate,
   onConfirm,
   onEdit,
   onDelete,
-  onCloseSimResult,
 }: OrderTableRowProps) {
-  const isExpanded = expandedOrderId === order.id
-
   return (
-    <Fragment key={order.id}>
       <TableRow>
         <TableCell className="font-medium">{order.order_no}</TableCell>
         <TableCell>{getProductName(order.product_id, products)}</TableCell>
@@ -159,28 +148,5 @@ export function OrderTableRow({
           </div>
         </TableCell>
       </TableRow>
-      {isExpanded && expandedSimResult && (
-        <TableRow key={`${order.id}-sim`}>
-          <TableCell colSpan={8} className="bg-muted/30 p-4">
-            <SimulationResult
-              result={expandedSimResult}
-              desiredDeadline={order.desired_deadline}
-            />
-            <div className="flex justify-end gap-2 mt-4">
-              <Button variant="outline" size="sm" onClick={onCloseSimResult}>
-                閉じる
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => onConfirm(order.id, order.order_no)}
-                disabled={confirmIsPending}
-              >
-                この内容で確定
-              </Button>
-            </div>
-          </TableCell>
-        </TableRow>
-      )}
-    </Fragment>
   )
 }

--- a/frontend/src/components/orders/simulation-side-sheet.tsx
+++ b/frontend/src/components/orders/simulation-side-sheet.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { SimulationResult } from "@/components/simulation-result"
+import type { Order, OrderSimulateResponse } from "@/types/order"
+
+interface SimulationSideSheetProps {
+  open: boolean
+  order: Order | null
+  result: OrderSimulateResponse | null
+  confirmIsPending: boolean
+  onClose: () => void
+  onConfirm: (orderId: number, orderNo: string) => void
+}
+
+export function SimulationSideSheet({
+  open,
+  order,
+  result,
+  confirmIsPending,
+  onClose,
+  onConfirm,
+}: SimulationSideSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose() }}>
+      <SheetContent side="right" className="flex flex-col w-[480px] sm:max-w-[480px] p-0">
+        <SheetHeader className="px-6 py-4 border-b shrink-0">
+          <SheetTitle>シミュレーション結果</SheetTitle>
+          {order && (
+            <p className="text-sm text-muted-foreground">注文番号: {order.order_no}</p>
+          )}
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <SimulationResult
+            result={result}
+            desiredDeadline={order?.desired_deadline}
+          />
+        </div>
+        <SheetFooter className="px-6 py-4 border-t shrink-0 flex flex-row justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>
+            閉じる
+          </Button>
+          <Button
+            disabled={confirmIsPending || !order}
+            onClick={() => {
+              if (order) onConfirm(order.id, order.order_no)
+            }}
+          >
+            この内容で確定
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
## Summary

- `simulation-side-sheet.tsx` を新規作成し、shadcn/ui `Sheet` を使った右スライドイン方式でシミュレーション結果を表示
- `order-table-row.tsx` から行内展開 JSX を削除し、テーブルレイアウトをシンプル化
- Sheet フッターに「閉じる」「この内容で確定」ボタンを固定配置し、スクロール時も常に操作可能

## Test plan

- [ ] 下書き注文の「シミュレーション実行」クリック → 画面右からシートがスライドイン
- [ ] Sheet 内をスクロールしてもフッターの「閉じる」「この内容で確定」が常に表示される
- [ ] 別の注文のシミュレーション実行 → Sheet の内容が切り替わる（1件のみ同時表示）
- [ ] 「閉じる」でシートが閉じ、テーブルレイアウトが崩れない
- [ ] 「この内容で確定」で注文が確定されトースト通知が表示される

## Related Issue

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)