### PR TITLE
feat: 一括シミュレーション実行前に処理順確認モーダルを追加 (#144)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -76,7 +76,7 @@ export default function OrdersPage() {
 
   return (
     <TooltipProvider>
-      <div className={cn("container mx-auto py-6 px-4", selectedOrderIds.size > 0 && "pb-24")}>
+      <div className={cn("container mx-auto py-6 px-4", selectedOrderIds.length > 0 && "pb-24")}>
         <div className="mb-6 flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold">注文一覧</h1>
@@ -149,7 +149,8 @@ export default function OrdersPage() {
                     isSimulating={simulatingOrderId === order.id}
                     hasSimulationError={simulationErrorOrderId === order.id}
                     confirmIsPending={confirmOrder.isPending}
-                    isSelected={selectedOrderIds.has(order.id)}
+                    isSelected={selectedOrderIds.includes(order.id)}
+                    selectionIndex={selectedOrderIds.includes(order.id) ? selectedOrderIds.indexOf(order.id) + 1 : undefined}
                     isBulkOperationInProgress={isBulkSimulating || isBulkConfirming}
                     hasBulkSimFailed={bulkSimFailedIds.has(order.id)}
                     onSimulate={handleSimulate}
@@ -209,7 +210,7 @@ export default function OrdersPage() {
         />
 
         <BulkActionBar
-          selectedCount={selectedOrderIds.size}
+          selectedCount={selectedOrderIds.length}
           selectedScheduledCount={selectedScheduledCount}
           isBulkSimulating={isBulkSimulating}
           isBulkConfirming={isBulkConfirming}

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -14,6 +14,7 @@ import {
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { MasterPagination } from "@/components/master-pagination"
 import { BulkActionBar } from "@/components/orders/bulk-action-bar"
+import { BulkSimulateConfirmDialog } from "@/components/orders/bulk-simulate-confirm-dialog"
 import { BulkSimulateSummaryDialog } from "@/components/orders/bulk-simulate-summary-dialog"
 import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
 import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
@@ -62,10 +63,13 @@ export default function OrdersPage() {
     someDraftOnPageSelected,
     isBulkSimulating,
     isBulkConfirming,
+    isBulkSimulateConfirmOpen,
     handleToggleSelect,
     handleToggleSelectAll,
     handleClearSelection,
-    handleBulkSimulate,
+    handleBulkSimulateRequest,
+    handleBulkSimulateConfirm,
+    handleBulkSimulateCancel,
     handleBulkConfirm,
     bulkSimSummary,
     bulkSimFailedIds,
@@ -214,9 +218,17 @@ export default function OrdersPage() {
           selectedScheduledCount={selectedScheduledCount}
           isBulkSimulating={isBulkSimulating}
           isBulkConfirming={isBulkConfirming}
-          onBulkSimulate={handleBulkSimulate}
+          onBulkSimulate={handleBulkSimulateRequest}
           onBulkConfirm={handleBulkConfirm}
           onClearSelection={handleClearSelection}
+        />
+
+        <BulkSimulateConfirmDialog
+          open={isBulkSimulateConfirmOpen}
+          orders={selectedOrderIds.map((id) => orders?.find((o) => o.id === id)!).filter(Boolean)}
+          products={products}
+          onConfirm={handleBulkSimulateConfirm}
+          onCancel={handleBulkSimulateCancel}
         />
 
         <BulkSimulateSummaryDialog

--- a/frontend/src/components/orders/bulk-simulate-confirm-dialog.tsx
+++ b/frontend/src/components/orders/bulk-simulate-confirm-dialog.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { getProductName } from "@/lib/order-utils"
+import type { Order } from "@/types/order"
+import type { Product } from "@/types/product"
+
+interface BulkSimulateConfirmDialogProps {
+  open: boolean
+  orders: Order[]
+  products?: Product[]
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function BulkSimulateConfirmDialog({
+  open,
+  orders,
+  products,
+  onConfirm,
+  onCancel,
+}: BulkSimulateConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>一括シミュレーションの確認</DialogTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            この順番で処理します（{orders.length}件）
+          </p>
+        </DialogHeader>
+
+        <div className="max-h-80 overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">#</TableHead>
+                <TableHead>注文番号</TableHead>
+                <TableHead>品名</TableHead>
+                <TableHead>希望納期</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {orders.map((order, index) => (
+                <TableRow key={order.id}>
+                  <TableCell className="text-muted-foreground font-medium">{index + 1}</TableCell>
+                  <TableCell className="font-medium">{order.order_no}</TableCell>
+                  <TableCell className="text-sm">{getProductName(order.product_id, products)}</TableCell>
+                  <TableCell className="text-sm">
+                    {order.desired_deadline
+                      ? format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
+                      : "未設定"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            キャンセル
+          </Button>
+          <Button onClick={onConfirm}>実行</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -36,6 +36,7 @@ interface OrderTableRowProps {
   hasSimulationError: boolean
   confirmIsPending: boolean
   isSelected: boolean
+  selectionIndex?: number
   isBulkOperationInProgress: boolean
   hasBulkSimFailed?: boolean
   onSimulate: (order: Order) => void
@@ -53,6 +54,7 @@ export function OrderTableRow({
   hasSimulationError,
   confirmIsPending,
   isSelected,
+  selectionIndex,
   isBulkOperationInProgress,
   hasBulkSimFailed,
   onSimulate,
@@ -65,12 +67,19 @@ export function OrderTableRow({
       <TableRow className={hasBulkSimFailed ? "border-l-[3px] border-l-destructive bg-destructive/5" : undefined}>
         <TableCell className="w-10">
           {order.status === "draft" ? (
-            <Checkbox
-              checked={isSelected}
-              onCheckedChange={() => onToggleSelect(order.id)}
-              disabled={isBulkOperationInProgress}
-              aria-label={`注文 ${order.order_no} を選択`}
-            />
+            <div className="relative flex items-center justify-center">
+              <Checkbox
+                checked={isSelected}
+                onCheckedChange={() => onToggleSelect(order.id)}
+                disabled={isBulkOperationInProgress}
+                aria-label={`注文 ${order.order_no} を選択`}
+              />
+              {selectionIndex != null && (
+                <Badge className="absolute -top-2 -right-2 h-4 w-4 p-0 text-[10px] flex items-center justify-center rounded-full">
+                  {selectionIndex}
+                </Badge>
+              )}
+            </div>
           ) : null}
         </TableCell>
         <TableCell className="font-medium">{order.order_no}</TableCell>

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -39,7 +39,7 @@ export function useOrdersPage() {
   const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
   const [simulatingOrderId, setSimulatingOrderId] = useState<number | null>(null)
   const [simulationErrorOrderId, setSimulationErrorOrderId] = useState<number | null>(null)
-  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<number>>(new Set())
+  const [selectedOrderIds, setSelectedOrderIds] = useState<number[]>([])
   const [isBulkSimulating, setIsBulkSimulating] = useState(false)
   const [isBulkConfirming, setIsBulkConfirming] = useState(false)
   const [bulkSimSummary, setBulkSimSummary] = useState<BulkSimulateResult[] | null>(null)
@@ -99,18 +99,18 @@ export function useOrdersPage() {
     [pagedOrders]
   )
   const selectedScheduledCount = useMemo(
-    () => Array.from(selectedOrderIds).filter(
+    () => selectedOrderIds.filter(
       (id) => orders?.find((o) => o.id === id)?.is_scheduled
     ).length,
     [selectedOrderIds, orders]
   )
   const allDraftOnPageSelected =
-    draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.has(o.id))
+    draftPageOrders.length > 0 && draftPageOrders.every((o) => selectedOrderIds.includes(o.id))
   const someDraftOnPageSelected =
-    draftPageOrders.some((o) => selectedOrderIds.has(o.id)) && !allDraftOnPageSelected
+    draftPageOrders.some((o) => selectedOrderIds.includes(o.id)) && !allDraftOnPageSelected
 
   useEffect(() => {
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     setBulkSimFailedIds(new Set())
   }, [page, statusFilter])
 
@@ -174,29 +174,26 @@ export function useOrdersPage() {
   }
 
   const handleToggleSelect = (orderId: number) => {
-    setSelectedOrderIds((prev) => {
-      const next = new Set(prev)
-      next.has(orderId) ? next.delete(orderId) : next.add(orderId)
-      return next
-    })
+    setSelectedOrderIds((prev) =>
+      prev.includes(orderId) ? prev.filter((id) => id !== orderId) : [...prev, orderId]
+    )
   }
 
   const handleToggleSelectAll = () => {
     setSelectedOrderIds((prev) => {
-      const next = new Set(prev)
       if (allDraftOnPageSelected) {
-        draftPageOrders.forEach((o) => next.delete(o.id))
+        return prev.filter((id) => !draftPageOrders.some((o) => o.id === id))
       } else {
-        draftPageOrders.forEach((o) => next.add(o.id))
+        const newIds = draftPageOrders.map((o) => o.id).filter((id) => !prev.includes(id))
+        return [...prev, ...newIds]
       }
-      return next
     })
   }
 
-  const handleClearSelection = () => setSelectedOrderIds(new Set())
+  const handleClearSelection = () => setSelectedOrderIds([])
 
   const handleBulkSimulate = async () => {
-    const ids = Array.from(selectedOrderIds)
+    const ids = selectedOrderIds
     setIsBulkSimulating(true)
     setBulkSimFailedIds(new Set())
     const results: BulkSimulateResult[] = []
@@ -215,7 +212,7 @@ export function useOrdersPage() {
       results.filter((r) => r.result === null || !r.result.is_feasible).map((r) => r.orderId)
     )
     setBulkSimFailedIds(failedIds)
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     setIsBulkSimulating(false)
     setBulkSimSummary(results)
   }
@@ -223,7 +220,7 @@ export function useOrdersPage() {
   const handleCloseBulkSimSummary = () => setBulkSimSummary(null)
 
   const handleBulkConfirm = async () => {
-    const ids = Array.from(selectedOrderIds)
+    const ids = selectedOrderIds
     const scheduledIds = ids.filter((id) => orders?.find((o) => o.id === id)?.is_scheduled)
     const skippedCount = ids.length - scheduledIds.length
     setIsBulkConfirming(true)
@@ -237,7 +234,7 @@ export function useOrdersPage() {
       }
     }
     setIsBulkConfirming(false)
-    setSelectedOrderIds(new Set())
+    setSelectedOrderIds([])
     const parts = (
       [
         successCount > 0 ? `成功 ${successCount}件` : null,

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -42,6 +42,7 @@ export function useOrdersPage() {
   const [selectedOrderIds, setSelectedOrderIds] = useState<number[]>([])
   const [isBulkSimulating, setIsBulkSimulating] = useState(false)
   const [isBulkConfirming, setIsBulkConfirming] = useState(false)
+  const [isBulkSimulateConfirmOpen, setIsBulkSimulateConfirmOpen] = useState(false)
   const [bulkSimSummary, setBulkSimSummary] = useState<BulkSimulateResult[] | null>(null)
   const [bulkSimFailedIds, setBulkSimFailedIds] = useState<Set<number>>(new Set())
 
@@ -192,7 +193,12 @@ export function useOrdersPage() {
 
   const handleClearSelection = () => setSelectedOrderIds([])
 
-  const handleBulkSimulate = async () => {
+  const handleBulkSimulateRequest = () => setIsBulkSimulateConfirmOpen(true)
+
+  const handleBulkSimulateCancel = () => setIsBulkSimulateConfirmOpen(false)
+
+  const handleBulkSimulateConfirm = async () => {
+    setIsBulkSimulateConfirmOpen(false)
     const ids = selectedOrderIds
     setIsBulkSimulating(true)
     setBulkSimFailedIds(new Set())
@@ -298,10 +304,13 @@ export function useOrdersPage() {
     someDraftOnPageSelected,
     isBulkSimulating,
     isBulkConfirming,
+    isBulkSimulateConfirmOpen,
     handleToggleSelect,
     handleToggleSelectAll,
     handleClearSelection,
-    handleBulkSimulate,
+    handleBulkSimulateRequest,
+    handleBulkSimulateConfirm,
+    handleBulkSimulateCancel,
     handleBulkConfirm,
     bulkSimSummary,
     bulkSimFailedIds,


### PR DESCRIPTION
## Summary

- `bulk-simulate-confirm-dialog.tsx` を新規作成（番号・注文番号・品名・希望納期を一覧表示）
- 「一括シミュレーション」ボタン押下時に即実行せず確認モーダルを開くよう変更
- `handleBulkSimulate` を `handleBulkSimulateRequest`（モーダルを開く）と `handleBulkSimulateConfirm`（実際の逐次実行）に分割

> **Note**: このPRは #148 (#143) の変更を含みます。#143 がマージされてからベースブランチを `main` に変更してください。

## Test plan

- [ ] 「一括シミュレーション」ボタン押下で確認モーダルが開く（即実行しない）
- [ ] モーダルに番号・注文番号・品名・希望納期が一覧表示される
- [ ] 表示順が #143 のチェック番号順と一致している
- [ ] 「実行」押下で既存の逐次シミュレーションが開始される
- [ ] 「キャンセル」で選択状態を保ったままモーダルが閉じる

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)