### PR TITLE
fix: 設備グループ管理モーダルの表示崩れを修正 (#185, #186)

### DIFF
--- a/frontend/src/components/equipment-group-assignment-dialog.tsx
+++ b/frontend/src/components/equipment-group-assignment-dialog.tsx
@@ -91,13 +91,13 @@ export function EquipmentGroupAssignmentDialog({ equipment, open, onOpenChange }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="flex flex-col max-h-[90vh]">
         <DialogHeader>
           <DialogTitle>{equipment?.name} のグループ設定</DialogTitle>
           <DialogDescription>この設備が属するグループを選択してください</DialogDescription>
         </DialogHeader>
 
-        <div className="py-4">
+        <div className="overflow-y-auto flex-1 min-h-0 py-4">
           {groups.length === 0 ? (
             <p className="text-sm text-muted-foreground">グループが登録されていません</p>
           ) : (

--- a/frontend/src/components/equipment-group-members-dialog.tsx
+++ b/frontend/src/components/equipment-group-members-dialog.tsx
@@ -67,7 +67,7 @@ export function EquipmentGroupMembersDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid grid-cols-[1fr_auto_1fr] gap-4 py-4 flex-1 min-h-0">
+        <div className="grid grid-cols-[1fr_auto_1fr] grid-rows-[minmax(0,_1fr)] gap-4 py-4 flex-1 min-h-0">
           {/* 左側: 未所属設備リスト */}
           <EquipmentList
             title="未所属設備"

--- a/frontend/src/components/equipment-list.tsx
+++ b/frontend/src/components/equipment-list.tsx
@@ -31,7 +31,7 @@ export function EquipmentList({
     emptyMessage = "設備はありません",
 }: EquipmentListProps) {
     return (
-        <div className="border rounded-lg p-4 h-full flex flex-col">
+        <div className="border rounded-lg p-4 flex flex-col min-h-0">
             <h3 className="font-semibold mb-3 text-sm">{title}</h3>
             <div className="space-y-1 flex-1 overflow-y-auto min-h-0">
                 {isLoading ? (


### PR DESCRIPTION
## Summary
- CSS Grid の `grid-template-rows` 未指定によるコンテンツオーバーフローを修正（#185）
- グループ設定ダイアログがビューポート高さを超えて操作不能になる問題を修正（#186）

## 変更内容

### #185: メンバー管理ダイアログのコンテンツオーバーフロー
`equipment-group-members-dialog.tsx` のグリッドコンテナに `grid-rows-[minmax(0,_1fr)]` を追加し、設備リストが `h-[600px]` の枠外にはみ出す問題を解消。合わせて `equipment-list.tsx` の外側 div から `h-full` を削除し `min-h-0` を追加して `overflow-y-auto` が正しく機能するよう修正。

### #186: グループ設定ダイアログのビューポートオーバーフロー
`equipment-group-assignment-dialog.tsx` の `DialogContent` に `max-h-[90vh] flex flex-col` を追加し、グループリストコンテナに `overflow-y-auto flex-1 min-h-0` を追加。グループ数が多い場合もダイアログがビューポート内に収まりスクロール可能になる。

## Test plan
- [ ] 設備グループのメンバー管理モーダルを開き、設備リストがダイアログ内でスクロールすることを確認
- [ ] グループ設定モーダルを開き、グループ数が多い場合もダイアログがビューポート内に収まることを確認
- [ ] 設備のグループ追加・削除が正常に動作することを確認

Closes #185
Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)