### PR TITLE
fix: order_no が null の場合のビルドエラーを修正

### DIFF
--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -156,7 +156,7 @@ export function OrderTableRow({
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => onConfirm(order.id, order.order_no)}
+                onClick={() => onConfirm(order.id, order.order_no ?? "")}
                 disabled={confirmIsPending || isBulkOperationInProgress}
               >
                 確定


### PR DESCRIPTION
## Summary

- `order-table-row.tsx` の `onConfirm` 呼び出しで `order.order_no`（`string | null`）を `string` 型の引数に渡していたためビルドエラーが発生していた
- `order.order_no ?? ""` を使用し、`null` の場合は空文字列にフォールバックするよう修正

## Test plan

- [ ] `npm run build` がエラーなく完了することを確認
- [ ] 注文確定ボタンの動作が従来通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)