### PR TITLE
fix: 注文詳細ページを実装し注文クリック時の404エラーを修正 (#153)

### DIFF
--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -1,0 +1,231 @@
+"use client"
+
+import { useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import {
+  ArrowLeft,
+  Calculator,
+  Check,
+  Pencil,
+  Trash2,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { SimulationResult } from "@/components/simulation-result"
+import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
+import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
+import {
+  useOrder,
+  useSimulateOrderById,
+  useConfirmOrder,
+  useDeleteOrder,
+} from "@/hooks/use-orders"
+import { useProducts } from "@/hooks/use-products"
+import { useCustomers } from "@/hooks/use-customers"
+import {
+  getProductName,
+  getCustomerName,
+  getStatusLabel,
+  getStatusBadgeClass,
+} from "@/lib/order-utils"
+import type { OrderSimulateResponse } from "@/types/order"
+
+export default function OrderDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const orderId = Number(params.id)
+
+  const { data: order, isLoading, isError } = useOrder(orderId)
+  const { data: products } = useProducts()
+  const { data: customers } = useCustomers()
+
+  const simulateMutation = useSimulateOrderById()
+  const confirmMutation = useConfirmOrder()
+  const deleteMutation = useDeleteOrder()
+
+  const [simulationResult, setSimulationResult] = useState<OrderSimulateResponse | null>(null)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+
+  const handleSimulate = async () => {
+    try {
+      const result = await simulateMutation.mutateAsync(orderId)
+      setSimulationResult(result)
+      toast.success("シミュレーションが完了しました")
+    } catch {
+      toast.error("シミュレーションに失敗しました")
+    }
+  }
+
+  const handleConfirm = async () => {
+    try {
+      await confirmMutation.mutateAsync(orderId)
+      toast.success("注文を確定しました")
+      router.push("/orders")
+    } catch {
+      toast.error("注文の確定に失敗しました")
+    }
+  }
+
+  const handleDelete = async () => {
+    try {
+      await deleteMutation.mutateAsync(orderId)
+      toast.success("注文を削除しました")
+      router.push("/orders")
+    } catch {
+      toast.error("注文の削除に失敗しました")
+    }
+  }
+
+  const formatDate = (dateStr?: string | null) => {
+    if (!dateStr) return <span className="text-muted-foreground">未設定</span>
+    return format(new Date(dateStr), "yyyy/MM/dd HH:mm", { locale: ja })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto py-6 px-4">
+        <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
+      </div>
+    )
+  }
+
+  if (isError || !order) {
+    return (
+      <div className="container mx-auto py-6 px-4">
+        <div className="p-8 text-center text-muted-foreground">
+          注文が見つかりませんでした
+        </div>
+      </div>
+    )
+  }
+
+  const isDraft = order.status === "draft"
+  const canDelete = order.status === "draft" || order.status === "canceled"
+
+  return (
+    <div className="container mx-auto py-6 px-4">
+      <div className="mb-6 flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push("/orders")}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          注文一覧へ
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">{order.order_no}</h1>
+          <p className="text-muted-foreground mt-1">注文詳細</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* 左: 注文基本情報 */}
+        <div className="space-y-6">
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-4">注文基本情報</h2>
+            <dl className="space-y-3 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">注文番号</dt>
+                <dd className="font-medium">{order.order_no}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">製品</dt>
+                <dd>{getProductName(order.product_id, products)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">顧客</dt>
+                <dd>{order.customer_id ? getCustomerName(order.customer_id, customers) : <span className="text-muted-foreground">未設定</span>}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">数量</dt>
+                <dd>{order.quantity}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">希望納期</dt>
+                <dd>{formatDate(order.desired_deadline)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">確定納期</dt>
+                <dd>{formatDate(order.confirmed_deadline)}</dd>
+              </div>
+              <div className="flex justify-between items-center">
+                <dt className="text-muted-foreground">ステータス</dt>
+                <dd>
+                  <Badge className={getStatusBadgeClass(order.status)}>
+                    {getStatusLabel(order.status)}
+                  </Badge>
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          {/* アクションボタン */}
+          <div className="flex flex-wrap gap-3">
+            {isDraft && (
+              <Button
+                onClick={handleSimulate}
+                disabled={simulateMutation.isPending}
+                className="flex-1"
+              >
+                <Calculator className="mr-2 h-4 w-4" />
+                {simulateMutation.isPending ? "計算中..." : "シミュレーション実行"}
+              </Button>
+            )}
+            {isDraft && order.is_scheduled && (
+              <Button
+                onClick={handleConfirm}
+                disabled={confirmMutation.isPending}
+                variant="default"
+                className="flex-1"
+              >
+                <Check className="mr-2 h-4 w-4" />
+                {confirmMutation.isPending ? "処理中..." : "注文確定"}
+              </Button>
+            )}
+            {isDraft && (
+              <Button
+                variant="outline"
+                onClick={() => setIsEditDialogOpen(true)}
+              >
+                <Pencil className="mr-2 h-4 w-4" />
+                編集
+              </Button>
+            )}
+            {canDelete && (
+              <Button
+                variant="destructive"
+                onClick={() => setIsDeleteDialogOpen(true)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                削除
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* 右: シミュレーション結果 */}
+        <div className="rounded-lg border bg-card p-6 shadow-sm min-h-[400px]">
+          <h2 className="text-xl font-semibold mb-4">シミュレーション結果</h2>
+          <SimulationResult
+            result={simulationResult}
+            desiredDeadline={order.desired_deadline}
+          />
+        </div>
+      </div>
+
+      <EditOrderDialog
+        order={order}
+        open={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+      />
+
+      <DeleteOrderDialog
+        order={isDeleteDialogOpen ? order : null}
+        isPending={deleteMutation.isPending}
+        onConfirm={handleDelete}
+        onOpenChange={(open) => { if (!open) setIsDeleteDialogOpen(false) }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -74,7 +74,7 @@ export default function OrderDetailPage() {
     try {
       await deleteMutation.mutateAsync(orderId)
       toast.success("注文を削除しました")
-      router.push("/orders")
+      router.back()
     } catch {
       toast.error("注文の削除に失敗しました")
     }
@@ -109,9 +109,9 @@ export default function OrderDetailPage() {
   return (
     <div className="container mx-auto py-6 px-4">
       <div className="mb-6 flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => router.push("/orders")}>
+        <Button variant="ghost" size="sm" onClick={() => router.back()}>
           <ArrowLeft className="mr-2 h-4 w-4" />
-          注文一覧へ
+          戻る
         </Button>
         <div>
           <h1 className="text-3xl font-bold">{order.order_no}</h1>

--- a/frontend/src/hooks/use-orders.ts
+++ b/frontend/src/hooks/use-orders.ts
@@ -109,6 +109,17 @@ export function useDeleteOrder() {
 }
 
 /**
+ * 注文を1件取得するフック
+ */
+export function useOrder(orderId: number) {
+  return useQuery<Order>({
+    queryKey: ["orders", orderId],
+    queryFn: () => apiClient<Order>(`/orders/${orderId}`),
+    enabled: !!orderId,
+  })
+}
+
+/**
  * 既存の注文IDでシミュレーションを実行するフック
  */
 export function useSimulateOrderById() {


### PR DESCRIPTION
## Summary
- `frontend/src/hooks/use-orders.ts` に `useOrder(orderId)` フックを追加 (`GET /orders/{id}`)
- `frontend/src/app/orders/[id]/page.tsx` を新規作成し、注文詳細ページを実装
- ホーム画面・注文一覧から注文をクリックした際の 404 エラーを解消

## 変更内容
### `frontend/src/hooks/use-orders.ts`
- `useOrder(orderId: number)` を追加

### `frontend/src/app/orders/[id]/page.tsx`（新規）
- 注文基本情報カード（注文番号・製品・顧客・数量・希望納期・確定納期・ステータス）
- アクションボタン（status に応じて表示制御）
  - シミュレーション実行: `status === 'draft'`
  - 注文確定: `status === 'draft' && is_scheduled === true`
  - 編集: `status === 'draft'`
  - 削除: `status === 'draft'` または `'canceled'`
- シミュレーション結果を右カラムに表示（`SimulationResult` コンポーネントを再利用）

## Test plan
- [ ] ホーム画面の「最新の注文」から任意の注文をクリック → `/orders/{id}` に遷移し 404 が発生しないこと
- [ ] 注文基本情報（注文番号・製品・数量・ステータス）が正しく表示されること
- [ ] draft 注文でシミュレーションボタンを押すと結果が右カラムに表示されること
- [ ] `is_scheduled=true` の draft 注文で「注文確定」ボタンが表示されること
- [ ] 削除後に `/orders` へリダイレクトされること

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)