### PR TITLE
fix: redirect_slashes=False によるコレクションエンドポイントの 404 を修正

### DIFF
--- a/backend/__tests__/api/routers/master/test_calendars.py
+++ b/backend/__tests__/api/routers/master/test_calendars.py
@@ -66,7 +66,7 @@ class TestCalendarRouter:
         mock_response.data = mock_calendar_data
         mock_client.table.return_value.select.return_value.gte.return_value.lte.return_value.execute.return_value = mock_response
 
-        response = client.get("/calendars/?year=2024&month=1", headers=headers)
+        response = client.get("/calendars?year=2024&month=1", headers=headers)
 
         assert response.status_code == 200
         assert response.json() == mock_calendar_data
@@ -94,7 +94,7 @@ class TestCalendarRouter:
             mock_response
         )
 
-        response = client.post("/calendars/", json=payload, headers=headers)
+        response = client.post("/calendars", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json()["is_holiday"] is True

--- a/backend/__tests__/api/routers/master/test_customers_router.py
+++ b/backend/__tests__/api/routers/master/test_customers_router.py
@@ -54,7 +54,7 @@ class TestCustomerRouter:
         mock_repo.get_all.return_value = expected_data
 
         # 2. リクエスト実行
-        response = client.get("/customers/")
+        response = client.get("/customers")
 
         # 3. 検証
         assert response.status_code == 200
@@ -93,7 +93,7 @@ class TestCustomerRouter:
 
         mock_repo.create.return_value = created_data
 
-        response = client.post("/customers/", json=payload, headers=headers)
+        response = client.post("/customers", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json() == created_data

--- a/backend/__tests__/api/routers/master/test_equipment_groups.py
+++ b/backend/__tests__/api/routers/master/test_equipment_groups.py
@@ -37,7 +37,7 @@ class TestEquipmentGroupRouter:
         ]
         mock_repo.get_all_groups.return_value = expected_data
 
-        response = client.get("/equipment-groups/")
+        response = client.get("/equipment-groups")
 
         assert response.status_code == 200
         assert response.json() == expected_data
@@ -64,7 +64,7 @@ class TestEquipmentGroupRouter:
 
         mock_repo.create_group.return_value = created_data
 
-        response = client.post("/equipment-groups/", json=payload, headers=headers)
+        response = client.post("/equipment-groups", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json() == created_data

--- a/backend/__tests__/api/routers/master/test_equipments.py
+++ b/backend/__tests__/api/routers/master/test_equipments.py
@@ -39,7 +39,7 @@ class TestEquipmentRouter:
         ]
         mock_repo.get_all.return_value = expected_data
 
-        response = client.get("/equipments/")
+        response = client.get("/equipments")
 
         assert response.status_code == 200
         assert response.json() == expected_data
@@ -70,7 +70,7 @@ class TestEquipmentRouter:
 
         mock_repo.create.return_value = created_data
 
-        response = client.post("/equipments/", json=payload, headers=headers)
+        response = client.post("/equipments", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json() == created_data

--- a/backend/__tests__/api/routers/master/test_process_routings.py
+++ b/backend/__tests__/api/routers/master/test_process_routings.py
@@ -40,7 +40,7 @@ class TestProcessRoutingRouter:
         ]
         mock_repo.get_routings_by_product.return_value = expected_data
 
-        response = client.get(f"/process-routings/?product_id={product_id}")
+        response = client.get(f"/process-routings?product_id={product_id}")
 
         assert response.status_code == 200
         assert response.json() == expected_data
@@ -72,7 +72,7 @@ class TestProcessRoutingRouter:
 
         mock_repo.create_routing.return_value = created_data
 
-        response = client.post("/process-routings/", json=payload, headers=headers)
+        response = client.post("/process-routings", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json() == created_data

--- a/backend/__tests__/api/routers/master/test_products_router.py
+++ b/backend/__tests__/api/routers/master/test_products_router.py
@@ -56,7 +56,7 @@ class TestProductRouter:
         mock_repo.get_all.return_value = expected_data
 
         # 2. リクエスト実行
-        response = client.get("/products/")  # prefixの設定に合わせてパスを調整
+        response = client.get("/products")  # prefixの設定に合わせてパスを調整
 
         # 3. 検証
         assert response.status_code == 200
@@ -89,7 +89,7 @@ class TestProductRouter:
 
         mock_repo.create.return_value = created_data
 
-        response = client.post("/products/", json=payload, headers=headers)
+        response = client.post("/products", json=payload, headers=headers)
 
         assert response.status_code == 200
         assert response.json() == created_data

--- a/backend/__tests__/api/routers/master/test_scheduling_settings.py
+++ b/backend/__tests__/api/routers/master/test_scheduling_settings.py
@@ -51,7 +51,7 @@ class TestSchedulingSettingsRouter:
         """設定が存在しない場合にデフォルト値を返すこと"""
         _make_table_mock(mock_client, [])
 
-        response = client.get("/scheduling-settings/", headers=headers)
+        response = client.get("/scheduling-settings", headers=headers)
 
         assert response.status_code == 200
         body = response.json()
@@ -69,7 +69,7 @@ class TestSchedulingSettingsRouter:
         }
         _make_table_mock(mock_client, [existing])
 
-        response = client.get("/scheduling-settings/", headers=headers)
+        response = client.get("/scheduling-settings", headers=headers)
 
         assert response.status_code == 200
         body = response.json()
@@ -111,7 +111,7 @@ class TestSchedulingSettingsRouter:
         mock_client.table.side_effect = table_side_effect
 
         payload = {"guard_time_minutes": 10, "min_slot_minutes": 20, "max_fragments": 3}
-        response = client.put("/scheduling-settings/", json=payload, headers=headers)
+        response = client.put("/scheduling-settings", json=payload, headers=headers)
 
         assert response.status_code == 200
 
@@ -146,7 +146,7 @@ class TestSchedulingSettingsRouter:
 
         # guard_time_minutes だけ指定
         payload = {"guard_time_minutes": 5}
-        response = client.put("/scheduling-settings/", json=payload, headers=headers)
+        response = client.put("/scheduling-settings", json=payload, headers=headers)
 
         assert response.status_code == 200
 
@@ -154,12 +154,12 @@ class TestSchedulingSettingsRouter:
         """ガードタイムに負の値を渡した場合は 422 を返すこと"""
         _make_table_mock(mock_client, [])
         payload = {"guard_time_minutes": -1}
-        response = client.put("/scheduling-settings/", json=payload, headers=headers)
+        response = client.put("/scheduling-settings", json=payload, headers=headers)
         assert response.status_code == 422
 
     def test_put_rejects_zero_max_fragments(self, headers, mock_client):
         """最大断片数に 0 以下を渡した場合は 422 を返すこと"""
         _make_table_mock(mock_client, [])
         payload = {"max_fragments": 0}
-        response = client.put("/scheduling-settings/", json=payload, headers=headers)
+        response = client.put("/scheduling-settings", json=payload, headers=headers)
         assert response.status_code == 422

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -80,7 +80,7 @@ class TestOrderRouter:
         ]
         mock_repo.get_all.return_value = db_data
 
