### PR TITLE
feat: Gmail → 注文下書き自動作成パイプラインを実装 (#165 #166 #167)

### DIFF
--- a/.vscode/pp-words.txt
+++ b/.vscode/pp-words.txt
@@ -1,3 +1,6 @@
 productplanner
 SUPABASE
+supa
 delenv
+creds
+googleapiclient

--- a/.vscode/pp-words.txt
+++ b/.vscode/pp-words.txt
@@ -1,0 +1,3 @@
+productplanner
+SUPABASE
+delenv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,19 @@
         "**/.mypy_cache": true,
         "**/.venv": true,
         "**/.ruff_cache": true
-    }
+    },
+    "cSpell.customDictionaries": {
+        "pp-words": {
+            "name": "pp-words",
+            "path": "${workspaceRoot}/.vscode/pp-words.txt",
+            "description": "ProductPlannerプロジェクトでよく使われる単語を含むカスタム辞書",
+            "addWords": true
+        }
+    },
+    "cSpell.dictionaries": [
+        "python",
+        "typescript",
+        "terraform",
+        "softwareTerms"
+    ],
 }

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -29,10 +29,10 @@ GMAIL_CLIENT_SECRET=your_gmail_client_secret
 GMAIL_REFRESH_TOKEN=your_gmail_refresh_token
 
 # Gmail ラベルプレフィックス (デフォルトのまま変更不要な場合はコメントアウト)
-# GMAIL_LABEL_PREFIX_PENDING=処理待ち
-# GMAIL_LABEL_PREFIX_PROCESSING=処理中
-# GMAIL_LABEL_PREFIX_DONE=処理済み
-# GMAIL_LABEL_PREFIX_ERROR=エラー
+# GMAIL_LABEL_PREFIX_PENDING=pp-pending
+# GMAIL_LABEL_PREFIX_PROCESSING=pp-processing
+# GMAIL_LABEL_PREFIX_DONE=pp-done
+# GMAIL_LABEL_PREFIX_ERROR=pp-error
 
 # ============================================================
 # Claude API (GCP Secret Manager から取得)

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,58 @@
+# ============================================================
+# Supabase
+# ============================================================
+# ローカル: supabase start で表示される値を使用
+# 本番: Supabase ダッシュボード → Settings → API
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# ============================================================
+# Supabase プロジェクト (DB 直接接続 / マイグレーション用)
+# ============================================================
+SUPABASE_PROJECT_ID=your_project_id
+SUPABASE_DB_PASSWORD=your_db_password
+
+# ============================================================
+# Cron 認証
+# ============================================================
+# 生成方法: openssl rand -hex 32
+# Vercel の CRON_SECRET と同じ値を設定すること
+CRON_SECRET=your_cron_secret
+
+# ============================================================
+# Gmail OAuth2 (GCP Secret Manager から取得)
+# 取得手順: docs/infra/env-setup-gmail-cron.md を参照
+# ============================================================
+GMAIL_CLIENT_ID=your_gmail_client_id.apps.googleusercontent.com
+GMAIL_CLIENT_SECRET=your_gmail_client_secret
+GMAIL_REFRESH_TOKEN=your_gmail_refresh_token
+
+# Gmail ラベルプレフィックス (デフォルトのまま変更不要な場合はコメントアウト)
+# GMAIL_LABEL_PREFIX_PENDING=処理待ち
+# GMAIL_LABEL_PREFIX_PROCESSING=処理中
+# GMAIL_LABEL_PREFIX_DONE=処理済み
+# GMAIL_LABEL_PREFIX_ERROR=エラー
+
+# ============================================================
+# Claude API (GCP Secret Manager から取得)
+# ============================================================
+ANTHROPIC_API_KEY=your_anthropic_api_key
+
+# 使用モデル (デフォルトのまま変更不要な場合はコメントアウト)
+# EMAIL_EXTRACTION_MODEL=claude-haiku-4-5-20251001
+
+# ============================================================
+# 製品マッチング (pg_trgm)
+# ============================================================
+# デフォルトのまま変更不要な場合はコメントアウト
+# PRODUCT_MATCH_THRESHOLD=0.3
+# PRODUCT_MATCH_TOP_N=5
+
+# ============================================================
+# テスト用 (ローカル開発のみ)
+# ============================================================
+TEST_USER_EMAIL=test@example.com
+TEST_USER_PASS=Test123!
+TEST_TENANT_ID=your_test_tenant_uuid
+PLATFORM_ADMIN_EMAIL=your_admin_email@example.com

--- a/backend/__tests__/api/routers/cron/test_gmail_poll.py
+++ b/backend/__tests__/api/routers/cron/test_gmail_poll.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+VALID_SECRET = "test-cron-secret-abc123"
+
+
+@pytest.mark.api
+class TestGmailPollRouter:
+    def test_missing_auth_header_returns_401(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        response = client.get("/api/cron/gmail-poll")
+        assert response.status_code == 401
+
+    def test_wrong_secret_returns_401(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        response = client.get(
+            "/api/cron/gmail-poll",
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+        assert response.status_code == 401
+
+    def test_valid_secret_returns_processed_count(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        with patch(
+            "app.routers.cron.gmail_poll.poll_unread_emails",
+            return_value={"processed": 3},
+        ):
+            response = client.get(
+                "/api/cron/gmail-poll",
+                headers={"Authorization": f"Bearer {VALID_SECRET}"},
+            )
+        assert response.status_code == 200
+        assert response.json() == {"processed": 3}
+
+    def test_missing_cron_secret_env_returns_500(self, monkeypatch):
+        monkeypatch.delenv("CRON_SECRET", raising=False)
+        response = client.get(
+            "/api/cron/gmail-poll",
+            headers={"Authorization": f"Bearer {VALID_SECRET}"},
+        )
+        assert response.status_code == 500
+
+    def test_gmail_service_value_error_returns_500(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        with patch(
+            "app.routers.cron.gmail_poll.poll_unread_emails",
+            side_effect=ValueError("Missing env vars"),
+        ):
+            response = client.get(
+                "/api/cron/gmail-poll",
+                headers={"Authorization": f"Bearer {VALID_SECRET}"},
+            )
+        assert response.status_code == 500
+
+    def test_gmail_api_error_returns_502(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        with patch(
+            "app.routers.cron.gmail_poll.poll_unread_emails",
+            side_effect=Exception("Gmail rate limit"),
+        ):
+            response = client.get(
+                "/api/cron/gmail-poll",
+                headers={"Authorization": f"Bearer {VALID_SECRET}"},
+            )
+        assert response.status_code == 502

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -10,37 +10,46 @@ class TestPollUnreadEmails:
         monkeypatch.setenv("GMAIL_CLIENT_ID", "client-id")
         monkeypatch.setenv("GMAIL_CLIENT_SECRET", "client-secret")
         monkeypatch.setenv("GMAIL_REFRESH_TOKEN", "refresh-token")
-        monkeypatch.setenv("GMAIL_QUERY_FILTER", "is:unread")
-        monkeypatch.setenv("GMAIL_LABEL_PROCESSED", "Label_123")
 
-    def test_no_unread_emails_returns_zero(self, monkeypatch):
+    def test_no_pending_labels_returns_zero(self, monkeypatch):
         self._set_required_env(monkeypatch)
 
         mock_service = MagicMock()
-        mock_service.users().messages().list().execute.return_value = {"messages": []}
+        mock_service.users().labels().list().execute.return_value = {"labels": []}
 
         with patch(
             "app.services.gmail_service._build_gmail_client", return_value=mock_service
         ):
-            result = poll_unread_emails()
+            result = poll_unread_emails(MagicMock())
 
-        assert result == {"processed": 0}
+        assert result == {"processed": 0, "errors": 0}
 
-    def test_emails_are_labeled_and_count_returned(self, monkeypatch):
+    def test_messages_processed_and_count_returned(self, monkeypatch):
         self._set_required_env(monkeypatch)
 
         mock_service = MagicMock()
+        mock_service.users().labels().list().execute.return_value = {
+            "labels": [
+                {"name": "pp-pending/tenantA", "id": "label-1"},
+            ]
+        }
         mock_service.users().messages().list().execute.return_value = {
             "messages": [{"id": "aaa"}, {"id": "bbb"}]
         }
 
-        with patch(
-            "app.services.gmail_service._build_gmail_client", return_value=mock_service
+        mock_db = MagicMock()
+        with (
+            patch(
+                "app.services.gmail_service._build_gmail_client",
+                return_value=mock_service,
+            ),
+            patch("app.services.gmail_service._process_message") as mock_process,
         ):
-            result = poll_unread_emails()
+            result = poll_unread_emails(mock_db)
 
-        assert result == {"processed": 2}
-        mock_service.users().messages().batchModify.assert_called_once()
+        assert result["processed"] == 2
+        assert result["errors"] == 0
+        assert mock_process.call_count == 2
 
     def test_missing_env_vars_raise_value_error(self, monkeypatch):
         monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
@@ -48,21 +57,33 @@ class TestPollUnreadEmails:
         monkeypatch.delenv("GMAIL_REFRESH_TOKEN", raising=False)
 
         with pytest.raises(ValueError, match="Missing Gmail OAuth env vars"):
-            poll_unread_emails()
+            poll_unread_emails(MagicMock())
 
-    def test_paginated_emails_are_all_processed(self, monkeypatch):
+    def test_processing_error_increments_error_count(self, monkeypatch):
         self._set_required_env(monkeypatch)
 
         mock_service = MagicMock()
-        # 1ページ目: nextPageToken あり、2ページ目: なし
-        mock_service.users().messages().list().execute.side_effect = [
-            {"messages": [{"id": "aaa"}, {"id": "bbb"}], "nextPageToken": "tok"},
-            {"messages": [{"id": "ccc"}]},
-        ]
+        mock_service.users().labels().list().execute.return_value = {
+            "labels": [
+                {"name": "pp-pending/tenantA", "id": "label-1"},
+            ]
+        }
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "aaa"}]
+        }
 
-        with patch(
-            "app.services.gmail_service._build_gmail_client", return_value=mock_service
+        mock_db = MagicMock()
+        with (
+            patch(
+                "app.services.gmail_service._build_gmail_client",
+                return_value=mock_service,
+            ),
+            patch(
+                "app.services.gmail_service._process_message",
+                side_effect=Exception("processing failed"),
+            ),
         ):
-            result = poll_unread_emails()
+            result = poll_unread_emails(mock_db)
 
-        assert result == {"processed": 3}
+        assert result["processed"] == 0
+        assert result["errors"] == 1

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.services.gmail_service import poll_unread_emails
+
+
+@pytest.mark.unit
+class TestPollUnreadEmails:
+    def _set_required_env(self, monkeypatch):
+        monkeypatch.setenv("GMAIL_CLIENT_ID", "client-id")
+        monkeypatch.setenv("GMAIL_CLIENT_SECRET", "client-secret")
+        monkeypatch.setenv("GMAIL_REFRESH_TOKEN", "refresh-token")
+        monkeypatch.setenv("GMAIL_QUERY_FILTER", "is:unread")
+        monkeypatch.setenv("GMAIL_LABEL_PROCESSED", "Label_123")
+
+    def test_no_unread_emails_returns_zero(self, monkeypatch):
+        self._set_required_env(monkeypatch)
+
+        mock_service = MagicMock()
+        mock_service.users().messages().list().execute.return_value = {"messages": []}
+
+        with patch(
+            "app.services.gmail_service._build_gmail_client", return_value=mock_service
+        ):
+            result = poll_unread_emails()
+
+        assert result == {"processed": 0}
+
+    def test_emails_are_labeled_and_count_returned(self, monkeypatch):
+        self._set_required_env(monkeypatch)
+
+        mock_service = MagicMock()
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "aaa"}, {"id": "bbb"}]
+        }
+
+        with patch(
+            "app.services.gmail_service._build_gmail_client", return_value=mock_service
+        ):
+            result = poll_unread_emails()
+
+        assert result == {"processed": 2}
+        mock_service.users().messages().batchModify.assert_called_once()
+
+    def test_missing_env_vars_raise_value_error(self, monkeypatch):
+        monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("GMAIL_REFRESH_TOKEN", raising=False)
+
+        with pytest.raises(ValueError, match="Missing Gmail OAuth env vars"):
+            poll_unread_emails()
+
+    def test_paginated_emails_are_all_processed(self, monkeypatch):
+        self._set_required_env(monkeypatch)
+
+        mock_service = MagicMock()
+        # 1ページ目: nextPageToken あり、2ページ目: なし
+        mock_service.users().messages().list().execute.side_effect = [
+            {"messages": [{"id": "aaa"}, {"id": "bbb"}], "nextPageToken": "tok"},
+            {"messages": [{"id": "ccc"}]},
+        ]
+
+        with patch(
+            "app.services.gmail_service._build_gmail_client", return_value=mock_service
+        ):
+            result = poll_unread_emails()
+
+        assert result == {"processed": 3}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers.admin import admin_router
+from app.routers.cron import cron_router
 from app.routers.master import (
     calendar_router,
     customer_router,
@@ -54,6 +55,7 @@ app.include_router(production_schedules_router)
 app.include_router(scheduling_settings_router)
 app.include_router(member_router)
 app.include_router(admin_router)
+app.include_router(cron_router)
 
 
 @app.get("/health")

--- a/backend/app/models/transaction/order_schema.py
+++ b/backend/app/models/transaction/order_schema.py
@@ -11,12 +11,14 @@ class OrderCreate(BaseSchema):
     model_config = ConfigDict(populate_by_name=True)
 
     order_number: str | None = Field(None, alias="order_no")
-    product_id: int
-    quantity: int
+    product_id: int | None = None
+    quantity: int | None = None
     deadline_date: str | None = Field(None, alias="desired_deadline")
     customer_id: int | None = None
     source_type: str = Field("manual")
     source_raw: str | None = None
+    extracted_product_name: str | None = None
+    product_candidates: list[dict] | None = None
 
 
 class OrderSimulateRequest(BaseSchema):

--- a/backend/app/repositories/supa_infra/common/table_name.py
+++ b/backend/app/repositories/supa_infra/common/table_name.py
@@ -16,3 +16,4 @@ class SupabaseTableName(Enum):
     PRODUCTION_SCHEDULES = "production_schedules"
     WORK_CALENDARS = "work_calendars"
     SCHEDULING_SETTINGS = "scheduling_settings"
+    GMAIL_LABEL_TENANTS = "gmail_label_tenants"

--- a/backend/app/routers/cron/__init__.py
+++ b/backend/app/routers/cron/__init__.py
@@ -1,0 +1,3 @@
+from app.routers.cron.gmail_poll import cron_router
+
+__all__ = ["cron_router"]

--- a/backend/app/routers/cron/gmail_poll.py
+++ b/backend/app/routers/cron/gmail_poll.py
@@ -3,6 +3,7 @@ import secrets
 
 from fastapi import APIRouter, HTTPException, Request, status
 
+from app.dependencies import get_supabase_admin_client
 from app.services.gmail_service import poll_unread_emails
 from app.utils.logger import get_logger
 
@@ -35,7 +36,8 @@ def _validate_cron_secret(request: Request) -> None:
 def gmail_poll(request: Request):
     _validate_cron_secret(request)
     try:
-        return poll_unread_emails()
+        db_client = get_supabase_admin_client()
+        return poll_unread_emails(db_client)
     except ValueError as exc:
         logger.error(f"Gmail poll config error: {exc}")
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/routers/cron/gmail_poll.py
+++ b/backend/app/routers/cron/gmail_poll.py
@@ -1,0 +1,44 @@
+import os
+import secrets
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from app.services.gmail_service import poll_unread_emails
+from app.utils.logger import get_logger
+
+cron_router = APIRouter(prefix="/api/cron", tags=["Cron"])
+logger = get_logger(__name__)
+
+
+def _validate_cron_secret(request: Request) -> None:
+    cron_secret = os.environ.get("CRON_SECRET")
+    if not cron_secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="CRON_SECRET not configured.",
+        )
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header.",
+        )
+    token = auth_header.removeprefix("Bearer ")
+    if not secrets.compare_digest(token.encode(), cron_secret.encode()):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid CRON_SECRET.",
+        )
+
+
+@cron_router.get("/gmail-poll")
+def gmail_poll(request: Request):
+    _validate_cron_secret(request)
+    try:
+        return poll_unread_emails()
+    except ValueError as exc:
+        logger.error(f"Gmail poll config error: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Gmail poll failed: {exc}")
+        raise HTTPException(status_code=502, detail=f"Gmail API error: {exc}") from exc

