### PR TITLE
fix: cachetools を 5.5.2 に変更して google-auth との依存競合を解消 (#177)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.0
 azure-functions==1.24.0
-cachetools==6.2.4
+cachetools==5.5.2
 certifi==2025.11.12
 cffi==2.0.0
 cfgv==3.5.0


### PR DESCRIPTION
## Summary

- `cachetools==6.2.4` → `cachetools==5.5.2` に変更
- `google-auth==2.40.3` が要求する `cachetools<6.0` と `pyiceberg==0.10.0` が要求する `cachetools>=5.5` を両方満たすバージョンに修正
- Render 上の Docker ビルドが `ResolutionImpossible` で失敗していた問題を解消

Closes #177

## Test plan

- [ ] ローカルで `pip install -r requirements.txt` がエラーなく完了すること
- [ ] Render のデプロイが成功すること
- [ ] 既存のテストが通ること (`pytest __tests__/unit/` および `pytest __tests__/api/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)