### PR TITLE
fix: 本番 CORS エラー修正 (credentials + wildcard 非互換)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
 # backend/main.py
+import os
+
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -28,12 +30,11 @@ app = FastAPI(
 )
 
 # CORS設定
+_extra_origins = os.getenv("CORS_ALLOWED_ORIGINS", "")
 origins = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
-    "http://localhost:8081",  # In case user insists on 8081 proxy
-    "*",  # Permissive for development
-]
+] + [o.strip() for o in _extra_origins.split(",") if o.strip()]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- `allow_credentials=True` と `allow_origins=["*"]` の組み合わせはブラウザ仕様上無効なため、Vercel → Render でCORSエラーが発生していた
- `"*"` を origins リストから除去
- 本番 URL は Render の環境変数 `CORS_ALLOWED_ORIGINS` で注入する構成に変更（カンマ区切りで複数指定可）

## Render 環境変数の設定
```
CORS_ALLOWED_ORIGINS=https://your-app.vercel.app
```

## Test plan
- [ ] Render に `CORS_ALLOWED_ORIGINS` を設定してデプロイ
- [ ] Vercel からのリクエストで CORS エラーが解消されることを確認
- [ ] ローカル (`localhost:3000`) からのリクエストが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)