-        response = client.get("/orders/")
+        response = client.get("/orders")
 
         assert response.status_code == 200
         result = response.json()
@@ -119,7 +119,7 @@ class TestOrderRouter:
 
         mock_repo.create.return_value = created_data
 
-        response = client.post("/orders/", json=payload, headers=headers)
+        response = client.post("/orders", json=payload, headers=headers)
 
         assert response.status_code == 200
         result = response.json()

--- a/backend/__tests__/api/routers/transaction/test_production_schedules.py
+++ b/backend/__tests__/api/routers/transaction/test_production_schedules.py
@@ -63,7 +63,7 @@ class TestProductionSchedulesRouter:
         mock_repo.get_by_period.return_value = expected_data
 
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={"start_date": "2024-01-01", "end_date": "2024-01-31"},
             headers=headers,
         )
@@ -95,7 +95,7 @@ class TestProductionSchedulesRouter:
         mock_repo.get_by_period.return_value = expected_data
 
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={
                 "start_date": "2024-01-01",
                 "end_date": "2024-01-31",
@@ -113,7 +113,7 @@ class TestProductionSchedulesRouter:
         mock_repo.get_by_period.return_value = []
 
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={"start_date": "2024-12-01", "end_date": "2024-12-31"},
             headers=headers,
         )
@@ -129,7 +129,7 @@ class TestProductionSchedulesRouter:
         mock_repo.get_by_period.return_value = []
 
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={
                 "start_date": "2024-01-01",
                 "end_date": "2024-01-31",
@@ -146,7 +146,7 @@ class TestProductionSchedulesRouter:
         """GET /: 必須パラメータが不足している場合のテスト"""
         # start_date のみ指定
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={"start_date": "2024-01-01"},
             headers=headers,
         )
@@ -154,14 +154,14 @@ class TestProductionSchedulesRouter:
 
         # end_date のみ指定
         response = client.get(
-            "/production-schedules/",
+            "/production-schedules",
             params={"end_date": "2024-01-31"},
             headers=headers,
         )
         assert response.status_code == 422  # Unprocessable Entity
 
         # パラメータなし
-        response = client.get("/production-schedules/", headers=headers)
+        response = client.get("/production-schedules", headers=headers)
         assert response.status_code == 422  # Unprocessable Entity
 
     def test_update_production_schedule(self, headers, mock_repo):

