### PR TITLE
feat: 注文サマリカードに不足情報の内訳表示とSTEPラベルを追加 (#134)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -30,6 +30,8 @@ export default function OrdersPage() {
     customers,
     draftCount,
     incompleteCount,
+    noCustomerCount,
+    noDeadlineCount,
     filteredOrders,
     pagedOrders,
     isEditDialogOpen,
@@ -71,6 +73,8 @@ export default function OrdersPage() {
           <OrderNotificationCards
             draftCount={draftCount}
             incompleteCount={incompleteCount}
+            noCustomerCount={noCustomerCount}
+            noDeadlineCount={noDeadlineCount}
             onDraftClick={() => setParam("status", "draft")}
             onIncompleteClick={() => setParam("status", "incomplete")}
           />

--- a/frontend/src/components/orders/order-notification-cards.tsx
+++ b/frontend/src/components/orders/order-notification-cards.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent } from "@/components/ui/card"
 interface OrderNotificationCardsProps {
   draftCount: number
   incompleteCount: number
+  noCustomerCount: number
+  noDeadlineCount: number
   onDraftClick: () => void
   onIncompleteClick: () => void
 }
@@ -12,6 +14,8 @@ interface OrderNotificationCardsProps {
 export function OrderNotificationCards({
   draftCount,
   incompleteCount,
+  noCustomerCount,
+  noDeadlineCount,
   onDraftClick,
   onIncompleteClick,
 }: OrderNotificationCardsProps) {
@@ -19,25 +23,30 @@ export function OrderNotificationCards({
 
   return (
     <div className="mb-4 grid grid-cols-2 gap-4">
-      {draftCount > 0 && (
-        <Card
-          className="cursor-pointer border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-colors"
-          onClick={onDraftClick}
-        >
-          <CardContent className="pt-6">
-            <p className="text-2xl font-bold text-yellow-800">{draftCount}件 未確定</p>
-            <p className="text-sm text-yellow-700 mt-1">下書きを見る →</p>
-          </CardContent>
-        </Card>
-      )}
       {incompleteCount > 0 && (
         <Card
           className="cursor-pointer border-orange-300 bg-orange-50 hover:bg-orange-100 transition-colors"
           onClick={onIncompleteClick}
         >
           <CardContent className="pt-6">
+            <p className="text-xs font-semibold text-orange-500 uppercase tracking-wide mb-1">STEP 1</p>
             <p className="text-2xl font-bold text-orange-800">{incompleteCount}件 情報不足</p>
+            <p className="text-sm text-orange-600 mt-1">
+              顧客未設定 {noCustomerCount}件 / 希望納期未設定 {noDeadlineCount}件
+            </p>
             <p className="text-sm text-orange-700 mt-1">確認する →</p>
+          </CardContent>
+        </Card>
+      )}
+      {draftCount > 0 && (
+        <Card
+          className="cursor-pointer border-yellow-300 bg-yellow-50 hover:bg-yellow-100 transition-colors"
+          onClick={onDraftClick}
+        >
+          <CardContent className="pt-6">
+            <p className="text-xs font-semibold text-yellow-500 uppercase tracking-wide mb-1">STEP 2</p>
+            <p className="text-2xl font-bold text-yellow-800">{draftCount}件 未確定</p>
+            <p className="text-sm text-yellow-700 mt-1">下書きを見る →</p>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -65,6 +65,14 @@ export function useOrdersPage() {
     () => orders?.filter((o) => !o.customer_id || !o.desired_deadline).length ?? 0,
     [orders]
   )
+  const noCustomerCount = useMemo(
+    () => orders?.filter((o) => !o.customer_id).length ?? 0,
+    [orders]
+  )
+  const noDeadlineCount = useMemo(
+    () => orders?.filter((o) => !o.desired_deadline).length ?? 0,
+    [orders]
+  )
 
   const filteredOrders = useMemo(() => {
     if (!orders) return []
@@ -152,6 +160,8 @@ export function useOrdersPage() {
     // Derived
     draftCount,
     incompleteCount,
+    noCustomerCount,
+    noDeadlineCount,
     filteredOrders,
     pagedOrders,
     // Dialog state


### PR DESCRIPTION
## Summary
- 情報不足カードに「顧客未設定X件 / 希望納期未設定Y件」の内訳を追加し、何が不足しているかをカードから直接把握できるようにした
- カードの並び順を「情報不足(STEP 1) → 未確定(STEP 2)」に変更し、処理フローを明示
- `use-orders-page.ts` に `noCustomerCount` / `noDeadlineCount` の useMemo を追加

## 変更ファイル
- `frontend/src/hooks/use-orders-page.ts` — noCustomerCount / noDeadlineCount 算出ロジック追加
- `frontend/src/components/orders/order-notification-cards.tsx` — カード順変更・STEPラベル・内訳テキスト追加
- `frontend/src/app/orders/page.tsx` — 新 props を渡す

## Test plan
- [ ] 情報不足の注文がある状態で注文一覧を開き、「STEP 1」「情報不足カード」が先に表示されること
- [ ] 情報不足カードに「顧客未設定X件 / 希望納期未設定Y件」が正しく表示されること
- [ ] 「STEP 2 未確定」カードが後に表示されること
- [ ] `npx tsc --noEmit` でエラーなし

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)