### PR TITLE
fix: FastAPI redirect_slashes=False で不要な 307 リダイレクトを除去

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ app = FastAPI(
     title="Product Planner API",
     description="API on Render",
     version="1.0.0",
+    redirect_slashes=False,
 )
 
 # CORS設定


### PR DESCRIPTION
## 概要

- `/equipments`、`/calendars`、`/production-schedules` 等へのリクエストが末尾スラッシュ不一致で毎回 307 リダイレクトされていた
- FastAPI デフォルトの `redirect_slashes=True` が原因で、クライアントが 1 リクエストごとに必ず 2 RTT 消費していた
- `redirect_slashes=False` を設定することで 307 を排除し、リクエスト数を半減させる

## 変更内容

- `backend/app/main.py`: `FastAPI()` 初期化に `redirect_slashes=False` を追加（1行のみ）

## テスト方法

- [ ] ローカルで `func host start` を起動し、DevTools Network タブで `/equipments` 等に 307 が出ないことを確認
- [ ] 既存の API エンドポイントが引き続き正常レスポンスを返すことを確認
- [ ] `pytest __tests__/unit/ __tests__/api/` がグリーンであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)