### PR TITLE
feat: 一括シミュレーションのチェック順に優先番号バッジを表示 (#143)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -76,7 +76,7 @@ export default function OrdersPage() {
 
   return (
     <TooltipProvider>
-      <div className={cn("container mx-auto py-6 px-4", selectedOrderIds.size > 0 && "pb-24")}>
+      <div className={cn("container mx-auto py-6 px-4", selectedOrderIds.length > 0 && "pb-24")}>
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold">注文一覧</h1>
@@ -149,7 +149,8 @@ export default function OrdersPage() {
                     isSimulating={simulatingOrderId === order.id}
                     hasSimulationError={simulationErrorOrderId === order.id}
                     confirmIsPending={confirmOrder.isPending}
-                    isSelected={selectedOrderIds.has(order.id)}
+                    isSelected={selectedOrderIds.includes(order.id)}
+                    selectionIndex={selectedOrderIds.includes(order.id) ? selectedOrderIds.indexOf(order.id) + 1 : undefined}
                     isBulkOperationInProgress={isBulkSimulating || isBulkConfirming}
                     hasBulkSimFailed={bulkSimFailedIds.has(order.id)}
                     onSimulate={handleSimulate}
@@ -209,7 +210,7 @@ export default function OrdersPage() {
         />
 
         <BulkActionBar
-          selectedCount={selectedOrderIds.size}
+          selectedCount={selectedOrderIds.length}
           selectedScheduledCount={selectedScheduledCount}
           isBulkSimulating={isBulkSimulating}
           isBulkConfirming={isBulkConfirming}

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -36,6 +36,7 @@ interface OrderTableRowProps {
   hasSimulationError: boolean
   confirmIsPending: boolean
   isSelected: boolean
+  selectionIndex?: number
   isBulkOperationInProgress: boolean
   hasBulkSimFailed?: boolean
   onSimulate: (order: Order) => void
@@ -53,6 +54,7 @@ export function OrderTableRow({
   hasSimulationError,
   confirmIsPending,
   isSelected,
+  selectionIndex,
   isBulkOperationInProgress,
   hasBulkSimFailed,
   onSimulate,
@@ -65,12 +67,19 @@ export function OrderTableRow({
       <TableRow className={hasBulkSimFailed ? "border-l-[3px] border-l-destructive bg-destructive/5" : undefined}>
         <TableCell className="w-10">
           {order.status === "draft" ? (
-            <Checkbox
-              checked={isSelected}
-              onCheckedChange={() => onToggleSelect(order.id)}
-              disabled={isBulkOperationInProgress}
-              aria-label={`注文 ${order.order_no} を選択`}
-            />
+            <div className="relative flex items-center justify-center">
+              <Checkbox
+                checked={isSelected}
+                onCheckedChange={() => onToggleSelect(order.id)}
+                disabled={isBulkOperationInProgress}
+                aria-label={`注文 ${order.order_no} を選択`}
+              />
+              {selectionIndex != null && (
+                <Badge className="absolute -top-2 -right-2 h-4 w-4 p-0 text-[10px] flex items-center justify-center rounded-full">
+                  {selectionIndex}
+                </Badge>
+              )}
+            </div>
           ) : null}
         </TableCell>
         <TableCell className="font-medium">{order.order_no}</TableCell>

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -39,7 +39,7 @@ export function useOrdersPage() {
   const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
   const [simulatingOrderId, setSimulatingOrderId] = useState<number | null>(null)
   const [simulationErrorOrderId, setSimulationErrorOrderId] = useState<number | null>(null)
-  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<number>>(new Set())
+  const [selectedOrderIds, setSelectedOrderIds] = useState<number[]>([])
   const [isBulkSimulating, setIsBulkSimulating] = useState(false)
   const [isBulkConfirming, setIsBulkConfirming] = useState(false)
   const [bulkSimSummary, setBulkSimSummary] = useState<BulkSimulateResult[] | null>(null)
@@ -99,18 +99,18 @@ export function useOrdersPage() {
     [pagedOrders]
   )
   const selectedScheduledCount = useMemo(
-    () => Array.from(selectedOrderIds).filter(
+    () => selectedOrderIds.filter(
       (id) => orders?.find((o) => o.id === id)?.is_scheduled
     ).length,
     [selectedOrderIds, orders]
   )
   const allDraftOnPageSelected =
-    draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.has(o.id))
+    draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.includes(o.id))
   const someDraftOnPageSelected =
-    draftPageOrders.some((o) => selectedOrderIds.has(o.id)) && !allDraftOnPageSelected
+    draftPageOrders.some((o) => selectedOrderIds.includes(o.id)) && !allDraftOnPageSelected
 
   useEffect(() => {
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     setBulkSimFailedIds(new Set())
   }, [page, statusFilter])
 
@@ -174,29 +174,26 @@ export function useOrdersPage() {
   }
 
   const handleToggleSelect = (orderId: number) => {
-    setSelectedOrderIds((prev) => {
-      const next = new Set(prev)
-      next.has(orderId) ? next.delete(orderId) : next.add(orderId)
-      return next
-    })
+    setSelectedOrderIds((prev) =>
+      prev.includes(orderId) ? prev.filter((id) => id !== orderId) : [...prev, orderId]
+    )
   }
 
   const handleToggleSelectAll = () => {
     setSelectedOrderIds((prev) => {
-      const next = new Set(prev)
       if (allDraftOnPageSelected) {
-        draftPageOrders.forEach((o) => next.delete(o.id))
+        return prev.filter((id) => !draftPageOrders.some((o) => o.id === id))
       } else {
-        draftPageOrders.forEach((o) => next.add(o.id))
+        const newIds = draftPageOrders.map((o) => o.id).filter((id) => !prev.includes(id))
+        return [...prev, ...newIds]
       }
-      return next
     })
   }
 
-  const handleClearSelection = () => setSelectedOrderIds(new Set())
+  const handleClearSelection = () => setSelectedOrderIds([])
 
   const handleBulkSimulate = async () => {
-    const ids = Array.from(selectedOrderIds)
+    const ids = selectedOrderIds
     setIsBulkSimulating(true)
     setBulkSimFailedIds(new Set())
     const results: BulkSimulateResult[] = []
@@ -215,7 +212,7 @@ export function useOrdersPage() {
       results.filter((r) => r.result === null || !r.result.is_feasible).map((r) => r.orderId)
     )
     setBulkSimFailedIds(failedIds)
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     setIsBulkSimulating(false)
     setBulkSimSummary(results)
   }
@@ -223,7 +220,7 @@ export function useOrdersPage() {
   const handleCloseBulkSimSummary = () => setBulkSimSummary(null)
 
   const handleBulkConfirm = async () => {
-    const ids = Array.from(selectedOrderIds)
+    const ids = selectedOrderIds
     const scheduledIds = ids.filter((id) => orders?.find((o) => o.id === id)?.is_scheduled)
     const skippedCount = ids.length - scheduledIds.length
     setIsBulkConfirming(true)
@@ -237,7 +234,7 @@ export function useOrdersPage() {
       }
     }
     setIsBulkConfirming(false)
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     const parts = (
       [
         successCount > 0 ? `成功 ${successCount}件` : null,


### PR DESCRIPTION
## Summary

- `selectedOrderIds` の型を `Set<number>` → `number[]` に変更し、チェック順（挿入順）を保持
- 注文行コンポーネントに `selectionIndex` prop を追加し、選択中の行にチェック順番号バッジを表示
- 「すべて選択」は現在の表示順（ソート順）で番号を振る。チェックを外すと番号が詰め直される

## Test plan

- [ ] チェックを入れた行に 1, 2, 3… のバッジが表示される
- [ ] チェックを外すと残りの番号が詰め直される（欠番が生じない）
- [ ] 「すべて選択」で現在の表示順に番号が振られる
- [ ] 一括シミュレーションはバッジに表示された番号順に実行される

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)