### PR TITLE
feat: 受注管理ページのデフォルトソートを希望納期（近い順）に変更 (#142)

### DIFF
--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -15,6 +15,7 @@ import { useCustomers } from "@/hooks/use-customers"
 import {
   filterOrder,
   compareOrders,
+  DEFAULT_SORT,
   type StatusFilter,
   type SortKey,
 } from "@/lib/order-utils"
@@ -29,7 +30,7 @@ export function useOrdersPage() {
   const searchParams = useSearchParams()
 
   const statusFilter = (searchParams.get("status") ?? "") as StatusFilter
-  const sortKey = (searchParams.get("sort") ?? "created_at_desc") as SortKey
+  const sortKey = (searchParams.get("sort") ?? DEFAULT_SORT) as SortKey
   const page = Number(searchParams.get("page") ?? "1")
 
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -14,6 +14,8 @@ export const STATUS_TABS: { label: string; value: StatusFilter }[] = [
   { label: "キャンセル", value: "canceled" },
 ]
 
+export const DEFAULT_SORT: SortKey = "desired_deadline_asc"
+
 export const SORT_OPTIONS: { label: string; value: SortKey }[] = [
   { label: "登録日（新しい順）", value: "created_at_desc" },
   { label: "登録日（古い順）", value: "created_at_asc" },


### PR DESCRIPTION
## Summary

- `frontend/src/lib/order-utils.ts` に `DEFAULT_SORT = "desired_deadline_asc"` 定数を追加
- `frontend/src/hooks/use-orders-page.ts` のソートキーフォールバックを `DEFAULT_SORT` に変更

## Test plan

- [ ] URLパラメータなしで `/orders` を開き、希望納期が近い順に並ぶことを確認
- [ ] ソートセレクタの初期値が「希望納期（近い順）」と表示されることを確認
- [ ] 明示的にソートを変更した場合はその選択が維持されることを確認

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)