--- a/backend/app/routers/master/calendars.py
+++ b/backend/app/routers/master/calendars.py
@@ -43,7 +43,7 @@ def get_calendar_repo(
     return CalendarRepository(client)
 
 
-@calendar_router.get("/")
+@calendar_router.get("")
 def get_calendars(
     year: int,
     month: int,
@@ -71,7 +71,7 @@ def get_calendars(
     return repo.get_holidays_in_range(start_date, end_date)
 
 
-@calendar_router.post("/")
+@calendar_router.post("")
 def upsert_calendar(
     calendar_data: WorkCalendarCreate,
     tenant_id: str = Depends(get_current_tenant_id),

--- a/backend/app/routers/master/customers.py
+++ b/backend/app/routers/master/customers.py
@@ -11,7 +11,7 @@ customer_router = APIRouter(prefix="/customers", tags=["Master (Customers)"])
 logger = get_logger(__name__)
 
 
-@customer_router.post("/")
+@customer_router.post("")
 def create_customer(
     customer_data: CustomerCreateSchema,
     tenant_id: str = Depends(get_current_tenant_id),
@@ -22,7 +22,7 @@ def create_customer(
     return repo.create(customer_data.with_tenant_id(tenant_id))
 
 
-@customer_router.get("/")
+@customer_router.get("")
 def get_customers(repo: CustomerRepository = Depends(get_customer_repo)):
     """顧客を全件取得"""
     logger.info("Fetching all customers")

--- a/backend/app/routers/master/equipment_groups.py
+++ b/backend/app/routers/master/equipment_groups.py
@@ -26,7 +26,7 @@ def get_all_equipment_group_members(
     return repo.get_all_members()
 
 
-@equipment_group_router.post("/")
+@equipment_group_router.post("")
 def create_equipment_group(
     group_data: EquipmentGroupCreate,
     tenant_id: str = Depends(get_current_tenant_id),
@@ -37,7 +37,7 @@ def create_equipment_group(
     return repo.create_group(group_data.with_tenant_id(tenant_id))
 
 
-@equipment_group_router.get("/")
+@equipment_group_router.get("")
 def get_equipment_groups(repo: EquipmentRepository = Depends(get_equipment_repo)):
     """設備グループを全件取得"""
     logger.info("Fetching all equipment groups")

--- a/backend/app/routers/master/equipments.py
+++ b/backend/app/routers/master/equipments.py
@@ -14,7 +14,7 @@ equipment_router = APIRouter(prefix="/equipments", tags=["Master (Equipments)"])
 logger = get_logger(__name__)
 
 
-@equipment_router.post("/")
+@equipment_router.post("")
 def create_equipment(
     equipment_data: EquipmentCreate,
     tenant_id: str = Depends(get_current_tenant_id),
@@ -25,7 +25,7 @@ def create_equipment(
     return repo.create(equipment_data.with_tenant_id(tenant_id))
 
 
-@equipment_router.get("/")
+@equipment_router.get("")
 def get_equipments(repo: EquipmentRepository = Depends(get_equipment_repo)):
     """設備を全件取得"""
     logger.info("Fetching all equipments")

--- a/backend/app/routers/master/process_routings.py
+++ b/backend/app/routers/master/process_routings.py
@@ -13,7 +13,7 @@ process_routing_router = APIRouter(
 logger = get_logger(__name__)
 
 
-@process_routing_router.post("/")
+@process_routing_router.post("")
 def create_process_routing(
     routing_data: RoutingCreate,
     tenant_id: str = Depends(get_current_tenant_id),
@@ -24,7 +24,7 @@ def create_process_routing(
     return repo.create_routing(routing_data.with_tenant_id(tenant_id))
 
 
-@process_routing_router.get("/")
+@process_routing_router.get("")
 def get_process_routings(
     product_id: int = Query(..., description="製品ID"),
     repo: ProductRepository = Depends(get_product_repo),

--- a/backend/app/routers/master/products.py
+++ b/backend/app/routers/master/products.py
@@ -11,7 +11,7 @@ product_router = APIRouter(prefix="/products", tags=["Master (Products)"])
 logger = get_logger(__name__)
 
 
-@product_router.post("/")
+@product_router.post("")
 def create_product(
     product_data: ProductCreateSchema,  # Pydanticモデル
     tenant_id: str = Depends(get_current_tenant_id),
@@ -22,7 +22,7 @@ def create_product(
     return repo.create(product_data.with_tenant_id(tenant_id))
 
 
-@product_router.get("/")
+@product_router.get("")
 def get_products(repo: ProductRepository = Depends(get_product_repo)):
     """製品を全件取得"""
     logger.info("Fetching all products")

--- a/backend/app/routers/master/scheduling_settings.py
+++ b/backend/app/routers/master/scheduling_settings.py
@@ -33,7 +33,7 @@ def get_settings_repo(
     return SchedulingSettingsRepository(client)
 
 
-@scheduling_settings_router.get("/")
+@scheduling_settings_router.get("")
 def get_scheduling_settings(
     tenant_id: str = Depends(get_current_tenant_id),
     repo: SchedulingSettingsRepository = Depends(get_settings_repo),
@@ -51,7 +51,7 @@ def get_scheduling_settings(
     }
 
 
-@scheduling_settings_router.put("/")
+@scheduling_settings_router.put("")
 def upsert_scheduling_settings(
     data: SchedulingSettingsUpdate,
     tenant_id: str = Depends(get_current_tenant_id),

--- a/backend/app/routers/tenant/members.py
+++ b/backend/app/routers/tenant/members.py
@@ -38,7 +38,7 @@ def _require_admin(
         )
 
 
-@member_router.get("/", response_model=list[MemberResponse])
+@member_router.get("", response_model=list[MemberResponse])
 def list_members(
     tenant_id: str = Depends(get_current_tenant_id),
     current_user_id: str = Depends(get_current_user_id),
@@ -85,7 +85,7 @@ def list_members(
 
 
 @member_router.post(
-    "/", response_model=MemberResponse, status_code=status.HTTP_201_CREATED
+    "", response_model=MemberResponse, status_code=status.HTTP_201_CREATED
 )
 def create_member(
     data: MemberCreateSchema,

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -46,7 +46,7 @@ def _map_order_response(order: dict) -> dict:
     return mapped
 
 
-@orders_router.post("/")
+@orders_router.post("")
 def create_order(
     order_data: OrderCreate,
     tenant_id: str = Depends(get_current_tenant_id),
@@ -61,7 +61,7 @@ def create_order(
         raise HTTPException(status_code=400, detail=str(e)) from None
 
 
-@orders_router.get("/")
+@orders_router.get("")
 def get_orders(repo: OrderRepository = Depends(get_order_repo)):
     """注文を全件取得"""
     logger.info("Fetching all orders")

--- a/backend/app/routers/transaction/production_schedules.py
+++ b/backend/app/routers/transaction/production_schedules.py
@@ -15,7 +15,7 @@ production_schedules_router = APIRouter(
 logger = get_logger(__name__)
 
 
-@production_schedules_router.get("/")
+@production_schedules_router.get("")
 def get_production_schedules(
     start_date: str = Query(..., description="取得開始日 (ISO8601 / YYYY-MM-DD)"),
     end_date: str = Query(..., description="取得終了日 (ISO8601 / YYYY-MM-DD)"),

--- a/frontend/src/hooks/use-process-routings.ts
+++ b/frontend/src/hooks/use-process-routings.ts
@@ -13,7 +13,7 @@ const getProcessRoutingsQueryKey = (productId: number) => ["process-routings", p
 export function useProcessRoutings(productId: number | null) {
   return useQuery<ProcessRouting[]>({
     queryKey: getProcessRoutingsQueryKey(productId ?? 0),
-    queryFn: () => apiClient<ProcessRouting[]>(`/process-routings/?product_id=${productId}`),
+    queryFn: () => apiClient<ProcessRouting[]>(`/process-routings?product_id=${productId}`),
     enabled: productId !== null,
   })
 }
@@ -26,7 +26,7 @@ export function useCreateProcessRouting() {
 
   return useMutation({
     mutationFn: (data: ProcessRoutingCreate) =>
-      apiClient<ProcessRouting>("/process-routings/", {
+      apiClient<ProcessRouting>("/process-routings", {
         method: "POST",
         body: JSON.stringify(data),
       }),


### PR DESCRIPTION
## Summary

- PR #184 で `redirect_slashes=False` を設定した際、全ルーターのコレクションエンドポイントが `"/"` で登録されていたため末尾スラッシュなしリクエストが 404 になっていた
- 全バックエンドルーター（10ファイル）のコレクションデコレーターを `"/"` → `""` に変更
- `frontend/src/hooks/use-process-routings.ts` の末尾スラッシュも除去（このファイルだけ `/process-routings/` で呼んでいた）
- テストファイル（9ファイル）のパスも合わせて修正し、72テスト全パスを確認

Closes #188

## Test plan

- [ ] `cd backend && pytest __tests__/api/` が 72 passed で通ること
- [ ] 生産スケジュール画面で日次・週次・月次いずれのフィルターでもスケジュールが正常に取得できること
- [ ] 注文・設備・製品等の他の画面も正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)