### PR TITLE
fix: simulation-side-sheet の order_no null 型エラーを修正

### DIFF
--- a/frontend/src/components/orders/simulation-side-sheet.tsx
+++ b/frontend/src/components/orders/simulation-side-sheet.tsx
@@ -50,7 +50,7 @@ export function SimulationSideSheet({
           <Button
             disabled={confirmIsPending || !order}
             onClick={() => {
-              if (order) onConfirm(order.id, order.order_no)
+              if (order) onConfirm(order.id, order.order_no ?? '')
             }}
           >
             この内容で確定


### PR DESCRIPTION
## Summary
- `order_no` が `string | null` 型のため、`onConfirm` に `null` を渡すと TypeScript の型エラーが発生していた
- `?? ''` によるフォールバックで `null` を空文字列に変換し、Vercel ビルドエラーを解消

## Test plan
- [ ] Vercel ビルドが通ることを確認
- [ ] シミュレーション確定ボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)