### PR TITLE
feat: Secret Manager シークレットリソースを Terraform で管理 (#170)

### DIFF
--- a/infra/terraform/environments/prod/terraform.tfvars.example
+++ b/infra/terraform/environments/prod/terraform.tfvars.example
@@ -1,0 +1,33 @@
+project = {
+  id     = "your-gcp-project-id"
+  region = "asia-northeast1"
+  number = "your-project-number"
+}
+
+apis = {
+  gmail = {
+    service = "gmail.googleapis.com"
+  }
+  secretmanager = {
+    service = "secretmanager.googleapis.com"
+  }
+}
+
+# IAM member to grant secretAccessor role
+# e.g. "user:you@example.com" or "serviceAccount:sa@project.iam.gserviceaccount.com"
+secret_accessor_member = "user:you@example.com"
+
+secrets = {
+  client_id = {
+    secret_id   = "gmail-oauth-client-id"
+    description = "Gmail OAuth2 client ID"
+  }
+  client_secret = {
+    secret_id   = "gmail-oauth-client-secret"
+    description = "Gmail OAuth2 client secret"
+  }
+  refresh_token = {
+    secret_id   = "gmail-oauth-refresh-token"
+    description = "Gmail OAuth2 refresh token"
+  }
+}

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,0 +1,15 @@
+resource "google_secret_manager_secret" "gmail" {
+  for_each  = var.secrets
+  secret_id = each.value.secret_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "accessor" {
+  for_each  = var.secrets
+  secret_id = google_secret_manager_secret.gmail[each.key].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = var.secret_accessor_member
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -12,3 +12,16 @@ variable "apis" {
   }))
   default = {}
 }
+
+variable "secrets" {
+  type = map(object({
+    secret_id   = string
+    description = string
+  }))
+  default = {}
+}
+
+variable "secret_accessor_member" {
+  type        = string
+  description = "Secret Manager secretAccessor ロールを付与する IAM メンバー (例: serviceAccount:xxx@yyy.iam.gserviceaccount.com)"
+}


### PR DESCRIPTION
## Summary

- `google_secret_manager_secret` で Gmail OAuth2 用の 3 シークレットを定義（`gmail-oauth-client-id` / `gmail-oauth-client-secret` / `gmail-oauth-refresh-token`）
- `replication.auto {}` を使用
- `google_secret_manager_secret_iam_member` で `roles/secretmanager.secretAccessor` を `for_each` で付与
- シークレット値（バージョン）は Terraform で管理せず、state に平文保存しない設計
- `terraform.tfvars.example` を追加（セットアップ手順の参照用）

## Test plan

- [x] `terraform apply` で 3 シークレット + 3 IAM バインディング（計 6 リソース）が作成される
- [x] シークレットの値（バージョン）は Terraform state に含まれない
- [x] `terraform plan` で差分ゼロ（冪等性確認）

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)