### PR TITLE
feat: GCP プロジェクト基盤 & Terraform 初期構成 (#169)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ __queuestorage__
 __azurite_db*__.json
 .python_packages
 AzuriteConfig
+
+# Terraform
+infra/terraform/.terraform/
+infra/terraform/*.tfstate
+infra/terraform/*.tfstate.backup
+infra/terraform/environments/**/*.tfvars

--- a/docs/infra/gcp-terraform-foundation.md
+++ b/docs/infra/gcp-terraform-foundation.md
@@ -1,0 +1,90 @@
+# GCP プロジェクト基盤 & Terraform 初期構成
+
+Issue: #169
+
+## 目的
+
+Gmail OAuth 認証・Secret Manager を Terraform で管理するための GCP インフラ基盤を構築する。
+
+---
+
+## 作業ステップ
+
+### Step 1: GCP プロジェクト作成（手作業）
+
+```bash
+gcloud projects create productplanner-prod --name="Product Planner Prod"
+gcloud config set project productplanner-prod
+```
+
+- プロジェクト ID: `productplanner-prod`
+- プロジェクト番号: `terraform.tfvars` に記載（gitignore 対象）
+
+---
+
+### Step 1.5: 請求先アカウントのリンク（手作業・GCS バケット作成前に必須）
+
+GCS バケット作成には請求先アカウントのリンクが必要。
+
+**GCP コンソールで実施:**
+
+1. [GCP コンソール → 請求](https://console.cloud.google.com/billing) を開く
+2. 「請求先アカウントを管理」→「マイプロジェクトへのリンク」
+3. `productplanner-prod` を選択して請求先アカウントをリンク
+
+**または `gcloud` CLI で実施:**
+
+```bash
+# 請求先アカウント ID を確認
+gcloud billing accounts list
+
+# プロジェクトにリンク（BILLING_ACCOUNT_ID は上記コマンドで取得した値）
+gcloud billing projects link productplanner-prod \
+  --billing-account=BILLING_ACCOUNT_ID
+```
+
+リンク後、再度 Step 2 に進む。
+
+---
+
+### Step 2: GCS バケット作成（手作業・Terraform 管理外）
+
+Terraform state 格納用バケット。bootstrap 問題を避けるため手作業で作成する。
+
+```bash
+gsutil mb -l asia-northeast1 gs://productplanner-prod-tfstate
+gsutil versioning set on gs://productplanner-prod-tfstate
+```
+
+---
+
+### Step 3 & 4: Terraform ファイル作成・.gitignore 更新
+
+`infra/terraform/` 配下に `main.tf` / `variables.tf` / `apis.tf` と `environments/prod/` を作成。
+tfvars・state ファイルは `.gitignore` に追加済み。詳細はリポジトリを参照。
+
+---
+
+### Step 6: terraform init & apply
+
+```bash
+cd infra/terraform
+terraform init -backend-config=environments/prod/backend.tfvars
+terraform plan -var-file=environments/prod/terraform.tfvars
+terraform apply -var-file=environments/prod/terraform.tfvars
+```
+
+---
+
+## 完了条件
+
+- [x] `terraform init` が GCS バックエンドで成功する
+- [x] `terraform apply` で Gmail API・Secret Manager API が有効化される
+- [x] `terraform plan` で差分ゼロになる（冪等性確認）
+
+---
+
+## 関連
+
+- Issue #165: Gmail タイマートリガー Azure Function
+- 後続: Secret Manager Terraform リソース管理

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/apis.tf
+++ b/infra/terraform/apis.tf
@@ -1,0 +1,7 @@
+resource "google_project_service" "apis" {
+  for_each = var.apis
+
+  project            = var.project.id
+  service            = each.value.service
+  disable_on_destroy = false
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {}
+}
+
+provider "google" {
+  project = var.project.id
+  region  = var.project.region
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  type = object({
+    id     = string
+    region = string
+    number = string
+  })
+}
+
+variable "apis" {
+  type = map(object({
+    service = string
+  }))
+  default = {}
+}


### PR DESCRIPTION
## Summary

- GCS バックエンド（`productplanner-prod-tfstate`）で Terraform state を管理
- `google_project_service` で Gmail API・Secret Manager API を有効化（`disable_on_destroy = false`）
- `variables.tf` の map-of-objects パターンでプロジェクト変数を定義
- `infra/terraform/environments/**/*.tfvars` と state ファイルを `.gitignore` に追加

## 手作業で実施済み（Terraform 管理外）

- GCP プロジェクト `productplanner-prod` 作成
- 請求先アカウントのリンク
- GCS バケット `productplanner-prod-tfstate` 作成（バージョニング有効）

## Test plan

- [x] `terraform init -backend-config=environments/prod/backend.tfvars` 成功
- [x] `terraform apply` で Gmail API・Secret Manager API が有効化
- [x] `terraform plan` で差分ゼロ（冪等性確認）

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)