### PR TITLE
feat: 一括シミュレーション結果モーダルにページネーション・NGフィルタ追加、選択件数警告を実装 (#145, #146)

### DIFF
--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -74,6 +74,7 @@ export default function OrdersPage() {
     bulkSimSummary,
     bulkSimFailedIds,
     handleCloseBulkSimSummary,
+    handleBulkConfirmFromSummary,
   } = useOrdersPage()
 
   const expandedOrder = orders?.find((o) => o.id === expandedOrderId) ?? null
@@ -234,6 +235,7 @@ export default function OrdersPage() {
         <BulkSimulateSummaryDialog
           results={bulkSimSummary}
           onClose={handleCloseBulkSimSummary}
+          onBulkConfirm={handleBulkConfirmFromSummary}
         />
       </div>
     </TooltipProvider>

--- a/frontend/src/components/orders/bulk-action-bar.tsx
+++ b/frontend/src/components/orders/bulk-action-bar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Loader2, X } from "lucide-react"
+import { AlertTriangle, Loader2, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Tooltip,
@@ -31,12 +31,19 @@ export function BulkActionBar({
 
   const isBusy = isBulkSimulating || isBulkConfirming
   const canConfirm = selectedScheduledCount > 0
+  const BULK_SIMULATE_WARN_THRESHOLD = 20
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 rounded-xl border bg-card px-4 py-3 shadow-lg">
       <span className="text-sm font-medium text-muted-foreground">
         {selectedCount}件選択中
       </span>
+      {selectedCount > BULK_SIMULATE_WARN_THRESHOLD && (
+        <span className="flex items-center gap-1 text-xs text-yellow-600">
+          <AlertTriangle className="h-3 w-3" />
+          結果確認に時間がかかる場合があります
+        </span>
+      )}
       <div className="h-4 w-px bg-border" />
       <Button size="sm" variant="outline" onClick={onBulkSimulate} disabled={isBusy}>
         {isBulkSimulating ? (

--- a/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
+++ b/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import { useState } from "react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -13,27 +15,50 @@ import {
 } from "@/components/ui/dialog"
 import type { BulkSimulateResult } from "@/types/order"
 
+const PAGE_SIZE = 5
+
 interface BulkSimulateSummaryDialogProps {
   results: BulkSimulateResult[] | null
   onClose: () => void
+  onBulkConfirm?: (orderIds: number[]) => void
 }
 
 function formatDate(iso: string) {
   return format(new Date(iso), "yyyy/MM/dd HH:mm", { locale: ja })
 }
 
-export function BulkSimulateSummaryDialog({ results, onClose }: BulkSimulateSummaryDialogProps) {
+export function BulkSimulateSummaryDialog({ results, onClose, onBulkConfirm }: BulkSimulateSummaryDialogProps) {
+  const [currentPage, setCurrentPage] = useState(1)
+  const [showNgOnly, setShowNgOnly] = useState(false)
+
   if (!results) return null
 
   const okCount = results.filter((r) => r.result !== null && r.result.is_feasible).length
   const infeasibleCount = results.filter((r) => r.result !== null && !r.result.is_feasible).length
   const failedCount = results.filter((r) => r.result === null).length
 
+  const filteredResults = showNgOnly
+    ? results.filter((r) => !r.result?.is_feasible)
+    : results
+  const totalPages = Math.max(1, Math.ceil(filteredResults.length / PAGE_SIZE))
+  const pagedResults = filteredResults.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+
+  const currentPageOkIds = pagedResults
+    .filter((r) => r.result !== null && r.result.is_feasible)
+    .map((r) => r.orderId)
+
+  const handleNgOnlyChange = (checked: boolean) => {
+    setShowNgOnly(checked)
+    setCurrentPage(1)
+  }
+
   return (
     <Dialog open={results !== null} onOpenChange={(open) => { if (!open) onClose() }}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>一括シミュレーション結果</DialogTitle>
+          <DialogTitle>
+            一括シミュレーション結果（{results.length}件）　{currentPage}/{totalPages}ページ
+          </DialogTitle>
           <p className="flex items-center gap-2 text-sm text-muted-foreground mt-1 flex-wrap">
             <span className="flex items-center gap-1">
               <CheckCircle2 className="h-4 w-4 text-green-500" />
@@ -52,8 +77,8 @@ export function BulkSimulateSummaryDialog({ results, onClose }: BulkSimulateSumm
           </p>
         </DialogHeader>
 
-        <div className="max-h-80 overflow-y-auto space-y-1 py-2">
-          {results.map((r) => {
+        <div className="space-y-1 py-2">
+          {pagedResults.map((r) => {
             const isFailed = r.result === null
             const isInfeasible = r.result !== null && !r.result.is_feasible
             const rowClass = isFailed
@@ -101,8 +126,43 @@ export function BulkSimulateSummaryDialog({ results, onClose }: BulkSimulateSumm
           })}
         </div>
 
-        <DialogFooter>
-          <Button onClick={onClose}>閉じる</Button>
+        <DialogFooter className="flex-col gap-2 sm:flex-col">
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="ng-only"
+              checked={showNgOnly}
+              onCheckedChange={(v) => handleNgOnlyChange(!!v)}
+            />
+            <label htmlFor="ng-only" className="text-sm cursor-pointer">NGのみ表示</label>
+          </div>
+          <div className="flex items-center gap-2 ml-auto flex-wrap">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => p - 1)}
+              disabled={currentPage <= 1}
+            >
+              ← 前へ
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => p + 1)}
+              disabled={currentPage >= totalPages}
+            >
+              次へ →
+            </Button>
+            {onBulkConfirm && (
+              <Button
+                size="sm"
+                onClick={() => onBulkConfirm(currentPageOkIds)}
+                disabled={currentPageOkIds.length === 0}
+              >
+                OK分だけ一括確定
+              </Button>
+            )}
+            <Button onClick={onClose}>閉じる</Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -226,6 +226,34 @@ export function useOrdersPage() {
 
   const handleCloseBulkSimSummary = () => setBulkSimSummary(null)
 
+  const handleBulkConfirmFromSummary = async (orderIds: number[]) => {
+    setIsBulkConfirming(true)
+    let successCount = 0, failCount = 0
+    for (const id of orderIds) {
+      try {
+        await confirmOrder.mutateAsync(id)
+        successCount++
+      } catch {
+        failCount++
+      }
+    }
+    await queryClient.invalidateQueries({ queryKey: ["orders"] })
+    setIsBulkConfirming(false)
+    const parts = (
+      [
+        successCount > 0 ? `成功 ${successCount}件` : null,
+        failCount > 0 ? `失敗 ${failCount}件` : null,
+      ] as (string | null)[]
+    ).filter((p): p is string => p !== null).join(" / ")
+    if (failCount === 0) {
+      toast.success(`一括確定完了: ${parts}`)
+    } else if (successCount === 0) {
+      toast.error(`一括確定失敗: ${parts}`)
+    } else {
+      toast.warning(`一括確定完了: ${parts}`)
+    }
+  }
+
   const handleBulkConfirm = async () => {
     const ids = selectedOrderIds
     const scheduledIds = ids.filter((id) => orders?.find((o) => o.id === id)?.is_scheduled)
@@ -316,5 +344,6 @@ export function useOrdersPage() {
     bulkSimSummary,
     bulkSimFailedIds,
     handleCloseBulkSimSummary,
+    handleBulkConfirmFromSummary,
   }
 }


### PR DESCRIPTION
## Summary

- **#145**: 結果モーダルを全件スクロールから5件/ページのページネーション表示に変更
- **#145**: 「NGのみ表示」チェックボックスでNG・失敗件のみに絞り込み（切替時に1ページ目へリセット）
- **#145**: 「OK分だけ一括確定」ボタンで現在ページのOK件のみを確定（OK件なしはdisabled）
- **#146**: 選択件数が20件超のときフローティングツールバーに警告テキストを表示

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `frontend/src/components/orders/bulk-simulate-summary-dialog.tsx` | ページネーション・NGフィルタ・OK一括確定ボタン追加 |
| `frontend/src/components/orders/bulk-action-bar.tsx` | 件数警告メッセージ追加（20件超） |
| `frontend/src/hooks/use-orders-page.ts` | `handleBulkConfirmFromSummary` ハンドラ追加 |
| `frontend/src/app/orders/page.tsx` | `onBulkConfirm` props を渡す |

## Test plan

- [ ] draft 注文を複数選択し一括シミュレーション実行 → 結果モーダルが5件/ページで表示される
- [ ] ヘッダーに「N件 M/Lページ」が表示される
- [ ] 前へ/次へボタンでページ移動できる
- [ ] 「NGのみ表示」チェックでNG・失敗件のみに絞り込める（ページが1に戻る）
- [ ] 「OK分だけ一括確定」が現在ページのOK件のみを対象に確定する
- [ ] OK件がないページでは「OK分だけ一括確定」が disabled になる
- [ ] 21件以上選択するとツールバーに警告メッセージが表示される
- [ ] 20件以下に戻ると警告が消える

Closes #145
Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)