### PR TITLE
feat: 注文一覧に一括操作機能を追加（チェックボックス + 一括シミュレーション / 一括確定）

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -3,6 +3,7 @@
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
 import {
   Table,
   TableBody,
@@ -54,6 +55,7 @@ export default function OrdersPage() {
     handleConfirmDelete,
     closeSimResult,
     selectedOrderIds,
+    selectedScheduledCount,
     draftPageOrders,
     allDraftOnPageSelected,
     someDraftOnPageSelected,
@@ -70,7 +72,7 @@ export default function OrdersPage() {
 
   return (
     <TooltipProvider>
-      <div className="container mx-auto py-6 px-4">
+      <div className={cn("container mx-auto py-6 px-4", selectedOrderIds.size > 0 && "pb-24")}>
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold">注文一覧</h1>
@@ -108,18 +110,20 @@ export default function OrdersPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-10">
-                    <Checkbox
-                      checked={
-                        allDraftOnPageSelected
-                          ? true
-                          : someDraftOnPageSelected
-                          ? "indeterminate"
-                          : false
-                      }
-                      onCheckedChange={handleToggleSelectAll}
-                      disabled={draftPageOrders.length === 0 || isBulkSimulating || isBulkConfirming}
-                      aria-label="全選択"
-                    />
+                    <div className="flex items-center justify-center">
+                      <Checkbox
+                        checked={
+                          allDraftOnPageSelected
+                            ? true
+                            : someDraftOnPageSelected
+                            ? "indeterminate"
+                            : false
+                        }
+                        onCheckedChange={handleToggleSelectAll}
+                        disabled={draftPageOrders.length === 0 || isBulkSimulating || isBulkConfirming}
+                        aria-label="全選択"
+                      />
+                    </div>
                   </TableHead>
                   <TableHead>注文番号</TableHead>
                   <TableHead>製品</TableHead>
@@ -201,6 +205,7 @@ export default function OrdersPage() {
 
         <BulkActionBar
           selectedCount={selectedOrderIds.size}
+          selectedScheduledCount={selectedScheduledCount}
           isBulkSimulating={isBulkSimulating}
           isBulkConfirming={isBulkConfirming}
           onBulkSimulate={handleBulkSimulate}

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -2,6 +2,7 @@
 
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Table,
   TableBody,
@@ -11,6 +12,7 @@ import {
 } from "@/components/ui/table"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { MasterPagination } from "@/components/master-pagination"
+import { BulkActionBar } from "@/components/orders/bulk-action-bar"
 import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
 import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
 import { OrderNotificationCards } from "@/components/orders/order-notification-cards"
@@ -51,6 +53,17 @@ export default function OrdersPage() {
     handleOpenEditDialog,
     handleConfirmDelete,
     closeSimResult,
+    selectedOrderIds,
+    draftPageOrders,
+    allDraftOnPageSelected,
+    someDraftOnPageSelected,
+    isBulkSimulating,
+    isBulkConfirming,
+    handleToggleSelect,
+    handleToggleSelectAll,
+    handleClearSelection,
+    handleBulkSimulate,
+    handleBulkConfirm,
   } = useOrdersPage()
 
   const expandedOrder = orders?.find((o) => o.id === expandedOrderId) ?? null
@@ -94,6 +107,20 @@ export default function OrdersPage() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={
+                        allDraftOnPageSelected
+                          ? true
+                          : someDraftOnPageSelected
+                          ? "indeterminate"
+                          : false
+                      }
+                      onCheckedChange={handleToggleSelectAll}
+                      disabled={draftPageOrders.length === 0 || isBulkSimulating || isBulkConfirming}
+                      aria-label="全選択"
+                    />
+                  </TableHead>
                   <TableHead>注文番号</TableHead>
                   <TableHead>製品</TableHead>
                   <TableHead>顧客</TableHead>
@@ -114,10 +141,13 @@ export default function OrdersPage() {
                     isSimulating={simulatingOrderId === order.id}
                     hasSimulationError={simulationErrorOrderId === order.id}
                     confirmIsPending={confirmOrder.isPending}
+                    isSelected={selectedOrderIds.has(order.id)}
+                    isBulkOperationInProgress={isBulkSimulating || isBulkConfirming}
                     onSimulate={handleSimulate}
                     onConfirm={handleConfirmFromRow}
                     onEdit={handleOpenEditDialog}
                     onDelete={setDeleteTargetOrder}
+                    onToggleSelect={handleToggleSelect}
                   />
                 ))}
               </TableBody>
@@ -167,6 +197,15 @@ export default function OrdersPage() {
           confirmIsPending={confirmOrder.isPending}
           onClose={closeSimResult}
           onConfirm={handleConfirmFromRow}
+        />
+
+        <BulkActionBar
+          selectedCount={selectedOrderIds.size}
+          isBulkSimulating={isBulkSimulating}
+          isBulkConfirming={isBulkConfirming}
+          onBulkSimulate={handleBulkSimulate}
+          onBulkConfirm={handleBulkConfirm}
+          onClearSelection={handleClearSelection}
         />
       </div>
     </TooltipProvider>

--- a/frontend/src/components/orders/bulk-action-bar.tsx
+++ b/frontend/src/components/orders/bulk-action-bar.tsx
@@ -2,9 +2,15 @@
 
 import { Loader2, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 interface BulkActionBarProps {
   selectedCount: number
+  selectedScheduledCount: number
   isBulkSimulating: boolean
   isBulkConfirming: boolean
   onBulkSimulate: () => void
@@ -14,6 +20,7 @@ interface BulkActionBarProps {
 
 export function BulkActionBar({
   selectedCount,
+  selectedScheduledCount,
   isBulkSimulating,
   isBulkConfirming,
   onBulkSimulate,
@@ -23,6 +30,7 @@ export function BulkActionBar({
   if (selectedCount === 0) return null
 
   const isBusy = isBulkSimulating || isBulkConfirming
+  const canConfirm = selectedScheduledCount > 0
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 rounded-xl border bg-card px-4 py-3 shadow-lg">
@@ -40,26 +48,47 @@ export function BulkActionBar({
           `一括シミュレーション（${selectedCount}件）`
         )}
       </Button>
-      <Button size="sm" onClick={onBulkConfirm} disabled={isBusy}>
-        {isBulkConfirming ? (
-          <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            確定中...
-          </>
-        ) : (
-          `一括確定（${selectedCount}件）`
+      {/* disabled な Button は pointer-events: none のため Tooltip が発火しない。span でラップする */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={!canConfirm ? "cursor-not-allowed" : undefined}>
+            <Button
+              size="sm"
+              onClick={onBulkConfirm}
+              disabled={isBusy || !canConfirm}
+            >
+              {isBulkConfirming ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  確定中...
+                </>
+              ) : (
+                `一括確定（${selectedScheduledCount}件）`
+              )}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        {!canConfirm && (
+          <TooltipContent>
+            シミュレーション済みの注文がありません
+          </TooltipContent>
         )}
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={onClearSelection}
-        disabled={isBusy}
-        className="h-8 w-8 p-0"
-        aria-label="選択を解除"
-      >
-        <X className="h-4 w-4" />
-      </Button>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onClearSelection}
+            disabled={isBusy}
+            className="h-8 w-8 p-0"
+            aria-label="選択を解除"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>選択を解除してバーを閉じる</TooltipContent>
+      </Tooltip>
     </div>
   )
 }

--- a/frontend/src/components/orders/bulk-action-bar.tsx
+++ b/frontend/src/components/orders/bulk-action-bar.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Loader2, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface BulkActionBarProps {
+  selectedCount: number
+  isBulkSimulating: boolean
+  isBulkConfirming: boolean
+  onBulkSimulate: () => void
+  onBulkConfirm: () => void
+  onClearSelection: () => void
+}
+
+export function BulkActionBar({
+  selectedCount,
+  isBulkSimulating,
+  isBulkConfirming,
+  onBulkSimulate,
+  onBulkConfirm,
+  onClearSelection,
+}: BulkActionBarProps) {
+  if (selectedCount === 0) return null
+
+  const isBusy = isBulkSimulating || isBulkConfirming
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 rounded-xl border bg-card px-4 py-3 shadow-lg">
+      <span className="text-sm font-medium text-muted-foreground">
+        {selectedCount}件選択中
+      </span>
+      <div className="h-4 w-px bg-border" />
+      <Button size="sm" variant="outline" onClick={onBulkSimulate} disabled={isBusy}>
+        {isBulkSimulating ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            シミュレーション中...
+          </>
+        ) : (
+          `一括シミュレーション（${selectedCount}件）`
+        )}
+      </Button>
+      <Button size="sm" onClick={onBulkConfirm} disabled={isBusy}>
+        {isBulkConfirming ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            確定中...
+          </>
+        ) : (
+          `一括確定（${selectedCount}件）`
+        )}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={onClearSelection}
+        disabled={isBusy}
+        className="h-8 w-8 p-0"
+        aria-label="選択を解除"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -5,6 +5,7 @@ import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -34,10 +35,13 @@ interface OrderTableRowProps {
   isSimulating: boolean
   hasSimulationError: boolean
   confirmIsPending: boolean
+  isSelected: boolean
+  isBulkOperationInProgress: boolean
   onSimulate: (order: Order) => void
   onConfirm: (orderId: number, orderNo: string) => void
   onEdit: (order: Order) => void
   onDelete: (order: Order) => void
+  onToggleSelect: (orderId: number) => void
 }
 
 export function OrderTableRow({
@@ -47,13 +51,26 @@ export function OrderTableRow({
   isSimulating,
   hasSimulationError,
   confirmIsPending,
+  isSelected,
+  isBulkOperationInProgress,
   onSimulate,
   onConfirm,
   onEdit,
   onDelete,
+  onToggleSelect,
 }: OrderTableRowProps) {
   return (
       <TableRow>
+        <TableCell className="w-10">
+          {order.status === "draft" ? (
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={() => onToggleSelect(order.id)}
+              disabled={isBulkOperationInProgress}
+              aria-label={`注文 ${order.order_no} を選択`}
+            />
+          ) : null}
+        </TableCell>
         <TableCell className="font-medium">{order.order_no}</TableCell>
         <TableCell>{getProductName(order.product_id, products)}</TableCell>
         <TableCell>
@@ -112,7 +129,7 @@ export function OrderTableRow({
                 size="sm"
                 variant="outline"
                 onClick={() => onSimulate(order)}
-                disabled={isSimulating}
+                disabled={isSimulating || isBulkOperationInProgress}
               >
                 {isSimulating ? (
                   <>
@@ -129,7 +146,7 @@ export function OrderTableRow({
                 size="sm"
                 variant="outline"
                 onClick={() => onConfirm(order.id, order.order_no)}
-                disabled={confirmIsPending}
+                disabled={confirmIsPending || isBulkOperationInProgress}
               >
                 確定
               </Button>

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -1,7 +1,8 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
+import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
   useConfirmOrder,
@@ -38,6 +39,11 @@ export function useOrdersPage() {
   const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
   const [simulatingOrderId, setSimulatingOrderId] = useState<number | null>(null)
   const [simulationErrorOrderId, setSimulationErrorOrderId] = useState<number | null>(null)
+  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<number>>(new Set())
+  const [isBulkSimulating, setIsBulkSimulating] = useState(false)
+  const [isBulkConfirming, setIsBulkConfirming] = useState(false)
+
+  const queryClient = useQueryClient()
 
   const { data: orders, isLoading: ordersLoading } = useOrders()
   const { data: products, isLoading: productsLoading } = useProducts()
@@ -85,6 +91,19 @@ export function useOrdersPage() {
     const offset = (page - 1) * PAGE_SIZE
     return filteredOrders.slice(offset, offset + PAGE_SIZE)
   }, [filteredOrders, page])
+
+  const draftPageOrders = useMemo(
+    () => pagedOrders.filter((o) => o.status === "draft"),
+    [pagedOrders]
+  )
+  const allDraftOnPageSelected =
+    draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.has(o.id))
+  const someDraftOnPageSelected =
+    draftPageOrders.some((o) => selectedOrderIds.has(o.id)) && !allDraftOnPageSelected
+
+  useEffect(() => {
+    setSelectedOrderIds(new Set())
+  }, [page, statusFilter])
 
   const handleConfirmFromRow = (orderId: number, orderNo: string) => {
     confirmOrder.mutate(orderId, {
@@ -145,6 +164,84 @@ export function useOrdersPage() {
     setExpandedSimResult(null)
   }
 
+  const handleToggleSelect = (orderId: number) => {
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev)
+      next.has(orderId) ? next.delete(orderId) : next.add(orderId)
+      return next
+    })
+  }
+
+  const handleToggleSelectAll = () => {
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev)
+      if (allDraftOnPageSelected) {
+        draftPageOrders.forEach((o) => next.delete(o.id))
+      } else {
+        draftPageOrders.forEach((o) => next.add(o.id))
+      }
+      return next
+    })
+  }
+
+  const handleClearSelection = () => setSelectedOrderIds(new Set())
+
+  const handleBulkSimulate = async () => {
+    const ids = Array.from(selectedOrderIds)
+    setIsBulkSimulating(true)
+    let successCount = 0, failCount = 0
+    for (const id of ids) {
+      try {
+        await simulateOrderById.mutateAsync(id)
+        successCount++
+      } catch {
+        failCount++
+      }
+    }
+    await queryClient.invalidateQueries({ queryKey: ["orders"] })
+    setIsBulkSimulating(false)
+    setSelectedOrderIds(new Set())
+    if (failCount === 0) {
+      toast.success(`一括シミュレーション完了: 成功 ${successCount}件`)
+    } else if (successCount === 0) {
+      toast.error(`一括シミュレーション失敗: 失敗 ${failCount}件`)
+    } else {
+      toast.warning(`一括シミュレーション完了: 成功 ${successCount}件 / 失敗 ${failCount}件`)
+    }
+  }
+
+  const handleBulkConfirm = async () => {
+    const ids = Array.from(selectedOrderIds)
+    const scheduledIds = ids.filter((id) => orders?.find((o) => o.id === id)?.is_scheduled)
+    const skippedCount = ids.length - scheduledIds.length
+    setIsBulkConfirming(true)
+    let successCount = 0, failCount = 0
+    for (const id of scheduledIds) {
+      try {
+        await confirmOrder.mutateAsync(id)
+        successCount++
+      } catch {
+        failCount++
+      }
+    }
+    setIsBulkConfirming(false)
+    setSelectedOrderIds(new Set())
+    const parts = (
+      [
+        successCount > 0 ? `成功 ${successCount}件` : null,
+        failCount > 0 ? `失敗 ${failCount}件` : null,
+        skippedCount > 0 ? `スキップ ${skippedCount}件（未スケジュール）` : null,
+      ] as (string | null)[]
+    ).filter((p): p is string => p !== null).join(" / ")
+    if (failCount === 0 && skippedCount === 0) {
+      toast.success(`一括確定完了: ${parts}`)
+    } else if (successCount === 0 && failCount > 0) {
+      toast.error(`一括確定失敗: ${parts}`)
+    } else {
+      toast.warning(`一括確定完了: ${parts}`)
+    }
+  }
+
   return {
     // URL state
     statusFilter,
@@ -184,5 +281,17 @@ export function useOrdersPage() {
     handleOpenEditDialog,
     handleConfirmDelete,
     closeSimResult,
+    // Bulk selection
+    selectedOrderIds,
+    draftPageOrders,
+    allDraftOnPageSelected,
+    someDraftOnPageSelected,
+    isBulkSimulating,
+    isBulkConfirming,
+    handleToggleSelect,
+    handleToggleSelectAll,
+    handleClearSelection,
+    handleBulkSimulate,
+    handleBulkConfirm,
   }
 }

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -96,6 +96,12 @@ export function useOrdersPage() {
     () => pagedOrders.filter((o) => o.status === "draft"),
     [pagedOrders]
   )
+  const selectedScheduledCount = useMemo(
+    () => Array.from(selectedOrderIds).filter(
+      (id) => orders?.find((o) => o.id === id)?.is_scheduled
+    ).length,
+    [selectedOrderIds, orders]
+  )
   const allDraftOnPageSelected =
     draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.has(o.id))
   const someDraftOnPageSelected =
@@ -283,6 +289,7 @@ export function useOrdersPage() {
     closeSimResult,
     // Bulk selection
     selectedOrderIds,
+    selectedScheduledCount,
     draftPageOrders,
     allDraftOnPageSelected,
     someDraftOnPageSelected,


### PR DESCRIPTION
## 概要

Issue #135 の対応。下書き注文が多い場合に1件ずつ操作する手間を解消するため、チェックボックスによる複数選択とフローティングバーによる一括操作機能を追加。

## 変更内容

- **チェックボックス列**: `draft` 注文行のみにチェックボックスを追加（`confirmed`/`completed` は非表示）
- **全選択**: ヘッダーに全選択チェックボックス（indeterminate 対応）
- **フローティングアクションバー**: 1件以上選択時に画面下部に表示（`bulk-action-bar.tsx` 新規作成）
- **一括シミュレーション**: 順次実行 → 完了後に「成功 X件 / 失敗 Y件」のサマリー toast
- **一括確定**: `is_scheduled=false` の注文はスキップ → スキップ件数もサマリーに含む
- **競合防止**: 一括操作中は個別の操作ボタンを `disabled` に
- **選択リセット**: ページ/フィルター変更時に自動で選択解除

## 実装の注意点

- バックエンド変更なし。既存の `POST /orders/{id}/simulate` と `POST /orders/{id}/confirm` を順次コール
- `useSimulateOrderById` は既存で `onSuccess` の queryInvalidation がないため、一括シミュレーション後に明示的に `invalidateQueries` を呼び出し `is_scheduled` を更新

## テスト計画

- [ ] draft 注文行にチェックボックスが表示される（confirmed/completed には非表示）
- [ ] ヘッダー全選択でページ内 draft 注文が全選択される
- [ ] 選択時にフローティングバーが表示され、一括操作が実行できる
- [ ] 一括シミュレーション完了後にサマリー toast が表示される
- [ ] 一括確定で `is_scheduled=false` の注文がスキップされる
- [ ] フィルター/ページ変更で選択がリセットされる
- [ ] 一括操作中に個別ボタンが無効化される

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)