### PR TITLE
feat: シミュレーション結果の工程表示を集約し確認欄を上部へ移動

### DIFF
--- a/backend/__tests__/unit/services/test_simulation_service.py
+++ b/backend/__tests__/unit/services/test_simulation_service.py
@@ -137,6 +137,119 @@ class TestSimulationService:
                 [], "2024-12-31T17:00:00", mock_product_repo, mock_equipment_repo
             )
 
+    def test_build_process_schedules_merges_consecutive_same_routing(self):
+        """同一 process_routing_id の連続セグメントが1エントリに集約される"""
+        mock_product_repo = MagicMock()
+        mock_equipment_repo = MagicMock()
+        mock_product_repo.get_process_name.return_value = "内職"
+        mock_equipment_repo.get_equipment_name.return_value = "Machine A"
+
+        schedules = [
+            {
+                "process_routing_id": 5,
+                "equipment_id": 10,
+                "start_datetime": "2024-06-17T13:05:00",
+                "end_datetime": "2024-06-17T17:00:00",
+            },
+            {
+                "process_routing_id": 5,
+                "equipment_id": 10,
+                "start_datetime": "2024-06-18T09:00:00",
+                "end_datetime": "2024-06-18T17:00:00",
+            },
+            {
+                "process_routing_id": 5,
+                "equipment_id": 10,
+                "start_datetime": "2024-07-09T09:00:00",
+                "end_datetime": "2024-07-09T11:12:00",
+            },
+        ]
+
+        result = build_process_schedules(
+            schedules, mock_product_repo, mock_equipment_repo
+        )
+
+        assert len(result) == 1
+        assert result[0]["process_name"] == "内職"
+        assert result[0]["start_time"] == "2024-06-17T13:05:00"
+        assert result[0]["end_time"] == "2024-07-09T11:12:00"
+
+    def test_build_process_schedules_separate_different_routing(self):
+        """異なる process_routing_id のセグメントは別エントリになる"""
+        mock_product_repo = MagicMock()
+        mock_equipment_repo = MagicMock()
+        mock_product_repo.get_process_name.side_effect = lambda rid: {
+            1: "組立",
+            2: "検査",
+        }[rid]
+        mock_equipment_repo.get_equipment_name.return_value = None
+
+        schedules = [
+            {
+                "process_routing_id": 1,
+                "equipment_id": None,
+                "start_datetime": "2024-12-01T09:00:00",
+                "end_datetime": "2024-12-01T12:00:00",
+            },
+            {
+                "process_routing_id": 2,
+                "equipment_id": None,
+                "start_datetime": "2024-12-01T12:00:00",
+                "end_datetime": "2024-12-01T15:00:00",
+            },
+        ]
+
+        result = build_process_schedules(
+            schedules, mock_product_repo, mock_equipment_repo
+        )
+
+        assert len(result) == 2
+        assert result[0]["process_name"] == "組立"
+        assert result[1]["process_name"] == "検査"
+
+    def test_build_process_schedules_lookup_called_once_per_group(self):
+        """get_process_name はグループ数（工程数）だけ呼ばれる（セグメント数ではない）"""
+        mock_product_repo = MagicMock()
+        mock_equipment_repo = MagicMock()
+        mock_product_repo.get_process_name.return_value = "内職"
+        mock_equipment_repo.get_equipment_name.return_value = None
+
+        schedules = [
+            {
+                "process_routing_id": 5,
+                "equipment_id": None,
+                "start_datetime": f"2024-06-{17 + i:02d}T09:00:00",
+                "end_datetime": f"2024-06-{17 + i:02d}T17:00:00",
+            }
+            for i in range(5)  # 5セグメント、全て同じ routing_id
+        ]
+
+        build_process_schedules(schedules, mock_product_repo, mock_equipment_repo)
+
+        # lookup は1回のみ
+        mock_product_repo.get_process_name.assert_called_once_with(5)
+
+    def test_build_process_schedules_no_routing_id_in_merged_output(self):
+        """出力に内部キー _routing_id が含まれないこと"""
+        mock_product_repo = MagicMock()
+        mock_equipment_repo = MagicMock()
+        mock_product_repo.get_process_name.return_value = "組立"
+
+        schedules = [
+            {
+                "process_routing_id": 1,
+                "equipment_id": None,
+                "start_datetime": "2024-12-01T09:00:00",
+                "end_datetime": "2024-12-01T12:00:00",
+            }
+        ]
+
+        result = build_process_schedules(
+            schedules, mock_product_repo, mock_equipment_repo
+        )
+
+        assert "_routing_id" not in result[0]
+
     def test_build_simulate_response_exceeds_deadline(self):
         """計算納期が希望納期を超える場合"""
         mock_product_repo = MagicMock()

