### PR TITLE
feat: Gmail OAuth2 refresh_token 取得スクリプト作成 (#171)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ infra/terraform/.terraform/
 infra/terraform/*.tfstate
 infra/terraform/*.tfstate.backup
 infra/terraform/environments/**/*.tfvars
+
+# OAuth2 認証情報（絶対にコミットしない）
+scripts/credentials.json

--- a/docs/infra/gcp-terraform-foundation.md
+++ b/docs/infra/gcp-terraform-foundation.md
@@ -86,5 +86,6 @@ terraform apply -var-file=environments/prod/terraform.tfvars
 
 ## 関連
 
-- Issue #165: Gmail タイマートリガー Azure Function
-- 後続: Secret Manager Terraform リソース管理
+- #170: Secret Manager リソース管理（[secret-manager-terraform.md](secret-manager-terraform.md)）
+- #171: Gmail OAuth2 認証情報セットアップ（[gmail-oauth-setup.md](gmail-oauth-setup.md)）
+- #165: Gmail タイマートリガー Azure Function（後続）

--- a/docs/infra/gmail-oauth-setup.md
+++ b/docs/infra/gmail-oauth-setup.md
@@ -1,0 +1,66 @@
+# Gmail OAuth2 認証情報セットアップ
+
+Issue: #171
+
+## 概要
+
+Gmail API アクセスに必要な OAuth2 認証情報（`client_id` / `client_secret` / `refresh_token`）を取得し、Secret Manager へ投入する手順。
+
+> **前提**: #170 で Secret Manager シークレットリソースが作成済みであること。
+
+---
+
+## 手順
+
+### 1. OAuth 同意画面の設定（GCP コンソール・手作業）
+
+GCP コンソール > APIs & Services > OAuth 同意画面
+
+- User Type: **Internal**（社内利用のため。External は Google 審査が必要）
+- スコープ: `https://www.googleapis.com/auth/gmail.modify`
+
+### 2. OAuth クライアント ID の作成（GCP コンソール・手作業）
+
+GCP コンソール > APIs & Services > 認証情報 > 認証情報を作成 > OAuth クライアント ID
+
+- アプリケーションの種類: **デスクトップアプリ**
+- `credentials.json` をダウンロードし、リポジトリ外の安全な場所に保管
+
+> `credentials.json` は `.gitignore` 対象。絶対にコミットしない。
+
+### 3. refresh_token の取得（スクリプト実行）
+
+```bash
+pip install -r scripts/requirements.txt
+python scripts/get_gmail_refresh_token.py --credentials path/to/credentials.json
+```
+
+ブラウザが自動で開き、認可後に `client_id` / `client_secret` / `refresh_token` が標準出力に表示される。
+
+### 4. Secret Manager への値投入
+
+```bash
+echo -n "CLIENT_ID" | gcloud secrets versions add gmail-oauth-client-id --data-file=-
+echo -n "CLIENT_SECRET" | gcloud secrets versions add gmail-oauth-client-secret --data-file=-
+echo -n "REFRESH_TOKEN" | gcloud secrets versions add gmail-oauth-refresh-token --data-file=-
+```
+
+### 5. 確認
+
+```bash
+gcloud secrets versions access latest --secret="gmail-oauth-refresh-token"
+```
+
+---
+
+## 注意事項
+
+- refresh_token はアカウントのパスワード変更・長期未使用で無効化される場合がある
+- 無効化された場合は手順 3〜4 を再実行して再投入する
+
+## 関連
+
+- #169: GCP プロジェクト基盤
+- #170: Secret Manager Terraform リソース管理
+- #165: Gmail タイマートリガー Azure Function（本セットアップ完了後に実装）
+- `scripts/get_gmail_refresh_token.py`

--- a/docs/infra/secret-manager-terraform.md
+++ b/docs/infra/secret-manager-terraform.md
@@ -1,0 +1,40 @@
+# Secret Manager リソース管理（Terraform）
+
+Issue: #170
+
+## 概要
+
+Gmail OAuth2 認証情報を格納する Secret Manager シークレットリソースを Terraform で定義する。
+シークレットの**値投入は手作業**（`gcloud` CLI）で行い、値を Terraform state に含めない。
+
+## 管理対象シークレット
+
+| キー | Secret ID | 用途 |
+|---|---|---|
+| `client_id` | `gmail-oauth-client-id` | Gmail OAuth2 クライアント ID |
+| `client_secret` | `gmail-oauth-client-secret` | Gmail OAuth2 クライアントシークレット |
+| `refresh_token` | `gmail-oauth-refresh-token` | Gmail OAuth2 リフレッシュトークン |
+
+## 設計方針
+
+- `google_secret_manager_secret_version` は Terraform で管理しない（値を state に平文保存しないため）
+- IAM は `roles/secretmanager.secretAccessor` のみ付与（最小権限）
+- シークレット追加は `terraform.tfvars` の `secrets` map に追記するだけで対応可能
+
+## 値の投入・確認
+
+```bash
+# 投入
+echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-id --data-file=-
+echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-secret --data-file=-
+echo -n "VALUE" | gcloud secrets versions add gmail-oauth-refresh-token --data-file=-
+
+# 確認
+gcloud secrets versions access latest --secret="gmail-oauth-client-id"
+```
+
+## 関連
+
+- #169: GCP プロジェクト基盤 & Terraform 初期構成
+- #171: Gmail OAuth2 refresh_token 取得スクリプト
+- `infra/terraform/secrets.tf`

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,22 @@
+# scripts/ ディレクトリ
+
+運用・セットアップ用のユーティリティスクリプト置き場。本番コード（`backend/`）には含めない一回性・手動実行系の処理を管理する。
+
+## 依存ライブラリのインストール
+
+```bash
+pip install -r scripts/requirements.txt
+```
+
+## スクリプト一覧
+
+| ファイル | 用途 | 関連 Issue |
+|---|---|---|
+| `get_gmail_refresh_token.py` | Gmail OAuth2 の refresh_token を取得して標準出力に表示 | #171 |
+
+## スクリプトの追加ルール
+
+- 引数は `argparse` で定義し、`--help` で使い方が分かるようにする
+- 認証情報・シークレット値はファイルに書き出さず標準出力に出力する
+- 依存ライブラリは `scripts/requirements.txt` に追加する
+- このドキュメントのスクリプト一覧に追記する

--- a/scripts/get_gmail_refresh_token.py
+++ b/scripts/get_gmail_refresh_token.py
@@ -4,6 +4,7 @@ Gmail OAuth2 refresh_token 取得スクリプト
 Usage:
     python scripts/get_gmail_refresh_token.py --credentials path/to/credentials.json
 
+ブラウザが自動で開き、認可後に localhost へリダイレクトされてトークンを取得する。
 取得した値を Secret Manager へ投入:
     echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-id --data-file=-
     echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-secret --data-file=-
@@ -12,7 +13,7 @@ Usage:
 
 import argparse
 
-from google_auth_oauthlib.flow import Flow
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
@@ -26,25 +27,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    flow = Flow.from_client_secrets_file(
-        args.credentials,
-        scopes=SCOPES,
-        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
-    )
+    flow = InstalledAppFlow.from_client_secrets_file(args.credentials, scopes=SCOPES)
 
-    auth_url, _ = flow.authorization_url(
-        access_type="offline",
-        prompt="consent",
-    )
+    # port=0 でランダムポートを使用。ブラウザが自動で開く。
+    creds = flow.run_local_server(port=0, access_type="offline", prompt="consent")
 
-    print("\n以下の URL をブラウザで開き、認可してください:\n")
-    print(auth_url)
-    print()
-
-    code = input("認可後に表示されたコードを貼り付けてください: ").strip()
-    flow.fetch_token(code=code)
-
-    creds = flow.credentials
     print("\n--- Secret Manager へ投入する値 ---")
     print(f"client_id:     {creds.client_id}")
     print(f"client_secret: {creds.client_secret}")

--- a/scripts/get_gmail_refresh_token.py
+++ b/scripts/get_gmail_refresh_token.py
@@ -1,0 +1,56 @@
+"""
+Gmail OAuth2 refresh_token 取得スクリプト
+
+Usage:
+    python scripts/get_gmail_refresh_token.py --credentials path/to/credentials.json
+
+取得した値を Secret Manager へ投入:
+    echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-id --data-file=-
+    echo -n "VALUE" | gcloud secrets versions add gmail-oauth-client-secret --data-file=-
+    echo -n "VALUE" | gcloud secrets versions add gmail-oauth-refresh-token --data-file=-
+"""
+
+import argparse
+
+from google_auth_oauthlib.flow import Flow
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gmail OAuth2 refresh_token を取得する")
+    parser.add_argument(
+        "--credentials",
+        default="credentials.json",
+        help="GCP からダウンロードした OAuth2 クライアント認証情報 JSON ファイルのパス",
+    )
+    args = parser.parse_args()
+
+    flow = Flow.from_client_secrets_file(
+        args.credentials,
+        scopes=SCOPES,
+        redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+    )
+
+    auth_url, _ = flow.authorization_url(
+        access_type="offline",
+        prompt="consent",
+    )
+
+    print("\n以下の URL をブラウザで開き、認可してください:\n")
+    print(auth_url)
+    print()
+
+    code = input("認可後に表示されたコードを貼り付けてください: ").strip()
+    flow.fetch_token(code=code)
+
+    creds = flow.credentials
+    print("\n--- Secret Manager へ投入する値 ---")
+    print(f"client_id:     {creds.client_id}")
+    print(f"client_secret: {creds.client_secret}")
+    print(f"refresh_token: {creds.refresh_token}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+google-auth-oauthlib>=1.0.0


### PR DESCRIPTION
## Summary

- `scripts/get_gmail_refresh_token.py` を追加
  - `InstalledAppFlow.run_local_server(port=0)` による loopback フロー（OOB フロー廃止対応）
  - `client_id` / `client_secret` / `refresh_token` を標準出力に表示
- `scripts/requirements.txt` に `google-auth-oauthlib>=1.0.0` を追加
- `.gitignore` に `scripts/credentials.json` を追加

## 手作業で実施済み

1. GCP コンソールで OAuth 同意画面（Internal）と OAuth クライアント ID（デスクトップアプリ）を作成
2. スクリプトで refresh_token を取得
3. Secret Manager へ 3 シークレット全てを投入済み

## Test plan

- [x] `python scripts/get_gmail_refresh_token.py` が refresh_token を出力できる
- [x] Secret Manager の 3 シークレット全てにバージョンが投入されている
- [x] `gcloud secrets versions access latest --secret=gmail-oauth-refresh-token` で値が取得できる

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)