--- a/backend/app/services/customer_matching_service.py
+++ b/backend/app/services/customer_matching_service.py
@@ -1,0 +1,52 @@
+import re
+from typing import Any, cast
+
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.utils.logger import get_logger
+from supabase import Client
+
+logger = get_logger(__name__)
+
+# Matches forwarded message headers in both English and Japanese:
+#   "From: Name <addr@example.com>"  or  "差出人: addr@example.com"
+_FORWARDED_EMAIL_RE = re.compile(
+    r"(?:From|差出人)\s*:.*?([a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,})",
+    re.IGNORECASE,
+)
+
+
+def extract_sender_email(body: str) -> str | None:
+    m = _FORWARDED_EMAIL_RE.search(body)
+    return m.group(1) if m else None
+
+
+def resolve_or_create_customer(db: Client, tenant_id: str, email: str) -> int:
+    """
+    メールアドレスで顧客を検索し、存在すれば customer_id を返す。
+    存在しなければ draft 顧客を自動作成して返す。
+    """
+    table = SupabaseTableName.CUSTOMERS.value
+    result = (
+        db.table(table)
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("email", email)
+        .limit(1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    if rows:
+        logger.info(f"customer found: id={rows[0]['id']} email={email}")
+        return int(rows[0]["id"])
+
+    created = (
+        db.table(table)
+        .insert(
+            {"tenant_id": tenant_id, "email": email, "name": email, "status": "draft"}
+        )
+        .execute()
+    )
+    created_rows = cast(list[dict[str, Any]], created.data or [])
+    new_id = int(created_rows[0]["id"])
+    logger.info(f"customer auto-created: id={new_id} email={email}")
+    return new_id

--- a/backend/app/services/email_extraction_service.py
+++ b/backend/app/services/email_extraction_service.py
@@ -1,0 +1,58 @@
+import os
+from typing import Any
+
+import anthropic
+
+_client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+_EXTRACT_TOOL: Any = {
+    "name": "extract_order_fields",
+    "description": "メール本文から注文情報を抽出する",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "product_name": {
+                "type": ["string", "null"],
+                "description": "製品名・型番・品番等の文字列。見つからない場合はnull",
+            },
+            "quantity": {
+                "type": ["integer", "null"],
+                "description": "注文数量（整数）。見つからない場合はnull",
+            },
+            "deadline_date": {
+                "type": ["string", "null"],
+                "description": "希望納期 (ISO 8601: YYYY-MM-DD)。見つからない場合はnull",
+            },
+            "order_number": {
+                "type": ["string", "null"],
+                "description": "顧客注文番号・発注番号。見つからない場合はnull",
+            },
+        },
+        "required": ["product_name", "quantity", "deadline_date", "order_number"],
+    },
+}
+
+
+def extract_email_fields(body: str) -> dict:
+    model = os.environ.get("EMAIL_EXTRACTION_MODEL", "claude-haiku-4-5-20251001")
+    response = _client.messages.create(
+        model=model,
+        max_tokens=512,
+        tools=[_EXTRACT_TOOL],
+        tool_choice={"type": "tool", "name": "extract_order_fields"},
+        messages=[
+            {
+                "role": "user",
+                "content": f"以下のメール本文から注文情報を抽出してください。\n\n{body}",
+            }
+        ],
+    )
+    for block in response.content:
+        if block.type == "tool_use" and block.name == "extract_order_fields":
+            return block.input
+    return {
+        "product_name": None,
+        "quantity": None,
+        "deadline_date": None,
+        "order_number": None,
+    }

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -21,10 +21,10 @@ logger = get_logger(__name__)
 _GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
 # Label name prefixes — full label names are "{prefix}/{tenant_name}"