--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -92,31 +92,38 @@ def build_process_schedules(
     """
     スケジュール情報からプロセススケジュールを構築する。
 
+    同一 process_routing_id の連続セグメントを1エントリに集約する。
+    （スケジューラが日跨ぎで分割したセグメントを工程単位に統合）
+
     Args:
         schedules: スケジュール情報のリスト
         product_repo: 製品リポジトリ
         equipment_repo: 設備リポジトリ
 
     Returns:
-        プロセススケジュールのリスト
+        工程単位に集約されたプロセススケジュールのリスト
     """
-    process_schedules = []
+    merged: list[dict] = []
     for schedule in schedules:
         routing_id = schedule.get("process_routing_id")
+
+        # 直前と同じ工程なら終了時刻だけ更新（日跨ぎセグメントのマージ）
+        if merged and merged[-1]["_routing_id"] == routing_id:
+            merged[-1]["end_time"] = schedule["end_datetime"]
+            continue
+
+        # 新しい工程グループの開始
+        process_name = (
+            product_repo.get_process_name(routing_id) if routing_id else "不明"
+        )
         equipment_id = schedule.get("equipment_id")
+        equipment_name = (
+            equipment_repo.get_equipment_name(equipment_id) if equipment_id else None
+        )
 
-        # 工程名を取得
-        process_name = "不明"
-        if routing_id:
-            process_name = product_repo.get_process_name(routing_id)
-
-        # 設備名を取得
-        equipment_name = None
-        if equipment_id:
-            equipment_name = equipment_repo.get_equipment_name(equipment_id)
-
-        process_schedules.append(
+        merged.append(
             {
+                "_routing_id": routing_id,
                 "process_name": process_name,
                 "start_time": schedule["start_datetime"],
                 "end_time": schedule["end_datetime"],
@@ -124,4 +131,7 @@ def build_process_schedules(
             }
         )
 
-    return process_schedules
+    for entry in merged:
+        entry.pop("_routing_id", None)
+
+    return merged

--- a/frontend/src/app/orders/new/page.tsx
+++ b/frontend/src/app/orders/new/page.tsx
@@ -270,55 +270,53 @@ export default function NewOrderPage() {
           <SimulationResult
             result={simulationResult}
             desiredDeadline={desiredDeadline}
-          />
-
-          {/* 確定前サマリー */}
-          {simulationResult && (
-            <div className="mt-4 rounded-lg border p-4 space-y-3 text-sm">
-              <p className="font-semibold">注文内容の確認</p>
-              <dl className="space-y-1.5">
-                <div className="flex justify-between">
-                  <dt className="text-muted-foreground">注文番号</dt>
-                  <dd>{orderNo || <span className="text-muted-foreground">未設定</span>}</dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-muted-foreground">製品</dt>
-                  <dd>{productId ? getProductName(parseInt(productId), products) : "-"}</dd>
-                </div>
-                {customerId && (
+            summaryContent={simulationResult && (
+              <div className="rounded-lg border p-4 space-y-3 text-sm">
+                <p className="font-semibold">注文内容の確認</p>
+                <dl className="space-y-1.5">
                   <div className="flex justify-between">
-                    <dt className="text-muted-foreground">顧客</dt>
-                    <dd>{getCustomerName(parseInt(customerId), customers)}</dd>
+                    <dt className="text-muted-foreground">注文番号</dt>
+                    <dd>{orderNo || <span className="text-muted-foreground">未設定</span>}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">製品</dt>
+                    <dd>{productId ? getProductName(parseInt(productId), products) : "-"}</dd>
+                  </div>
+                  {customerId && (
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">顧客</dt>
+                      <dd>{getCustomerName(parseInt(customerId), customers)}</dd>
+                    </div>
+                  )}
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">数量</dt>
+                    <dd>{quantity || "-"}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">希望納期</dt>
+                    <dd>
+                      {desiredDeadline
+                        ? format(new Date(desiredDeadline), "yyyy/MM/dd HH:mm", { locale: ja })
+                        : <span className="text-muted-foreground">未設定</span>}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-muted-foreground">確定納期</dt>
+                    <dd className={!simulationResult.is_feasible ? "text-red-600 font-medium" : ""}>
+                      {format(new Date(simulationResult.calculated_deadline), "yyyy/MM/dd HH:mm", { locale: ja })}
+                    </dd>
+                  </div>
+                </dl>
+
+                {(!desiredDeadline || !customerId) && (
+                  <div className="flex items-start gap-1.5 text-yellow-700 pt-1 border-t">
+                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <p>このまま確定してよいですか？</p>
                   </div>
                 )}
-                <div className="flex justify-between">
-                  <dt className="text-muted-foreground">数量</dt>
-                  <dd>{quantity || "-"}</dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-muted-foreground">希望納期</dt>
-                  <dd>
-                    {desiredDeadline
-                      ? format(new Date(desiredDeadline), "yyyy/MM/dd HH:mm", { locale: ja })
-                      : <span className="text-muted-foreground">未設定</span>}
-                  </dd>
-                </div>
-                <div className="flex justify-between">
-                  <dt className="text-muted-foreground">確定納期</dt>
-                  <dd className={!simulationResult.is_feasible ? "text-red-600 font-medium" : ""}>
-                    {format(new Date(simulationResult.calculated_deadline), "yyyy/MM/dd HH:mm", { locale: ja })}
-                  </dd>
-                </div>
-              </dl>
-
-              {(!desiredDeadline || !customerId) && (
-                <div className="flex items-start gap-1.5 text-yellow-700 pt-1 border-t">
-                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                  <p>このまま確定してよいですか？</p>
-                </div>
-              )}
-            </div>
-          )}
+              </div>
+            )}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/simulation-result.tsx
+++ b/frontend/src/components/simulation-result.tsx
@@ -9,6 +9,7 @@ import type { OrderSimulateResponse } from "@/types/order"
 interface SimulationResultProps {
   result: OrderSimulateResponse | null
   desiredDeadline?: string
+  summaryContent?: React.ReactNode
 }
 
 /**
@@ -17,6 +18,7 @@ interface SimulationResultProps {
 export function SimulationResult({
   result,
   desiredDeadline,
+  summaryContent,
 }: SimulationResultProps) {
   if (!result) {
     return (
@@ -70,6 +72,8 @@ export function SimulationResult({
           </p>
         )}
       </div>
+
+      {summaryContent}
 
       {/* 工程プレビュー */}
       <div className="rounded-lg border bg-card p-6 shadow-sm">


### PR DESCRIPTION
## Summary

- **工程スケジュールの集約表示**: スケジューラが日跨ぎで分割した生セグメントをそのまま列挙していたため、31件表示になる問題を修正。`build_process_schedules()` で同一 `process_routing_id` の連続セグメントを1エントリにマージし、工程数（5〜6行）に集約
- **レイアウト変更**: 「注文内容の確認」を工程スケジュールより上に移動し、スクロール不要で確認できるよう変更（表示順: 回答納期 → 注文内容の確認 → 工程スケジュール）

Closes #157

## Changes

### Backend
- `backend/app/services/simulation_service.py`: `build_process_schedules()` をセグメントマージ対応に変更
- `backend/__tests__/unit/services/test_simulation_service.py`: マージ動作を検証するテスト4件を追加

### Frontend
- `frontend/src/components/simulation-result.tsx`: `summaryContent?: React.ReactNode` プロップを追加し、回答納期と工程リストの間に任意コンテンツを挿入可能に
- `frontend/src/app/orders/new/page.tsx`: 注文確認サマリーを `summaryContent` として渡すよう変更

## Test plan

- [ ] `pytest __tests__/unit/ -v` — simulation_service の新規テスト4件を含む全件パス
- [ ] `pytest __tests__/api/ -v` — 66件全件パス
- [ ] 製品・数量を入力してシミュレーション実行 → 工程スケジュールが工程数に集約されて表示される（31行 → 5〜6行）
- [ ] 「注文内容の確認」が工程スケジュールより上に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)