-_PREFIX_PENDING = os.environ.get("GMAIL_LABEL_PREFIX_PENDING", "処理待ち")
-_PREFIX_PROCESSING = os.environ.get("GMAIL_LABEL_PREFIX_PROCESSING", "処理中")
-_PREFIX_DONE = os.environ.get("GMAIL_LABEL_PREFIX_DONE", "処理済み")
-_PREFIX_ERROR = os.environ.get("GMAIL_LABEL_PREFIX_ERROR", "エラー")
+_PREFIX_PENDING = os.environ.get("GMAIL_LABEL_PREFIX_PENDING", "pp-pending")
+_PREFIX_PROCESSING = os.environ.get("GMAIL_LABEL_PREFIX_PROCESSING", "pp-processing")
+_PREFIX_DONE = os.environ.get("GMAIL_LABEL_PREFIX_DONE", "pp-done")
+_PREFIX_ERROR = os.environ.get("GMAIL_LABEL_PREFIX_ERROR", "pp-error")
 
 
 def _build_gmail_client():

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -1,0 +1,82 @@
+import os
+from typing import Any
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+
+def _build_gmail_client():
+    client_id = os.environ.get("GMAIL_CLIENT_ID")
+    client_secret = os.environ.get("GMAIL_CLIENT_SECRET")
+    refresh_token = os.environ.get("GMAIL_REFRESH_TOKEN")
+
+    if not all([client_id, client_secret, refresh_token]):
+        raise ValueError(
+            "Missing Gmail OAuth env vars: GMAIL_CLIENT_ID, "
+            "GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN must all be set."
+        )
+
+    creds = Credentials(
+        token=None,
+        refresh_token=refresh_token,
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=_GMAIL_SCOPES,
+    )
+    creds.refresh(Request())
+    return build("gmail", "v1", credentials=creds, cache_discovery=False)
+
+
+def poll_unread_emails() -> dict[str, Any]:
+    """未読メールを取得し、処理済みラベルを付与して件数を返す。"""
+    query_filter = os.environ.get("GMAIL_QUERY_FILTER", "is:unread")
+    label_processed = os.environ.get("GMAIL_LABEL_PROCESSED", "Label_processed")
+
+    logger.info(f"Gmail poll: query='{query_filter}' label='{label_processed}'")
+
+    service = _build_gmail_client()
+    messages: list[dict] = []
+    page_token: str | None = None
+
+    while True:
+        kwargs: dict[str, Any] = {
+            "userId": "me",
+            "q": query_filter,
+            "maxResults": 500,
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+
+        result = service.users().messages().list(**kwargs).execute()
+        messages.extend(result.get("messages", []))
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
+
+    if not messages:
+        logger.info("Gmail poll: no unread messages.")
+        return {"processed": 0}
+
+    msg_ids = [m["id"] for m in messages]
+    logger.info(f"Gmail poll: {len(msg_ids)} messages to process.")
+
+    for i in range(0, len(msg_ids), 1000):
+        service.users().messages().batchModify(
+            userId="me",
+            body={
+                "ids": msg_ids[i : i + 1000],
+                "addLabelIds": [label_processed],
+                "removeLabelIds": ["UNREAD"],
+            },
+        ).execute()
+
+    logger.info(f"Gmail poll: labeled {len(msg_ids)} messages.")
+    return {"processed": len(msg_ids)}

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -1,15 +1,30 @@
+import base64
 import os
-from typing import Any
+from typing import Any, cast
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.services.customer_matching_service import (
+    extract_sender_email,
+    resolve_or_create_customer,
+)
+from app.services.email_extraction_service import extract_email_fields
+from app.services.product_matching_service import match_products
 from app.utils.logger import get_logger
+from supabase import Client
 
 logger = get_logger(__name__)
 
 _GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+# Label name prefixes — full label names are "{prefix}/{tenant_name}"
+_PREFIX_PENDING = os.environ.get("GMAIL_LABEL_PREFIX_PENDING", "処理待ち")
+_PREFIX_PROCESSING = os.environ.get("GMAIL_LABEL_PREFIX_PROCESSING", "処理中")
+_PREFIX_DONE = os.environ.get("GMAIL_LABEL_PREFIX_DONE", "処理済み")
+_PREFIX_ERROR = os.environ.get("GMAIL_LABEL_PREFIX_ERROR", "エラー")
 
 
 def _build_gmail_client():
@@ -35,48 +50,197 @@ def _build_gmail_client():
     return build("gmail", "v1", credentials=creds, cache_discovery=False)
 
 
-def poll_unread_emails() -> dict[str, Any]:
-    """未読メールを取得し、処理済みラベルを付与して件数を返す。"""
-    query_filter = os.environ.get("GMAIL_QUERY_FILTER", "is:unread")
-    label_processed = os.environ.get("GMAIL_LABEL_PROCESSED", "Label_processed")
+def _get_label_id_map(service) -> dict[str, str]:
+    """ラベル名 → Gmail label ID のマップを返す。"""
+    result = service.users().labels().list(userId="me").execute()
+    return {lbl["name"]: lbl["id"] for lbl in result.get("labels", [])}
 
-    logger.info(f"Gmail poll: query='{query_filter}' label='{label_processed}'")
 
-    service = _build_gmail_client()
-    messages: list[dict] = []
-    page_token: str | None = None
+def _get_message_body(msg: dict) -> str:
+    """Gmail API メッセージからプレーンテキスト本文を抽出する。"""
+    payload = msg.get("payload", {})
 
-    while True:
-        kwargs: dict[str, Any] = {
-            "userId": "me",
-            "q": query_filter,
-            "maxResults": 500,
+    def _decode(data: str) -> str:
+        return base64.urlsafe_b64decode(data + "==").decode("utf-8", errors="replace")
+
+    parts = payload.get("parts", [])
+    if parts:
+        for part in parts:
+            if part.get("mimeType") == "text/plain":
+                body_data = part.get("body", {}).get("data", "")
+                if body_data:
+                    return _decode(body_data)
+        # fallback: first part
+        body_data = parts[0].get("body", {}).get("data", "")
+        return _decode(body_data) if body_data else ""
+
+    body_data = payload.get("body", {}).get("data", "")
+    return _decode(body_data) if body_data else ""
+
+
+def _lookup_tenant_id(db: Client, tenant_name: str) -> str | None:
+    """ラベルのテナント名部分から tenant_id を引く。"""
+    table = SupabaseTableName.GMAIL_LABEL_TENANTS.value
+    result = (
+        db.table(table)
+        .select("tenant_id")
+        .eq("label_name", tenant_name)
+        .limit(1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    return str(rows[0]["tenant_id"]) if rows else None
+
+
+def _move_label(
+    service, msg_id: str, add_id: str | None, remove_id: str | None
+) -> None:
+    add_ids = [add_id] if add_id else []
+    remove_ids = [remove_id] if remove_id else []
+    service.users().messages().modify(
+        userId="me",
+        id=msg_id,
+        body={"addLabelIds": add_ids, "removeLabelIds": remove_ids},
+    ).execute()
+
+
+def _process_message(
+    service,
+    db: Client,
+    msg_id: str,
+    tenant_name: str,
+    label_id_map: dict[str, str],
+) -> None:
+    pending_label = f"{_PREFIX_PENDING}/{tenant_name}"
+    processing_label = f"{_PREFIX_PROCESSING}/{tenant_name}"
+    done_label = f"{_PREFIX_DONE}/{tenant_name}"
+    error_label = f"{_PREFIX_ERROR}/{tenant_name}"
+
+    processing_id = label_id_map.get(processing_label)
+    pending_id = label_id_map.get(pending_label)
+    done_id = label_id_map.get(done_label)
+    error_id = label_id_map.get(error_label)
+
+    # 1. 処理待ち → 処理中 (二重処理防止)
+    _move_label(service, msg_id, processing_id, pending_id)
+    logger.info(f"msg {msg_id}: moved to {processing_label}")
+
+    try:
+        # 2. 本文取得
+        msg = (
+            service.users()
+            .messages()
+            .get(userId="me", id=msg_id, format="full")
+            .execute()
+        )
+        body = _get_message_body(msg)
+
+        # 3. テナント解決
+        tenant_id = _lookup_tenant_id(db, tenant_name)
+        if not tenant_id:
+            raise ValueError(f"tenant not found for label: {tenant_name}")
+
+        # 4. Claude で注文フィールド抽出
+        fields = extract_email_fields(body)
+        logger.info(f"msg {msg_id}: extracted fields={fields}")
+
+        # 5. 製品マッチング
+        product_id: int | None = None
+        candidates: list[dict] = []
+        if fields.get("product_name"):
+            match = match_products(db, tenant_id, fields["product_name"])
+            product_id = match["product_id"]
+            candidates = match["candidates"]
+
+        # 6. 顧客マッチング
+        customer_id: int | None = None
+        sender_email = extract_sender_email(body)
+        if sender_email:
+            customer_id = resolve_or_create_customer(db, tenant_id, sender_email)
+
+        # 7. ドラフト注文を Supabase に登録
+        order_row: dict[str, Any] = {
+            "tenant_id": tenant_id,
+            "source_type": "email",
+            "source_raw": body,
+            "status": "draft",
+            "product_id": product_id,
+            "quantity": fields.get("quantity"),
+            "deadline_date": fields.get("deadline_date"),
+            "order_number": fields.get("order_number"),
+            "extracted_product_name": fields.get("product_name"),
+            "product_candidates": candidates if candidates else None,
+            "customer_id": customer_id,
         }
-        if page_token:
-            kwargs["pageToken"] = page_token
+        db.table(SupabaseTableName.ORDERS.value).insert(order_row).execute()
+        logger.info(f"msg {msg_id}: order draft created for tenant {tenant_id}")
 
-        result = service.users().messages().list(**kwargs).execute()
-        messages.extend(result.get("messages", []))
-        page_token = result.get("nextPageToken")
-        if not page_token:
-            break
+        # 8. 処理中 → 処理済み
+        _move_label(service, msg_id, done_id, processing_id)
+
+    except Exception as exc:
+        logger.error(f"msg {msg_id}: processing failed: {exc}", exc_info=True)
+        # 処理中 → エラー
+        _move_label(service, msg_id, error_id, processing_id)
+        raise
+
+
+def poll_unread_emails(db: Client) -> dict[str, Any]:
+    """処理待ちラベルのメールを取得し、注文ドラフトを作成して件数を返す。"""
+    service = _build_gmail_client()
+    label_id_map = _get_label_id_map(service)
+
+    # 処理待ち/* ラベルを持つメッセージを列挙
+    pending_label_ids = [
+        lid
+        for name, lid in label_id_map.items()
+        if name.startswith(f"{_PREFIX_PENDING}/")
+    ]
+
+    if not pending_label_ids:
+        logger.info("Gmail poll: no pending labels found.")
+        return {"processed": 0, "errors": 0}
+
+    messages: list[dict] = []
+    for label_id in pending_label_ids:
+        page_token: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "userId": "me",
+                "labelIds": [label_id],
+                "maxResults": 500,
+            }
+            if page_token:
+                kwargs["pageToken"] = page_token
+            result = service.users().messages().list(**kwargs).execute()
+            for m in result.get("messages", []):
+                messages.append({"id": m["id"], "label_id": label_id})
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                break
 
     if not messages:
-        logger.info("Gmail poll: no unread messages.")
-        return {"processed": 0}
+        logger.info("Gmail poll: no messages in pending labels.")
+        return {"processed": 0, "errors": 0}
 
-    msg_ids = [m["id"] for m in messages]
-    logger.info(f"Gmail poll: {len(msg_ids)} messages to process.")
+    logger.info(f"Gmail poll: {len(messages)} messages to process.")
 
-    for i in range(0, len(msg_ids), 1000):
-        service.users().messages().batchModify(
-            userId="me",
-            body={
-                "ids": msg_ids[i : i + 1000],
-                "addLabelIds": [label_processed],
-                "removeLabelIds": ["UNREAD"],
-            },
-        ).execute()
+    # label_id → テナント名 逆引き
+    id_to_tenant: dict[str, str] = {
+        lid: name.removeprefix(f"{_PREFIX_PENDING}/")
+        for name, lid in label_id_map.items()
+        if name.startswith(f"{_PREFIX_PENDING}/")
+    }
 
-    logger.info(f"Gmail poll: labeled {len(msg_ids)} messages.")
-    return {"processed": len(msg_ids)}
+    processed = 0
+    errors = 0
+    for m in messages:
+        tenant_name = id_to_tenant.get(m["label_id"], "")
+        try:
+            _process_message(service, db, m["id"], tenant_name, label_id_map)
+            processed += 1
+        except Exception:
+            errors += 1
+
+    logger.info(f"Gmail poll complete: processed={processed} errors={errors}")
+    return {"processed": processed, "errors": errors}

--- a/backend/app/services/product_matching_service.py
+++ b/backend/app/services/product_matching_service.py
@@ -1,0 +1,43 @@
+import os
+from typing import Any, cast
+
+from app.utils.logger import get_logger
+from supabase import Client
+
+logger = get_logger(__name__)
+
+_THRESHOLD = float(os.environ.get("PRODUCT_MATCH_THRESHOLD", "0.3"))
+_TOP_N = int(os.environ.get("PRODUCT_MATCH_TOP_N", "5"))
+
+
+def match_products(db: Client, tenant_id: str, product_name: str) -> dict[str, Any]:
+    """
+    pg_trgm で製品名を類似度検索する。
+
+    Returns:
+        {
+            "product_id": int | None,    # 単一確定時のみセット
+            "candidates": list[dict],    # UI 表示用上位 N 件
+        }
+    """
+    result = db.rpc(
+        "match_products_by_name",
+        {
+            "query_text": product_name,
+            "p_tenant_id": tenant_id,
+            "similarity_threshold": _THRESHOLD,
+        },
+    ).execute()
+
+    rows = cast(list[dict[str, Any]], result.data or [])
+    logger.info(f"product match: query='{product_name}' hits={len(rows)}")
+
+    candidates = [
+        {"product_id": r["id"], "name": r["name"], "score": r["score"]}
+        for r in rows[:_TOP_N]
+    ]
+
+    if len(rows) == 1:
+        return {"product_id": rows[0]["id"], "candidates": candidates}
+
+    return {"product_id": None, "candidates": candidates}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -72,3 +72,5 @@ Werkzeug==3.1.4
 yarl==1.22.0
 uvicorn[standard]
 pydantic-settings
+google-api-python-client==2.170.0
+google-auth==2.40.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -74,3 +74,4 @@ uvicorn[standard]
 pydantic-settings
 google-api-python-client==2.170.0
 google-auth==2.40.3
+anthropic>=0.40.0

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -157,11 +157,22 @@ interface OrderCreate {
 
 ## 将来の拡張: メール解析パイプライン
 
-本機能はメール解析 Azure Function との接続を想定した土台。以下のフローで注文を自動起票する。
+本機能はメール解析パイプラインとの接続を想定した土台。以下のフローで注文を自動起票する。
 
+**現在のアーキテクチャ**
 ```
-[受信メール] → [Azure Function: メール解析]
+[Vercel Cron] → [バックエンド API（Render）: Gmail ポーリング]
+              → Gmail API で未読メール取得
               → LLM でフィールド抽出 (製品コード, 数量, 希望納期)
+              → POST /orders/ {source_type: "email", source_raw: "<メール本文>"}
+              → [人間によるレビュー・確定]
+```
+
+**将来のアーキテクチャ（スケールアップ時）**
+```
+[Cloud Scheduler] → [Cloud Run: Gmail ポーリング]
+              → Gmail API で未読メール取得
+              → LLM でフィールド抽出
               → POST /orders/ {source_type: "email", source_raw: "<メール本文>"}
               → [人間によるレビュー・確定]
 ```
@@ -187,5 +198,5 @@ interface OrderCreate {
 | Frontend: `Order` 型更新 | ✅ #155 |
 | Frontend: 注文番号フィールド任意化 | ✅ #155 |
 | Frontend: メール本文折りたたみUI | ✅ #155 |
-| Azure Function: メール受信トリガー | ❌ 未実装 |
+| Vercel Cron: Gmail ポーリングジョブ | ❌ 未実装 (#165) |
 | LLM によるメール本文解析 | ❌ 未実装 |

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -10,15 +10,31 @@ Gmail ポーリング Cron ジョブの動作に必要な環境変数を、GCP S
 
 ## 必要な環境変数一覧
 
-| 変数名 | 設定先 | 取得元 |
+### Render（バックエンド）
+
+| 変数名 | 取得元 | 備考 |
 |---|---|---|
-| `CRON_SECRET` | Render・Vercel（共通） | 自前生成 |
-| `GMAIL_CLIENT_ID` | Render | GCP Secret Manager |
-| `GMAIL_CLIENT_SECRET` | Render | GCP Secret Manager |
-| `GMAIL_REFRESH_TOKEN` | Render | GCP Secret Manager |
-| `GMAIL_QUERY_FILTER` | Render | 自前設定 |
-| `GMAIL_LABEL_PROCESSED` | Render | Gmail API で確認 |
-| `BACKEND_URL` | Vercel | Render のサービス URL |
+| `CRON_SECRET` | 自前生成 | Vercel と同じ値 |
+| `GMAIL_CLIENT_ID` | GCP Secret Manager | — |
+| `GMAIL_CLIENT_SECRET` | GCP Secret Manager | — |
+| `GMAIL_REFRESH_TOKEN` | GCP Secret Manager | — |
+| `GMAIL_LABEL_PREFIX_PENDING` | 自前設定 | デフォルト: `処理待ち` |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | 自前設定 | デフォルト: `処理中` |
+| `GMAIL_LABEL_PREFIX_DONE` | 自前設定 | デフォルト: `処理済み` |
+| `GMAIL_LABEL_PREFIX_ERROR` | 自前設定 | デフォルト: `エラー` |
+| `ANTHROPIC_API_KEY` | GCP Secret Manager | Claude メール解析用 |
+| `EMAIL_EXTRACTION_MODEL` | 自前設定 | デフォルト: `claude-haiku-4-5-20251001` |
+| `PRODUCT_MATCH_THRESHOLD` | 自前設定 | デフォルト: `0.3` |
+| `PRODUCT_MATCH_TOP_N` | 自前設定 | デフォルト: `5` |
+| `SUPABASE_SERVICE_ROLE_KEY` | GCP Secret Manager | Cron 専用。Secret Manager 管理必須 |
+| `SUPABASE_URL` | Supabase ダッシュボード | — |
+
+### Vercel（フロントエンド）
+
+| 変数名 | 取得元 | 備考 |
+|---|---|---|
+| `CRON_SECRET` | 自前生成 | Render と同じ値 |
+| `BACKEND_URL` | Render のサービス URL | 末尾スラッシュなし |
 
 ---
 
@@ -56,42 +72,65 @@ gcloud secrets versions access latest --secret="gmail-oauth-refresh-token"
 
 ---
 
-## Step 3: Gmail ラベル ID を確認する
-
-`GMAIL_LABEL_PROCESSED` には Gmail ラベルの**表示名ではなく ID**（`Label_XXXXXXXXX` 形式）を設定する必要がある。
-
-### ラベル一覧を取得
+## Step 3: Anthropic API キーを Secret Manager に登録する
 
 ```bash
-# access_token を取得（refresh_token から）
-ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
-  -d "client_id=$(gcloud secrets versions access latest --secret=gmail-oauth-client-id)" \
-  -d "client_secret=$(gcloud secrets versions access latest --secret=gmail-oauth-client-secret)" \
-  -d "refresh_token=$(gcloud secrets versions access latest --secret=gmail-oauth-refresh-token)" \
-  -d "grant_type=refresh_token" \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+# APIキーを Secret Manager に保存
+echo -n "<ANTHROPIC_API_KEY>" | \
+  gcloud secrets create anthropic-api-key --data-file=- --project=productplanner-prod
 
-# ラベル一覧を取得
-curl -s "https://gmail.googleapis.com/gmail/v1/users/me/labels" \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  | python3 -m json.tool | grep -A1 '"name"'
+# 既存シークレットを更新する場合
+echo -n "<ANTHROPIC_API_KEY>" | \
+  gcloud secrets versions add anthropic-api-key --data-file=- --project=productplanner-prod
+
+# 確認
+gcloud secrets versions access latest --secret="anthropic-api-key" --project=productplanner-prod
 ```
-
-出力例:
-```json
-"name": "受注",
-"id": "Label_1234567890123456789",
-```
-
-`"id"` の値（`Label_` から始まる文字列）が `GMAIL_LABEL_PROCESSED` に設定する値。
-
-### ラベルがまだない場合
-
-Gmail の設定画面（[mail.google.com → 設定 → ラベル](https://mail.google.com)）でラベルを作成してから上記コマンドを再実行する。
 
 ---
 
-## Step 4: Render に環境変数を設定する
+## Step 4: Gmail ネストラベルを作成する
+
+処理状態管理に使う 4 種のネストラベルを Gmail に作成する。
+
+Gmail の設定画面（[mail.google.com → 設定 → ラベル → 新しいラベルを作成](https://mail.google.com)）で以下を作成する。
+
+| ラベル名（例） | 用途 |
+|---|---|
+| `処理待ち/テナントA` | Gmail フィルタが受信時に自動付与 |
+| `処理中/テナントA` | Cron 処理開始時に自動遷移（二重処理防止） |
+| `処理済み/テナントA` | 正常完了時に自動遷移 |
+| `エラー/テナントA` | 例外発生時に自動遷移 |
+
+> テナント名部分（`テナントA`）はテナントごとに変える。プレフィックス（`処理待ち` 等）は環境変数で変更可能。
+
+### Gmail フィルタの設定
+
+Gmail の設定 → フィルタ → フィルタを作成 で以下を設定する。
+
+- **From:** （受注メールの送信元ドメイン、例: `@example-customer.co.jp`）
+- **ラベルを付ける:** `処理待ち/テナントA`
+
+---
+
+## Step 5: gmail_label_tenants テーブルにエントリを追加する
+
+Supabase ダッシュボード → SQL Editor で以下を実行する。
+
+```sql
+INSERT INTO gmail_label_tenants (label_name, tenant_id)
+VALUES ('テナントA', '<tenant_id_uuid>');
+```
+
+`tenant_id` は `tenants` テーブルから確認する。
+
+```sql
+SELECT id, name FROM tenants;
+```
+
+---
+
+## Step 6: Render に環境変数を設定する
 
 Render ダッシュボード → サービス選択 → **Environment** タブ で以下を設定する。
 
@@ -101,8 +140,21 @@ Render ダッシュボード → サービス選択 → **Environment** タブ �
 | `GMAIL_CLIENT_ID` | Step 2 で取得した値 |
 | `GMAIL_CLIENT_SECRET` | Step 2 で取得した値 |
 | `GMAIL_REFRESH_TOKEN` | Step 2 で取得した値 |
-| `GMAIL_QUERY_FILTER` | 例: `is:unread label:受注` |
-| `GMAIL_LABEL_PROCESSED` | Step 3 で確認した Label ID |
+| `ANTHROPIC_API_KEY` | Step 3 で登録した値 |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase ダッシュボード → Settings → API |
+| `SUPABASE_URL` | Supabase ダッシュボード → Settings → API |
+
+以下はデフォルト値から変更する場合のみ設定する。
+
+| Key | デフォルト | 説明 |
+|---|---|---|
+| `GMAIL_LABEL_PREFIX_PENDING` | `処理待ち` | — |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | `処理中` | — |
+| `GMAIL_LABEL_PREFIX_DONE` | `処理済み` | — |
+| `GMAIL_LABEL_PREFIX_ERROR` | `エラー` | — |
+| `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | — |
+| `PRODUCT_MATCH_THRESHOLD` | `0.3` | 類似度閾値（0〜1） |
+| `PRODUCT_MATCH_TOP_N` | `5` | 候補表示件数上限 |
 
 設定後、**Manual Deploy** でサービスを再デプロイする。
 
@@ -111,12 +163,12 @@ Render ダッシュボード → サービス選択 → **Environment** タブ �
 ```bash
 curl -s -X GET https://<render-service>.onrender.com/api/cron/gmail-poll \
   -H "Authorization: Bearer <CRON_SECRET>"
-# → {"processed": 0} または {"processed": N}
+# → {"processed": N, "errors": 0}
 ```
 
 ---
 
-## Step 5: Vercel に環境変数を設定する
+## Step 7: Vercel に環境変数を設定する
 
 Vercel ダッシュボード → プロジェクト選択 → **Settings → Environment Variables** で以下を設定する。
 
@@ -145,8 +197,14 @@ CRON_SECRET=<Step1の値>
 GMAIL_CLIENT_ID=<Step2の値>
 GMAIL_CLIENT_SECRET=<Step2の値>
 GMAIL_REFRESH_TOKEN=<Step2の値>
-GMAIL_QUERY_FILTER=is:unread
-GMAIL_LABEL_PROCESSED=<Step3のLabel ID>
+ANTHROPIC_API_KEY=<Step3の値>
+SUPABASE_SERVICE_ROLE_KEY=<Supabase Service Role Key>
+SUPABASE_URL=<Supabase URL>
+# 以下はデフォルト値から変更する場合のみ
+# GMAIL_LABEL_PREFIX_PENDING=処理待ち
+# EMAIL_EXTRACTION_MODEL=claude-haiku-4-5-20251001
+# PRODUCT_MATCH_THRESHOLD=0.3
+# PRODUCT_MATCH_TOP_N=5
 ```
 
 ```bash
@@ -161,6 +219,7 @@ BACKEND_URL=http://localhost:8000
 # バックエンドを起動した状態で
 curl -s http://localhost:8000/api/cron/gmail-poll \
   -H "Authorization: Bearer <CRON_SECRET>"
+# → {"processed": N, "errors": 0}
 ```
 
 ---
@@ -168,12 +227,13 @@ curl -s http://localhost:8000/api/cron/gmail-poll \
 ## 注意事項
 
 - `CRON_SECRET` は Render と Vercel で**必ず同じ値**を設定すること
+- `ANTHROPIC_API_KEY` と `SUPABASE_SERVICE_ROLE_KEY` は Secret Manager 管理必須。`.env` ファイルをリポジトリにコミットしないこと
 - `GMAIL_REFRESH_TOKEN` が無効化された場合は `scripts/get_gmail_refresh_token.py` を再実行して Secret Manager を更新し、Render の環境変数も差し替える（[gmail-oauth-setup.md](gmail-oauth-setup.md) 参照）
-- Vercel Cron の 5 分間隔実行は **Pro プラン以上**が必要。無料プランでは 1 日 2 回まで
+- Vercel Cron の 15 分間隔実行は **Pro プラン以上**が必要。無料プランでは 1 日 2 回まで
 
 ## 関連
 
 - #169: GCP プロジェクト基盤（[gcp-terraform-foundation.md](gcp-terraform-foundation.md)）
 - #170: Secret Manager リソース管理（[secret-manager-terraform.md](secret-manager-terraform.md)）
 - #171: Gmail OAuth2 認証情報セットアップ（[gmail-oauth-setup.md](gmail-oauth-setup.md)）
-- #165: Gmail ポーリング Vercel Cron ジョブ実装
+- #165 / #166 / #167: Gmail メール → 注文下書き自動作成パイプライン実装

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -1,0 +1,179 @@
+# 環境変数の取得・設定手順 — Gmail Cron ジョブ
+
+Issue: #165
+
+## 概要
+
+Gmail ポーリング Cron ジョブの動作に必要な環境変数を、GCP Secret Manager から取得して Render / Vercel に設定するまでの手順。
+
+---
+
+## 必要な環境変数一覧
+
+| 変数名 | 設定先 | 取得元 |
+|---|---|---|
+| `CRON_SECRET` | Render・Vercel（共通） | 自前生成 |
+| `GMAIL_CLIENT_ID` | Render | GCP Secret Manager |
+| `GMAIL_CLIENT_SECRET` | Render | GCP Secret Manager |
+| `GMAIL_REFRESH_TOKEN` | Render | GCP Secret Manager |
+| `GMAIL_QUERY_FILTER` | Render | 自前設定 |
+| `GMAIL_LABEL_PROCESSED` | Render | Gmail API で確認 |
+| `BACKEND_URL` | Vercel | Render のサービス URL |
+
+---
+
+## Step 1: CRON_SECRET を生成する
+
+```bash
+openssl rand -hex 32
+```
+
+出力された文字列をメモしておく。Render と Vercel の両方に同じ値を設定する。
+
+---
+
+## Step 2: Gmail 認証情報を GCP Secret Manager から取得する
+
+#171 で Secret Manager に投入済みの値を取得する。
+
+```bash
+# プロジェクトを設定
+gcloud config set project productplanner-prod
+
+# 各シークレットを表示
+gcloud secrets versions access latest --secret="gmail-oauth-client-id"
+gcloud secrets versions access latest --secret="gmail-oauth-client-secret"
+gcloud secrets versions access latest --secret="gmail-oauth-refresh-token"
+```
+
+各コマンドの出力が対応する環境変数の値になる。
+
+| コマンドの `--secret` | 対応する環境変数 |
+|---|---|
+| `gmail-oauth-client-id` | `GMAIL_CLIENT_ID` |
+| `gmail-oauth-client-secret` | `GMAIL_CLIENT_SECRET` |
+| `gmail-oauth-refresh-token` | `GMAIL_REFRESH_TOKEN` |
+
+---
+
+## Step 3: Gmail ラベル ID を確認する
+
+`GMAIL_LABEL_PROCESSED` には Gmail ラベルの**表示名ではなく ID**（`Label_XXXXXXXXX` 形式）を設定する必要がある。
+
+### ラベル一覧を取得
+
+```bash
+# access_token を取得（refresh_token から）
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  -d "client_id=$(gcloud secrets versions access latest --secret=gmail-oauth-client-id)" \
+  -d "client_secret=$(gcloud secrets versions access latest --secret=gmail-oauth-client-secret)" \
+  -d "refresh_token=$(gcloud secrets versions access latest --secret=gmail-oauth-refresh-token)" \
+  -d "grant_type=refresh_token" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# ラベル一覧を取得
+curl -s "https://gmail.googleapis.com/gmail/v1/users/me/labels" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  | python3 -m json.tool | grep -A1 '"name"'
+```
+
+出力例:
+```json
+"name": "受注",
+"id": "Label_1234567890123456789",
+```
+
+`"id"` の値（`Label_` から始まる文字列）が `GMAIL_LABEL_PROCESSED` に設定する値。
+
+### ラベルがまだない場合
+
+Gmail の設定画面（[mail.google.com → 設定 → ラベル](https://mail.google.com)）でラベルを作成してから上記コマンドを再実行する。
+
+---
+
+## Step 4: Render に環境変数を設定する
+
+Render ダッシュボード → サービス選択 → **Environment** タブ で以下を設定する。
+
+| Key | Value |
+|---|---|
+| `CRON_SECRET` | Step 1 で生成した値 |
+| `GMAIL_CLIENT_ID` | Step 2 で取得した値 |
+| `GMAIL_CLIENT_SECRET` | Step 2 で取得した値 |
+| `GMAIL_REFRESH_TOKEN` | Step 2 で取得した値 |
+| `GMAIL_QUERY_FILTER` | 例: `is:unread label:受注` |
+| `GMAIL_LABEL_PROCESSED` | Step 3 で確認した Label ID |
+
+設定後、**Manual Deploy** でサービスを再デプロイする。
+
+### 動作確認
+
+```bash
+curl -s -X GET https://<render-service>.onrender.com/api/cron/gmail-poll \
+  -H "Authorization: Bearer <CRON_SECRET>"
+# → {"processed": 0} または {"processed": N}
+```
+
+---
+
+## Step 5: Vercel に環境変数を設定する
+
+Vercel ダッシュボード → プロジェクト選択 → **Settings → Environment Variables** で以下を設定する。
+
+| Key | Value | 環境 |
+|---|---|---|
+| `CRON_SECRET` | Step 1 で生成した値 | Production / Preview / Development |
+| `BACKEND_URL` | 例: `https://<render-service>.onrender.com` | Production / Preview |
+
+> `BACKEND_URL` は末尾スラッシュなし。`NEXT_PUBLIC_` プレフィックスは不要（サーバーサイドのみ）。
+
+設定後、**Redeploy** を実行して反映する。
+
+### Cron ジョブの確認
+
+Vercel ダッシュボード → プロジェクト → **Cron Jobs** タブから手動実行できる（Pro プラン以上）。
+
+---
+
+## ローカル開発での設定
+
+`backend/.env` と `frontend/.env.local` に追記する。
+
+```bash
+# backend/.env
+CRON_SECRET=<Step1の値>
+GMAIL_CLIENT_ID=<Step2の値>
+GMAIL_CLIENT_SECRET=<Step2の値>
+GMAIL_REFRESH_TOKEN=<Step2の値>
+GMAIL_QUERY_FILTER=is:unread
+GMAIL_LABEL_PROCESSED=<Step3のLabel ID>
+```
+
+```bash
+# frontend/.env.local
+CRON_SECRET=<Step1の値>
+BACKEND_URL=http://localhost:8000
+```
+
+ローカルでの動作確認:
+
+```bash
+# バックエンドを起動した状態で
+curl -s http://localhost:8000/api/cron/gmail-poll \
+  -H "Authorization: Bearer <CRON_SECRET>"
+```
+
+---
+
+## 注意事項
+
+- `CRON_SECRET` は Render と Vercel で**必ず同じ値**を設定すること
+- `GMAIL_REFRESH_TOKEN` が無効化された場合は `scripts/get_gmail_refresh_token.py` を再実行して Secret Manager を更新し、Render の環境変数も差し替える（[gmail-oauth-setup.md](gmail-oauth-setup.md) 参照）
+- Vercel Cron の 5 分間隔実行は **Pro プラン以上**が必要。無料プランでは 1 日 2 回まで
+
+## 関連
+
+- #169: GCP プロジェクト基盤（[gcp-terraform-foundation.md](gcp-terraform-foundation.md)）
+- #170: Secret Manager リソース管理（[secret-manager-terraform.md](secret-manager-terraform.md)）
+- #171: Gmail OAuth2 認証情報セットアップ（[gmail-oauth-setup.md](gmail-oauth-setup.md)）
+- #165: Gmail ポーリング Vercel Cron ジョブ実装

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -18,10 +18,10 @@ Gmail ポーリング Cron ジョブの動作に必要な環境変数を、GCP S
 | `GMAIL_CLIENT_ID` | GCP Secret Manager | — |
 | `GMAIL_CLIENT_SECRET` | GCP Secret Manager | — |
 | `GMAIL_REFRESH_TOKEN` | GCP Secret Manager | — |
-| `GMAIL_LABEL_PREFIX_PENDING` | 自前設定 | デフォルト: `処理待ち` |
-| `GMAIL_LABEL_PREFIX_PROCESSING` | 自前設定 | デフォルト: `処理中` |
-| `GMAIL_LABEL_PREFIX_DONE` | 自前設定 | デフォルト: `処理済み` |
-| `GMAIL_LABEL_PREFIX_ERROR` | 自前設定 | デフォルト: `エラー` |
+| `GMAIL_LABEL_PREFIX_PENDING` | 自前設定 | デフォルト: `pp-pending` |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | 自前設定 | デフォルト: `pp-processing` |
+| `GMAIL_LABEL_PREFIX_DONE` | 自前設定 | デフォルト: `pp-done` |
+| `GMAIL_LABEL_PREFIX_ERROR` | 自前設定 | デフォルト: `pp-error` |
 | `ANTHROPIC_API_KEY` | GCP Secret Manager | Claude メール解析用 |
 | `EMAIL_EXTRACTION_MODEL` | 自前設定 | デフォルト: `claude-haiku-4-5-20251001` |
 | `PRODUCT_MATCH_THRESHOLD` | 自前設定 | デフォルト: `0.3` |
@@ -97,19 +97,19 @@ Gmail の設定画面（[mail.google.com → 設定 → ラベル → 新しい�
 
 | ラベル名（例） | 用途 |
 |---|---|
-| `処理待ち/テナントA` | Gmail フィルタが受信時に自動付与 |
-| `処理中/テナントA` | Cron 処理開始時に自動遷移（二重処理防止） |
-| `処理済み/テナントA` | 正常完了時に自動遷移 |
-| `エラー/テナントA` | 例外発生時に自動遷移 |
+| `pp-pending/テナントA` | Gmail フィルタが受信時に自動付与 |
+| `pp-processing/テナントA` | Cron 処理開始時に自動遷移（二重処理防止） |
+| `pp-done/テナントA` | 正常完了時に自動遷移 |
+| `pp-error/テナントA` | 例外発生時に自動遷移 |
 
-> テナント名部分（`テナントA`）はテナントごとに変える。プレフィックス（`処理待ち` 等）は環境変数で変更可能。
+> テナント名部分（`テナントA`）はテナントごとに変える。プレフィックス（`pp-pending` 等）は環境変数で変更可能。
 
 ### Gmail フィルタの設定
 
 Gmail の設定 → フィルタ → フィルタを作成 で以下を設定する。
 
 - **From:** （受注メールの送信元ドメイン、例: `@example-customer.co.jp`）
-- **ラベルを付ける:** `処理待ち/テナントA`
+- **ラベルを付ける:** `pp-pending/テナントA`
 
 ---
 
@@ -148,10 +148,10 @@ Render ダッシュボード → サービス選択 → **Environment** タブ �
 
 | Key | デフォルト | 説明 |
 |---|---|---|
-| `GMAIL_LABEL_PREFIX_PENDING` | `処理待ち` | — |
-| `GMAIL_LABEL_PREFIX_PROCESSING` | `処理中` | — |
-| `GMAIL_LABEL_PREFIX_DONE` | `処理済み` | — |
-| `GMAIL_LABEL_PREFIX_ERROR` | `エラー` | — |
+| `GMAIL_LABEL_PREFIX_PENDING` | `pp-pending` | — |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | `pp-processing` | — |
+| `GMAIL_LABEL_PREFIX_DONE` | `pp-done` | — |
+| `GMAIL_LABEL_PREFIX_ERROR` | `pp-error` | — |
 | `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | — |
 | `PRODUCT_MATCH_THRESHOLD` | `0.3` | 類似度閾値（0〜1） |
 | `PRODUCT_MATCH_TOP_N` | `5` | 候補表示件数上限 |
@@ -201,7 +201,7 @@ ANTHROPIC_API_KEY=<Step3の値>
 SUPABASE_SERVICE_ROLE_KEY=<Supabase Service Role Key>
 SUPABASE_URL=<Supabase URL>
 # 以下はデフォルト値から変更する場合のみ
-# GMAIL_LABEL_PREFIX_PENDING=処理待ち
+# GMAIL_LABEL_PREFIX_PENDING=pp-pending
 # EMAIL_EXTRACTION_MODEL=claude-haiku-4-5-20251001
 # PRODUCT_MATCH_THRESHOLD=0.3
 # PRODUCT_MATCH_TOP_N=5

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -229,7 +229,7 @@ curl -s http://localhost:8000/api/cron/gmail-poll \
 - `CRON_SECRET` は Render と Vercel で**必ず同じ値**を設定すること
 - `ANTHROPIC_API_KEY` と `SUPABASE_SERVICE_ROLE_KEY` は Secret Manager 管理必須。`.env` ファイルをリポジトリにコミットしないこと
 - `GMAIL_REFRESH_TOKEN` が無効化された場合は `scripts/get_gmail_refresh_token.py` を再実行して Secret Manager を更新し、Render の環境変数も差し替える（[gmail-oauth-setup.md](gmail-oauth-setup.md) 参照）
-- Vercel Cron の 15 分間隔実行は **Pro プラン以上**が必要。無料プランでは 1 日 2 回まで
+- Vercel Cron は無料プランで 1 日 2 回まで。現在は `0 8,17 * * *`（8 時・17 時）に設定
 
 ## 関連
 

--- a/docs/infra/gcp-terraform-foundation.md
+++ b/docs/infra/gcp-terraform-foundation.md
@@ -88,4 +88,4 @@ terraform apply -var-file=environments/prod/terraform.tfvars
 
 - #170: Secret Manager リソース管理（[secret-manager-terraform.md](secret-manager-terraform.md)）
 - #171: Gmail OAuth2 認証情報セットアップ（[gmail-oauth-setup.md](gmail-oauth-setup.md)）
-- #165: Gmail タイマートリガー Azure Function（後続）
+- #165: Gmail ポーリング Vercel Cron ジョブ（後続）

--- a/docs/infra/gmail-oauth-setup.md
+++ b/docs/infra/gmail-oauth-setup.md
@@ -62,5 +62,5 @@ gcloud secrets versions access latest --secret="gmail-oauth-refresh-token"
 
 - #169: GCP プロジェクト基盤
 - #170: Secret Manager Terraform リソース管理
-- #165: Gmail タイマートリガー Azure Function（本セットアップ完了後に実装）
+- #165: Gmail ポーリング Vercel Cron ジョブ（本セットアップ完了後に実装）
 - `scripts/get_gmail_refresh_token.py`

--- a/docs/specs/GMAIL_ORDER_INTAKE.md
+++ b/docs/specs/GMAIL_ORDER_INTAKE.md
@@ -89,7 +89,7 @@ sequenceDiagram
 
 ### 1. Vercel Cron トリガー
 
-- スケジュール: `*/15 * * * *`（15 分間隔）
+- スケジュール: `0 8,17 * * *`（8 時・17 時の 1 日 2 回、Vercel 無料プランの上限に合わせた設定）
 - 設定ファイル: [frontend/vercel.json](../../frontend/vercel.json)
 - Vercel が自動で `Authorization: Bearer <CRON_SECRET>` を付与する
 

--- a/docs/specs/GMAIL_ORDER_INTAKE.md
+++ b/docs/specs/GMAIL_ORDER_INTAKE.md
@@ -1,0 +1,322 @@
+# Gmail → ProductPlanner 注文下書き作成 仕様
+
+Gmail の受注メールを定期ポーリングし、Claude で注文情報を抽出して ProductPlanner に下書き (draft) として自動起票する機能の仕様。
+
+---
+
+## 概要
+
+受注メールが届くたびに手動でシステムへ転記する作業を自動化する。  
+LLM 解析の誤りに備え、起票は必ず **下書き状態** とし、担当者がレビュー・確定するワークフローを取る。
+
+---
+
+## システム構成
+
+| コンポーネント | 役割 |
+|---|---|
+| Gmail フィルタ | 受信時に `処理待ち/{テナント名}` ラベルを自動付与 |
+| Vercel Cron | 15 分ごとに Next.js API ルートを呼び出すスケジューラ |
+| Next.js API Route | Cron Secret を検証し、Render バックエンドへリクエストを転送 |
+| FastAPI (Render) | Gmail API 呼び出し・LLM 解析・注文下書き作成を実行 |
+| Gmail API | ラベル別メール取得と状態ラベルの遷移管理 |
+| Claude Haiku | メール本文から注文フィールドをツールユースで抽出 |
+| pg_trgm (Supabase) | 抽出製品名テキストから DB 製品 ID を類似度検索 |
+| Supabase | 下書き注文の永続化・テナント解決テーブル |
+
+---
+
+## ラベル設計
+
+メールの処理状態を Gmail のネストラベルで管理する。
+
+```
+処理待ち/テナントA    ← Gmail フィルタが受信時に自動付与
+処理中/テナントA      ← Cron 処理開始時に遷移（二重処理防止）
+処理済み/テナントA    ← 正常完了時に遷移
+エラー/テナントA      ← 例外発生時に遷移
+```
+
+プレフィックスは環境変数で変更可能（[環境変数一覧](#環境変数一覧) 参照）。  
+テナント名部分は `gmail_label_tenants` テーブルで `tenant_id` に解決する。
+
+---
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant GF as Gmail フィルタ
+    participant GM as Gmail API
+    participant VC as Vercel Cron
+    participant NR as Next.js<br>/api/cron/gmail-poll
+    participant BE as FastAPI<br>/api/cron/gmail-poll
+    participant LLM as Claude Haiku
+    participant PG as Supabase<br>pg_trgm
+    participant DB as Supabase<br>orders
+
+    GF->>GM: 受信メールに 処理待ち/テナントA を付与
+
+    VC->>NR: GET /api/cron/gmail-poll (15分ごと)
+    NR->>NR: CRON_SECRET 検証
+    NR->>BE: GET /api/cron/gmail-poll
+
+    BE->>GM: labels.list() → ラベル ID マップ取得
+    BE->>GM: messages.list(labelIds=[処理待ち/*])
+    GM-->>BE: メッセージ ID リスト
+
+    loop 各メール
+        BE->>GM: modify(処理待ち→処理中)
+        BE->>GM: messages.get(id, format=full)
+        GM-->>BE: 本文テキスト
+        BE->>DB: gmail_label_tenants lookup → tenant_id
+        BE->>LLM: extract_order_fields (tool use)
+        LLM-->>BE: {product_name, quantity, deadline_date, order_number}
+        BE->>PG: match_products_by_name RPC
+        PG-->>BE: [{id, name, score}, ...]
+        BE->>DB: customers lookup/auto-create
+        BE->>DB: orders INSERT (status=draft)
+        BE->>GM: modify(処理中→処理済み)
+    end
+
+    BE-->>NR: {processed: N, errors: E}
+    NR-->>VC: 200 OK
+```
+
+---
+
+## 処理フロー詳細
+
+### 1. Vercel Cron トリガー
+
+- スケジュール: `*/15 * * * *`（15 分間隔）
+- 設定ファイル: [frontend/vercel.json](../../frontend/vercel.json)
+- Vercel が自動で `Authorization: Bearer <CRON_SECRET>` を付与する
+
+### 2. Next.js API Route (`/api/cron/gmail-poll`)
+
+- `CRON_SECRET` を検証して不正リクエストを排除
+- `BACKEND_URL` へリクエストを転送
+- 実装: [frontend/src/app/api/cron/gmail-poll/route.ts](../../frontend/src/app/api/cron/gmail-poll/route.ts)
+
+### 3. FastAPI エンドポイント (`GET /api/cron/gmail-poll`)
+
+- `CRON_SECRET` を `secrets.compare_digest` でタイミング攻撃対策付き検証
+- `get_supabase_admin_client()` で Service Role Key クライアントを生成し `poll_unread_emails(db)` を呼び出す
+- 実装: [backend/app/routers/cron/gmail_poll.py](../../backend/app/routers/cron/gmail_poll.py)
+
+### 4. Gmail ラベルポーリング
+
+| 項目 | 詳細 |
+|---|---|
+| 取得対象 | `処理待ち/*` ラベルを持つメール全件 |
+| 二重処理防止 | 取得直後に `処理待ち → 処理中` へ遷移 |
+| ページング | `nextPageToken` によるページ送り（最大 500 件/回） |
+| エラー時 | メール単位でキャッチし `処理中 → エラー` へ遷移。他メールの処理は継続 |
+
+実装: [backend/app/services/gmail_service.py](../../backend/app/services/gmail_service.py)
+
+### 5. テナント解決
+
+`処理待ち/テナントA` ラベルのサフィックス（`テナントA`）を `gmail_label_tenants` テーブルに問い合わせ `tenant_id` (UUID) を取得する。  
+エントリが存在しない場合はエラーとして処理を中断し `エラー` ラベルへ遷移する。
+
+### 6. Claude による注文フィールド抽出
+
+メール本文を Claude Haiku に渡し、`extract_order_fields` ツールを強制呼び出しで構造化抽出する。
+
+| フィールド | 型 | 抽出不可時 |
+|---|---|---|
+| `product_name` | `string \| null` | null のまま起票 |
+| `quantity` | `integer \| null` | null のまま起票 |
+| `deadline_date` | `string (YYYY-MM-DD) \| null` | null のまま起票 |
+| `order_number` | `string \| null` | null のまま起票 |
+
+使用モデル: `EMAIL_EXTRACTION_MODEL` 環境変数（デフォルト: `claude-haiku-4-5-20251001`）  
+実装: [backend/app/services/email_extraction_service.py](../../backend/app/services/email_extraction_service.py)
+
+### 7. 製品 ID 解決（pg_trgm）
+
+抽出した `product_name` を `match_products_by_name` RPC に渡し、類似度スコアで候補を取得する。
+
+| 候補件数 | 処理 |
+|---|---|
+| 1 件 | `product_id` を自動確定 |
+| 複数件 | `product_id = null`、`product_candidates` JSONB に上位 N 件を格納 |
+| 0 件 | `product_id = null`、`product_candidates = null` |
+
+```json
+// product_candidates 格納例
+[
+  {"product_id": 12, "name": "アルミ板 A2024-T3", "score": 0.82},
+  {"product_id": 7,  "name": "アルミ板 A6061-T6", "score": 0.71}
+]
+```
+
+| 環境変数 | デフォルト | 用途 |
+|---|---|---|
+| `PRODUCT_MATCH_THRESHOLD` | `0.3` | 閾値未満の候補を除外 |
+| `PRODUCT_MATCH_TOP_N` | `5` | UI 表示件数上限（DB クエリは全件取得） |
+
+実装: [backend/app/services/product_matching_service.py](../../backend/app/services/product_matching_service.py)
+
+### 8. 顧客 ID 解決
+
+本文の転送ブロックから送信元メールアドレスを正規表現で抽出する。  
+英語 (`From: Name <addr@example.com>`) と日本語 (`差出人: addr@example.com`) の両形式に対応。
+
+```
+extract_sender_email(body) → "customer@example.com"
+  ↓
+customers テーブルで (tenant_id, email) 検索
+  ↓ 存在する → customer_id を利用
+  ↓ 存在しない → email・name="email値" で draft 顧客を自動作成
+```
+
+実装: [backend/app/services/customer_matching_service.py](../../backend/app/services/customer_matching_service.py)
+
+### 9. 注文下書き作成
+
+```json
+{
+  "tenant_id": "<uuid>",
+  "source_type": "email",
+  "source_raw": "<メール本文全体>",
+  "status": "draft",
+  "product_id": 12,
+  "quantity": 50,
+  "deadline_date": "2026-07-31",
+  "order_number": "PO-2026-001",
+  "extracted_product_name": "アルミ板 A2024",
+  "product_candidates": [...],
+  "customer_id": 8
+}
+```
+
+- `source_type: "email"` で手動起票と区別できる
+- `source_raw` に原文を保存し、解析ミス時の確認・修正を可能にする
+- `product_id` / `quantity` は nullable（抽出失敗時に担当者が補完）
+
+---
+
+## DB スキーマ変更
+
+マイグレーションファイル: [supabase/migrations/20260618000000_gmail_intake_v2.sql](../../supabase/migrations/20260618000000_gmail_intake_v2.sql)
+
+### orders テーブル
+
+| カラム | 変更内容 |
+|---|---|
+| `product_id` | NOT NULL → NULL 許可 |
+| `quantity` | NOT NULL → NULL 許可 |
+| `extracted_product_name` | `text` 追加（Claude 抽出生テキスト） |
+| `product_candidates` | `jsonb` 追加（pg_trgm 候補リスト） |
+
+### gmail_label_tenants テーブル（新規）
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `id` | `uuid` | PK |
+| `label_name` | `text UNIQUE` | テナント名（例: `テナントA`） |
+| `tenant_id` | `uuid` | FK → tenants.id |
+
+RLS 有効。Cron は Service Role Key でアクセスするため RLS ポリシーは不要。
+
+### products テーブル
+
+- GIN インデックス追加: `products_name_trgm_idx` (gin_trgm_ops) — 類似度検索の高速化
+- pg_trgm 拡張: `CREATE EXTENSION IF NOT EXISTS pg_trgm`
+
+### match_products_by_name RPC
+
+```sql
+SELECT id, name, similarity(name, query_text) AS score
+FROM products
+WHERE tenant_id = p_tenant_id
+  AND similarity(name, query_text) >= similarity_threshold
+ORDER BY score DESC;
+```
+
+---
+
+## 認証・セキュリティ
+
+| 項目 | 方式 |
+|---|---|
+| Cron 認証 | `CRON_SECRET` Bearer トークン（`secrets.compare_digest` でタイミング攻撃対策） |
+| Gmail 認証 | OAuth2 Refresh Token |
+| Gmail スコープ | `https://www.googleapis.com/auth/gmail.modify`（読み取り＋ラベル変更のみ） |
+| Supabase アクセス | Service Role Key（Secret Manager 管理必須。アプリコード内での直接参照禁止） |
+| Claude API キー | `ANTHROPIC_API_KEY`（Secret Manager 管理必須） |
+
+環境変数の取得・設定手順: [docs/infra/env-setup-gmail-cron.md](../infra/env-setup-gmail-cron.md)
+
+---
+
+## 環境変数一覧
+
+| 変数名 | デフォルト | 説明 |
+|---|---|---|
+| `GMAIL_CLIENT_ID` | — | Gmail OAuth2 クライアント ID |
+| `GMAIL_CLIENT_SECRET` | — | Gmail OAuth2 クライアントシークレット |
+| `GMAIL_REFRESH_TOKEN` | — | Gmail OAuth2 リフレッシュトークン |
+| `GMAIL_LABEL_PREFIX_PENDING` | `処理待ち` | 処理待ちラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | `処理中` | 処理中ラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_DONE` | `処理済み` | 処理済みラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_ERROR` | `エラー` | エラーラベルプレフィックス |
+| `CRON_SECRET` | — | Vercel Cron 認証トークン |
+| `ANTHROPIC_API_KEY` | — | Claude API キー |
+| `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | 使用する Claude モデル |
+| `PRODUCT_MATCH_THRESHOLD` | `0.3` | pg_trgm 類似度閾値 |
+| `PRODUCT_MATCH_TOP_N` | `5` | 候補表示上限件数 |
+| `SUPABASE_SERVICE_ROLE_KEY` | — | Cron 用 Service Role Key（Secret Manager 管理） |
+
+---
+
+## 注文レビューフロー（運用）
+
+```
+[Gmail 受信]
+    ↓ Gmail フィルタ
+[処理待ち/テナントA ラベル付与]
+    ↓ Vercel Cron (15分ごと)
+[Claude 抽出 → pg_trgm マッチ → draft 注文作成]
+    ↓
+[処理済み/テナントA ラベル付与]
+    ↓
+[担当者が ProductPlanner でレビュー]
+    ↓
+[確定] または [フィールド修正して確定]
+```
+
+- `source_type === "email"` の注文は一覧で識別できるようにする（UI 実装は #168）
+- `product_candidates` を参照して担当者が正しい製品 ID を選択できる
+- `source_raw` を参照して解析ミスを人間が修正できる
+
+---
+
+## 実装状況
+
+| フェーズ | 機能 | 状況 |
+|---|---|:---:|
+| 基盤 | DB: `order_number` nullable / `source_type` / `source_raw` 追加 | ✅ #155 |
+| 基盤 | Backend: `OrderCreate` スキーマ更新 | ✅ #155 |
+| 基盤 | Frontend: 注文番号任意化・メール本文表示 UI | ✅ #155 |
+| Cron | Vercel Cron ジョブ定義 (15 分間隔) | ✅ #165 |
+| Cron | Next.js API Route（転送ハンドラ） | ✅ #165 |
+| Cron | FastAPI エンドポイント + Gmail ラベルポーリング | ✅ #165 |
+| DB | pg_trgm 拡張・GIN インデックス・`match_products_by_name` RPC | ✅ #165 |
+| DB | `gmail_label_tenants` テーブル | ✅ #165 |
+| DB | `orders.product_id` nullable / `extracted_product_name` / `product_candidates` 追加 | ✅ #165 |
+| 解析 | Claude Haiku によるメール本文フィールド抽出 (`email_extraction_service.py`) | ✅ #166 |
+| 解析 | pg_trgm 製品 ID 解決 (`product_matching_service.py`) | ✅ #167 |
+| 解析 | 転送ブロック解析 + 顧客 ID 解決/自動作成 (`customer_matching_service.py`) | ✅ #167 |
+| UI | メール起票注文の一覧フィルタ・バッジ表示・製品候補選択 | ❌ #168 |
+
+---
+
+## 関連ドキュメント
+
+- [メール起票による注文入力設計](../features/email-order-intake.md)
+- [Gmail OAuth セットアップ](../infra/gmail-oauth-setup.md)
+- [Gmail Cron 環境変数セットアップ](../infra/env-setup-gmail-cron.md)

--- a/docs/specs/GMAIL_ORDER_INTAKE.md
+++ b/docs/specs/GMAIL_ORDER_INTAKE.md
@@ -15,7 +15,7 @@ LLM 解析の誤りに備え、起票は必ず **下書き状態** とし、担�
 
 | コンポーネント | 役割 |
 |---|---|
-| Gmail フィルタ | 受信時に `処理待ち/{テナント名}` ラベルを自動付与 |
+| Gmail フィルタ | 受信時に `pp-pending/{テナント名}` ラベルを自動付与 |
 | Vercel Cron | 15 分ごとに Next.js API ルートを呼び出すスケジューラ |
 | Next.js API Route | Cron Secret を検証し、Render バックエンドへリクエストを転送 |
 | FastAPI (Render) | Gmail API 呼び出し・LLM 解析・注文下書き作成を実行 |
@@ -31,10 +31,10 @@ LLM 解析の誤りに備え、起票は必ず **下書き状態** とし、担�
 メールの処理状態を Gmail のネストラベルで管理する。
 
 ```
-処理待ち/テナントA    ← Gmail フィルタが受信時に自動付与
-処理中/テナントA      ← Cron 処理開始時に遷移（二重処理防止）
-処理済み/テナントA    ← 正常完了時に遷移
-エラー/テナントA      ← 例外発生時に遷移
+pp-pending/テナントA    ← Gmail フィルタが受信時に自動付与
+pp-processing/テナントA ← Cron 処理開始時に遷移（二重処理防止）
+pp-done/テナントA       ← 正常完了時に遷移
+pp-error/テナントA      ← 例外発生時に遷移
 ```
 
 プレフィックスは環境変数で変更可能（[環境変数一覧](#環境変数一覧) 参照）。  
@@ -55,18 +55,18 @@ sequenceDiagram
     participant PG as Supabase<br>pg_trgm
     participant DB as Supabase<br>orders
 
-    GF->>GM: 受信メールに 処理待ち/テナントA を付与
+    GF->>GM: 受信メールに pp-pending/テナントA を付与
 
     VC->>NR: GET /api/cron/gmail-poll (15分ごと)
     NR->>NR: CRON_SECRET 検証
     NR->>BE: GET /api/cron/gmail-poll
 
     BE->>GM: labels.list() → ラベル ID マップ取得
-    BE->>GM: messages.list(labelIds=[処理待ち/*])
+    BE->>GM: messages.list(labelIds=[pp-pending/*])
     GM-->>BE: メッセージ ID リスト
 
     loop 各メール
-        BE->>GM: modify(処理待ち→処理中)
+        BE->>GM: modify(pp-pending→pp-processing)
         BE->>GM: messages.get(id, format=full)
         GM-->>BE: 本文テキスト
         BE->>DB: gmail_label_tenants lookup → tenant_id
@@ -76,7 +76,7 @@ sequenceDiagram
         PG-->>BE: [{id, name, score}, ...]
         BE->>DB: customers lookup/auto-create
         BE->>DB: orders INSERT (status=draft)
-        BE->>GM: modify(処理中→処理済み)
+        BE->>GM: modify(pp-processing→pp-done)
     end
 
     BE-->>NR: {processed: N, errors: E}
@@ -109,17 +109,17 @@ sequenceDiagram
 
 | 項目 | 詳細 |
 |---|---|
-| 取得対象 | `処理待ち/*` ラベルを持つメール全件 |
-| 二重処理防止 | 取得直後に `処理待ち → 処理中` へ遷移 |
+| 取得対象 | `pp-pending/*` ラベルを持つメール全件 |
+| 二重処理防止 | 取得直後に `pp-pending → pp-processing` へ遷移 |
 | ページング | `nextPageToken` によるページ送り（最大 500 件/回） |
-| エラー時 | メール単位でキャッチし `処理中 → エラー` へ遷移。他メールの処理は継続 |
+| エラー時 | メール単位でキャッチし `pp-processing → pp-error` へ遷移。他メールの処理は継続 |
 
 実装: [backend/app/services/gmail_service.py](../../backend/app/services/gmail_service.py)
 
 ### 5. テナント解決
 
-`処理待ち/テナントA` ラベルのサフィックス（`テナントA`）を `gmail_label_tenants` テーブルに問い合わせ `tenant_id` (UUID) を取得する。  
-エントリが存在しない場合はエラーとして処理を中断し `エラー` ラベルへ遷移する。
+`pp-pending/テナントA` ラベルのサフィックス（`テナントA`）を `gmail_label_tenants` テーブルに問い合わせ `tenant_id` (UUID) を取得する。  
+エントリが存在しない場合はエラーとして処理を中断し `pp-error` ラベルへ遷移する。
 
 ### 6. Claude による注文フィールド抽出
 
@@ -260,10 +260,10 @@ ORDER BY score DESC;
 | `GMAIL_CLIENT_ID` | — | Gmail OAuth2 クライアント ID |
 | `GMAIL_CLIENT_SECRET` | — | Gmail OAuth2 クライアントシークレット |
 | `GMAIL_REFRESH_TOKEN` | — | Gmail OAuth2 リフレッシュトークン |
-| `GMAIL_LABEL_PREFIX_PENDING` | `処理待ち` | 処理待ちラベルプレフィックス |
-| `GMAIL_LABEL_PREFIX_PROCESSING` | `処理中` | 処理中ラベルプレフィックス |
-| `GMAIL_LABEL_PREFIX_DONE` | `処理済み` | 処理済みラベルプレフィックス |
-| `GMAIL_LABEL_PREFIX_ERROR` | `エラー` | エラーラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_PENDING` | `pp-pending` | 処理待ちラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_PROCESSING` | `pp-processing` | 処理中ラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_DONE` | `pp-done` | 処理済みラベルプレフィックス |
+| `GMAIL_LABEL_PREFIX_ERROR` | `pp-error` | エラーラベルプレフィックス |
 | `CRON_SECRET` | — | Vercel Cron 認証トークン |
 | `ANTHROPIC_API_KEY` | — | Claude API キー |
 | `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | 使用する Claude モデル |
@@ -278,11 +278,11 @@ ORDER BY score DESC;
 ```
 [Gmail 受信]
     ↓ Gmail フィルタ
-[処理待ち/テナントA ラベル付与]
+[pp-pending/テナントA ラベル付与]
     ↓ Vercel Cron (15分ごと)
 [Claude 抽出 → pg_trgm マッチ → draft 注文作成]
     ↓
-[処理済み/テナントA ラベル付与]
+[pp-done/テナントA ラベル付与]
     ↓
 [担当者が ProductPlanner でレビュー]
     ↓

--- a/frontend/.env.local.sample
+++ b/frontend/.env.local.sample
@@ -1,0 +1,31 @@
+# ============================================================
+# Supabase
+# ============================================================
+# ローカル: supabase start で表示される値を使用
+# 本番: Supabase ダッシュボード → Settings → API
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_SECRET_KEY=your_supabase_service_role_key
+
+# ============================================================
+# バックエンド API
+# ============================================================
+# ローカル開発時
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Vercel → Render 転送用 (本番・Preview 環境のみ)
+# 末尾スラッシュなし / NEXT_PUBLIC_ プレフィックス不要
+BACKEND_URL=https://your-render-service.onrender.com
+
+# ============================================================
+# Cron 認証
+# ============================================================
+# 生成方法: openssl rand -hex 32
+# backend/.env の CRON_SECRET と同じ値を設定すること
+CRON_SECRET=your_cron_secret
+
+# ============================================================
+# テスト用 (ローカル開発のみ)
+# ============================================================
+NEXT_PUBLIC_TEST_USER=test@example.com
+NEXT_PUBLIC_TEST_PASSWORD=Test123!

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env*.sample
 
 # vercel
 .vercel

--- a/frontend/src/app/api/cron/gmail-poll/route.ts
+++ b/frontend/src/app/api/cron/gmail-poll/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /api/cron/gmail-poll
+ *
+ * Vercel Cron がこのルートを 5 分ごとに呼び出す。
+ * Vercel は本番環境で自動的に Authorization: Bearer <CRON_SECRET> を付与する。
+ * このハンドラはトークンを検証し、Render バックエンドの同名エンドポイントへ転送する。
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const cronSecret = process.env.CRON_SECRET;
+  const backendUrl = process.env.BACKEND_URL;
+
+  if (!cronSecret || !backendUrl) {
+    console.error("[gmail-poll] CRON_SECRET or BACKEND_URL is not set.");
+    return NextResponse.json(
+      { error: "Server misconfiguration." },
+      { status: 500 }
+    );
+  }
+
+  const authHeader = request.headers.get("authorization") ?? "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+
+  if (token !== cronSecret) {
+    console.warn("[gmail-poll] Unauthorized request: token mismatch.");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const targetUrl = `${backendUrl}/api/cron/gmail-poll`;
+  console.log(`[gmail-poll] Forwarding to ${targetUrl}`);
+
+  let backendResponse: Response;
+  try {
+    backendResponse = await fetch(targetUrl, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${cronSecret}` },
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("[gmail-poll] Backend unreachable:", err);
+    return NextResponse.json({ error: "Backend unreachable." }, { status: 502 });
+  }
+
+  const data = await backendResponse.json();
+
+  if (!backendResponse.ok) {
+    console.error("[gmail-poll] Backend returned error:", data);
+    return NextResponse.json(data, { status: backendResponse.status });
+  }
+
+  console.log("[gmail-poll] Success:", data);
+  return NextResponse.json(data, { status: 200 });
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/gmail-poll",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/gmail-poll",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 8,17 * * *"
     }
   ]
 }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/gmail-poll",
-      "schedule": "0 8,17 * * *"
+      "schedule": "0 8 * * *"
     }
   ]
 }

--- a/supabase/migrations/20260618000000_gmail_intake_v2.sql
+++ b/supabase/migrations/20260618000000_gmail_intake_v2.sql
@@ -1,0 +1,68 @@
+-- ==========================================
+-- Gmail Order Intake v2
+-- ==========================================
+
+-- pg_trgm: 製品名の類似度検索
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS products_name_trgm_idx
+  ON products USING gin (name gin_trgm_ops);
+
+-- ==========================================
+-- orders: email 起票向けカラム追加
+-- ==========================================
+
+-- product_id を nullable に（メール起票時は抽出できない場合あり）
+ALTER TABLE orders ALTER COLUMN product_id DROP NOT NULL;
+
+-- quantity を nullable に（抽出できない場合は 0 でなく null として担当者が確認）
+ALTER TABLE orders ALTER COLUMN quantity DROP NOT NULL;
+
+-- Claude が抽出した生の製品名文字列
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS extracted_product_name text;
+
+-- pg_trgm 候補リスト: [{"product_id": 12, "name": "...", "score": 0.82}, ...]
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS product_candidates jsonb;
+
+-- ==========================================
+-- gmail_label_tenants: ラベル名 → tenant_id マッピング
+-- ==========================================
+CREATE TABLE IF NOT EXISTS gmail_label_tenants (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  label_name  text NOT NULL UNIQUE,  -- e.g. "テナントA"
+  tenant_id   uuid NOT NULL REFERENCES tenants(id),
+  created_at  timestamptz DEFAULT now()
+);
+
+ALTER TABLE gmail_label_tenants ENABLE ROW LEVEL SECURITY;
+-- Cron は Service Role Key でアクセスするため RLS ポリシーは不要
+
+-- ==========================================
+-- customers: email 検索用インデックス
+-- ==========================================
+CREATE INDEX IF NOT EXISTS idx_customers_tenant_email
+  ON customers (tenant_id, email)
+  WHERE email IS NOT NULL;
+
+-- ==========================================
+-- match_products_by_name: pg_trgm RPC 関数
+-- ==========================================
+CREATE OR REPLACE FUNCTION match_products_by_name(
+  query_text          text,
+  p_tenant_id         uuid,
+  similarity_threshold float DEFAULT 0.3
+)
+RETURNS TABLE (id bigint, name text, score float)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT
+    p.id,
+    p.name,
+    similarity(p.name, query_text)::float AS score
+  FROM products p
+  WHERE p.tenant_id = p_tenant_id
+    AND similarity(p.name, query_text) >= similarity_threshold
+  ORDER BY score DESC;
+$$;


### PR DESCRIPTION
## 概要

Issue #165 / #166 / #167 の実装。Gmail 受信メールをラベルベースでポーリングし、Claude Haiku で注文フィールドを抽出、pg_trgm で製品 ID を解決して Supabase に注文下書きを自動作成するパイプラインを構築。

## アーキテクチャ

```
Gmail フィルタ → 処理待ち/テナントA ラベル付与
      ↓
Vercel Cron (*/15 * * * *)
      ↓
GET /api/cron/gmail-poll (Next.js → Render FastAPI)
      ↓ メッセージ単位で処理
      ├─ 処理待ち → 処理中 (二重処理防止)
      ├─ Claude Haiku: メール本文 → {product_name, quantity, deadline_date, order_number}
      ├─ pg_trgm RPC: product_name → product_id / product_candidates
      ├─ 転送ブロック正規表現: 送信元メールアドレス → customer_id (自動作成)
      ├─ orders INSERT (status=draft)
      └─ 処理中 → 処理済み (or エラー)
```

## 変更ファイル一覧

### Backend — 新規作成

| ファイル | 内容 |
|---|---|
| `backend/app/services/email_extraction_service.py` | Claude Haiku ツールユース強制呼び出しによるメール解析 |
| `backend/app/services/product_matching_service.py` | pg_trgm RPC → product_id 解決・candidates JSONB 生成 |
| `backend/app/services/customer_matching_service.py` | 転送ブロック email 抽出 + 顧客ルックアップ / draft 自動作成 |

### Backend — 更新

| ファイル | 変更内容 |
|---|---|
| `backend/app/services/gmail_service.py` | 全面書き換え: ラベルベースポーリング・状態遷移・テナント解決・パイプライン統合 |
| `backend/app/routers/cron/gmail_poll.py` | `get_supabase_admin_client()` を生成して `poll_unread_emails(db)` へ注入 |
| `backend/app/models/transaction/order_schema.py` | `product_id` / `quantity` を nullable に変更、`extracted_product_name` / `product_candidates` 追加 |
| `backend/app/repositories/supa_infra/common/table_name.py` | `GMAIL_LABEL_TENANTS` を追加 |
| `backend/requirements.txt` | `anthropic>=0.40.0` を追加 |

### DB マイグレーション

| ファイル | 内容 |
|---|---|
| `supabase/migrations/20260618000000_gmail_intake_v2.sql` | pg_trgm 拡張・GIN インデックス・`gmail_label_tenants` テーブル・`match_products_by_name` RPC・`orders` カラム追加 |

### ドキュメント

| ファイル | 内容 |
|---|---|
| `docs/specs/GMAIL_ORDER_INTAKE.md` | 仕様書を全面更新（ラベル設計・pg_trgm・Claude 抽出・顧客解決） |
| `docs/infra/env-setup-gmail-cron.md` | 新規環境変数・ラベル作成手順・DB 初期データ手順を追加 |

## 必要な環境変数（Render）

| 変数名 | 説明 |
|---|---|
| `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` / `GMAIL_REFRESH_TOKEN` | Gmail OAuth2 (GCP Secret Manager) |
| `ANTHROPIC_API_KEY` | Claude メール解析用 (Secret Manager 管理必須) |
| `SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_URL` | Cron 用 admin アクセス (Secret Manager 管理必須) |
| `CRON_SECRET` | Vercel と共通 |
| `EMAIL_EXTRACTION_MODEL` | デフォルト: `claude-haiku-4-5-20251001` |
| `PRODUCT_MATCH_THRESHOLD` | デフォルト: `0.3` |
| `PRODUCT_MATCH_TOP_N` | デフォルト: `5` |

ラベルプレフィックス (`GMAIL_LABEL_PREFIX_PENDING` 等) はデフォルトで `処理待ち / 処理中 / 処理済み / エラー`。

## DB 初期データ

Supabase SQL Editor で実行:
```sql
INSERT INTO gmail_label_tenants (label_name, tenant_id)
VALUES ('テナントA', '<tenant_id_uuid>');
```

## テスト手順

```bash
# ローカル確認
curl -X GET http://localhost:8000/api/cron/gmail-poll \
  -H "Authorization: Bearer <CRON_SECRET>"
# → {"processed": N, "errors": 0}
```

## Issue #166・#167 との差分

| 項目 | Issue 想定 | 実装 |
|---|---|---|
| 解析モデル | Gemini 2.0 Flash | Claude Haiku (ツールユース) |
| 製品解決 | 完全一致 → 部分一致 | pg_trgm 類似度スコア全候補取得 |
| 顧客解決 | customer_name テキストマッチ | 転送ブロックのメールアドレスで検索 |
| 顧客不在時 | null | draft 顧客を自動作成 |

## 関連 Issue
- Closes #165
- Closes #166
- Closes #167
- #168 (メール起票注文レビュー UI — 別 PR)
- #171 (Gmail OAuth2 セットアップ)
- #155 (email-order-intake 基盤実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)