### PR TITLE
feat: 設備グループUIでシステムグループと共有グループを分離 (#192)

### DIFF
--- a/backend/__tests__/api/routers/master/test_equipment_groups.py
+++ b/backend/__tests__/api/routers/master/test_equipment_groups.py
@@ -30,12 +30,45 @@ class TestEquipmentGroupRouter:
         app.dependency_overrides = {}
 
     def test_get_equipment_groups(self, mock_repo):
-        """GET /: 全件取得のテスト"""
-        expected_data = [
-            {"id": 1, "name": "Group A", "tenant_id": "uuid-1"},
-            {"id": 2, "name": "Group B", "tenant_id": "uuid-1"},
+        """GET /: 全件取得のテスト。member_names / member_count が付与されて返ること。"""
+        mock_repo.get_all_groups.return_value = [
+            {
+                "id": 1,
+                "name": "Group A",
+                "tenant_id": "uuid-1",
+                "member_names": ["設備A", "設備B"],
+                "member_count": 2,
+            },
+            {
+                "id": 2,
+                "name": "Group B",
+                "tenant_id": "uuid-1",
+                "member_names": ["設備C"],
+                "member_count": 1,
+            },
         ]
-        mock_repo.get_all_groups.return_value = expected_data
+        expected_data = [
+            {
+                "id": 1,
+                "name": "Group A",
+                "tenant_id": "uuid-1",
+                "guard_time_minutes": None,
+                "min_slot_minutes": None,
+                "max_fragments": None,
+                "member_names": ["設備A", "設備B"],
+                "member_count": 2,
+            },
+            {
+                "id": 2,
+                "name": "Group B",
+                "tenant_id": "uuid-1",
+                "guard_time_minutes": None,
+                "min_slot_minutes": None,
+                "max_fragments": None,
+                "member_names": ["設備C"],
+                "member_count": 1,
+            },
+        ]
 
         response = client.get("/equipment-groups")
 

--- a/backend/app/models/master/equipment_schemas.py
+++ b/backend/app/models/master/equipment_schemas.py
@@ -21,6 +21,15 @@ class EquipmentGroupBase(BaseSchema):
     )
 
 
+class EquipmentGroupResponse(EquipmentGroupBase):
+    """設備グループのレスポンススキーマ"""
+
+    id: int
+    tenant_id: str
+    member_names: list[str] = Field(default_factory=list)
+    member_count: int = Field(default=0)
+
+
 class EquipmentGroupCreate(EquipmentGroupBase):
     """設備グループを作成するためのスキーマ"""
 

--- a/backend/app/repositories/supa_infra/master/equipment_repo.py
+++ b/backend/app/repositories/supa_infra/master/equipment_repo.py
@@ -15,13 +15,21 @@ class EquipmentRepository(BaseRepository[T]):
     # --- Equipment Groups (別テーブル操作) ---
 
     def get_all_groups(self) -> list[T]:
-        """設備グループのリストを取得する。"""
+        """設備グループのリストを取得する。member_names / member_count を付与して返す。"""
         res = (
             self.client.table(SupabaseTableName.EQUIPMENT_GROUPS.value)
-            .select("*")
+            .select("*, equipment_group_members(equipments(id, name))")
             .execute()
         )
-        return cast(list[T], res.data)
+        groups = cast(list[dict[str, Any]], res.data)
+        for group in groups:
+            members = group.pop("equipment_group_members", [])
+            member_names = [
+                m["equipments"]["name"] for m in members if m.get("equipments")
+            ]
+            group["member_names"] = sorted(member_names)
+            group["member_count"] = len(member_names)
+        return cast(list[T], groups)
 
     def create_group(self, data: dict[str, Any]) -> T:
         """設備グループを新規作成"""

--- a/backend/app/routers/master/equipment_groups.py
+++ b/backend/app/routers/master/equipment_groups.py
@@ -5,6 +5,7 @@ from app.dependencies import get_current_tenant_id, get_equipment_repo
 from app.models.master.equipment_schemas import (
     EquipmentGroupCreate,
     EquipmentGroupMemberAdd,
+    EquipmentGroupResponse,
     EquipmentGroupUpdate,
 )
 from app.repositories.supa_infra.master.equipment_repo import EquipmentRepository
@@ -37,7 +38,7 @@ def create_equipment_group(
     return repo.create_group(group_data.with_tenant_id(tenant_id))
 
 
-@equipment_group_router.get("")
+@equipment_group_router.get("", response_model=list[EquipmentGroupResponse])
 def get_equipment_groups(repo: EquipmentRepository = Depends(get_equipment_repo)):
     """設備グループを全件取得"""
     logger.info("Fetching all equipment groups")

--- a/frontend/src/app/master/equipments/page.tsx
+++ b/frontend/src/app/master/equipments/page.tsx
@@ -466,6 +466,7 @@ export default function EquipmentsPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>グループ名</TableHead>
+                    <TableHead className="w-[80px] text-right">台数</TableHead>
                     <TableHead className="w-[200px] text-right">操作</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -473,12 +474,8 @@ export default function EquipmentsPage() {
                   {groups && groups.filter((g) => g.member_count >= 2).length > 0 ? (
                     groups.filter((g) => g.member_count >= 2).map((group) => (
                       <TableRow key={group.id}>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <span>{group.name}</span>
-                            <span className="text-sm text-muted-foreground">{group.member_count}台</span>
-                          </div>
-                        </TableCell>
+                        <TableCell>{group.name}</TableCell>
+                        <TableCell className="text-right text-sm text-muted-foreground">{group.member_count}台</TableCell>
                         <TableCell className="text-right">
                           <div className="flex justify-end gap-2">
                             <Button
@@ -509,7 +506,7 @@ export default function EquipmentsPage() {
                     ))
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={2} className="text-center text-muted-foreground py-10">
+                      <TableCell colSpan={3} className="text-center text-muted-foreground py-10">
                         データがありません
                       </TableCell>
                     </TableRow>

--- a/frontend/src/app/master/equipments/page.tsx
+++ b/frontend/src/app/master/equipments/page.tsx
@@ -151,10 +151,17 @@ export default function EquipmentsPage() {
   const updateGroupMutation = useUpdateEquipmentGroup()
   const deleteGroupMutation = useDeleteEquipmentGroup()
 
-  // 設備ID → 所属グループ名リスト のマップ
+  // 共有グループ(2設備以上)のIDセット
+  const sharedGroupIds = useMemo(
+    () => new Set(groups?.filter((g) => g.member_count >= 2).map((g) => g.id) ?? []),
+    [groups]
+  )
+
+  // 設備ID → 所属共有グループ名リスト のマップ(システムグループは除外)
   const equipmentGroupMap = useMemo(() => {
     const map = new Map<number, string[]>()
     for (const member of allMembers) {
+      if (!sharedGroupIds.has(member.equipment_group_id)) continue
       const group = groups?.find((g) => g.id === member.equipment_group_id)
       if (!group) continue
       const names = map.get(member.equipment_id) ?? []
@@ -162,7 +169,7 @@ export default function EquipmentsPage() {
       map.set(member.equipment_id, names)
     }
     return map
-  }, [allMembers, groups])
+  }, [allMembers, groups, sharedGroupIds])
 
   // ── 設備タブのハンドラ ────────────────────────────────────────
   const handleOpenCreateDialog = () => {
@@ -466,8 +473,8 @@ export default function EquipmentsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {groups && groups.length > 0 ? (
-                    groups.map((group) => (
+                  {groups && groups.filter((g) => g.member_count >= 2).length > 0 ? (
+                    groups.filter((g) => g.member_count >= 2).map((group) => (
                       <TableRow key={group.id}>
                         <TableCell className="font-medium">{group.id}</TableCell>
                         <TableCell>{group.name}</TableCell>

--- a/frontend/src/app/master/equipments/page.tsx
+++ b/frontend/src/app/master/equipments/page.tsx
@@ -379,7 +379,6 @@ export default function EquipmentsPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[100px]">ID</TableHead>
                     <TableHead>設備名</TableHead>
                     <TableHead>所属グループ</TableHead>
                     <TableHead className="w-[150px] text-right">操作</TableHead>
@@ -391,7 +390,6 @@ export default function EquipmentsPage() {
                       const groupNames = equipmentGroupMap.get(equipment.id) ?? []
                       return (
                         <TableRow key={equipment.id}>
-                          <TableCell className="font-medium">{equipment.id}</TableCell>
                           <TableCell>{equipment.name}</TableCell>
                           <TableCell>
                             {groupNames.length > 0 ? (
@@ -440,7 +438,7 @@ export default function EquipmentsPage() {
                     })
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-center py-10">
+                      <TableCell colSpan={3} className="text-center py-10">
                         設備がありません
                       </TableCell>
                     </TableRow>
@@ -467,7 +465,6 @@ export default function EquipmentsPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[100px]">ID</TableHead>
                     <TableHead>グループ名</TableHead>
                     <TableHead className="w-[200px] text-right">操作</TableHead>
                   </TableRow>
@@ -476,8 +473,12 @@ export default function EquipmentsPage() {
                   {groups && groups.filter((g) => g.member_count >= 2).length > 0 ? (
                     groups.filter((g) => g.member_count >= 2).map((group) => (
                       <TableRow key={group.id}>
-                        <TableCell className="font-medium">{group.id}</TableCell>
-                        <TableCell>{group.name}</TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <span>{group.name}</span>
+                            <span className="text-sm text-muted-foreground">{group.member_count}台</span>
+                          </div>
+                        </TableCell>
                         <TableCell className="text-right">
                           <div className="flex justify-end gap-2">
                             <Button
@@ -508,7 +509,7 @@ export default function EquipmentsPage() {
                     ))
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={3} className="text-center text-muted-foreground py-10">
+                      <TableCell colSpan={2} className="text-center text-muted-foreground py-10">
                         データがありません
                       </TableCell>
                     </TableRow>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -37,7 +37,7 @@ import {
   useUpdateProcessRouting,
   useDeleteProcessRouting,
 } from "@/hooks/use-process-routings"
-import { useEquipmentGroups } from "@/lib/hooks/use-equipment-groups"
+import { useEquipmentGroups, formatGroupLabel } from "@/lib/hooks/use-equipment-groups"
 import type { Product } from "@/types/product"
 import type { ProcessRouting } from "@/types/process-routing"
 
@@ -333,7 +333,7 @@ export function ProductRoutingsDialog({
                     <option value="none">設備なし</option>
                     {equipmentGroups?.map((group) => (
                       <option key={group.id} value={group.id}>
-                        {group.name}
+                        {formatGroupLabel(group)}
                       </option>
                     ))}
                   </select>

--- a/frontend/src/lib/hooks/use-equipment-groups.ts
+++ b/frontend/src/lib/hooks/use-equipment-groups.ts
@@ -10,6 +10,8 @@ export interface EquipmentGroup {
   guard_time_minutes?: number | null
   min_slot_minutes?: number | null
   max_fragments?: number | null
+  member_names: string[]
+  member_count: number
 }
 
 export interface EquipmentGroupCreate {
@@ -71,7 +73,7 @@ export function useUpdateEquipmentGroup() {
 // 削除
 export function useDeleteEquipmentGroup() {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
     mutationFn: (id: number) =>
       apiClient<{ status: string }>(`/equipment-groups/${id}`, {
@@ -81,4 +83,14 @@ export function useDeleteEquipmentGroup() {
       queryClient.invalidateQueries({ queryKey: EQUIPMENT_GROUPS_KEY })
     },
   })
+}
+
+function formatMemberNames(names: string[], max = 3): string {
+  if (names.length <= max) return names.join(' / ')
+  return `${names.slice(0, max).join(' / ')} 他${names.length - max}台`
+}
+
+export function formatGroupLabel(group: Pick<EquipmentGroup, 'name' | 'member_names'>): string {
+  if (group.member_names.length <= 1) return group.name
+  return `${group.name} (${formatMemberNames(group.member_names)})`
 }


### PR DESCRIPTION
## Summary

- `GET /equipment-groups` レスポンスに `member_names` / `member_count` を追加(Supabase embedded relation で N+1なし)
- 設備一覧の「所属グループ」列: `member_count = 1` のシステムグループを除外し共有グループのみ表示
- グループ管理タブ: `member_count >= 2` の共有グループのみ一覧表示
- 工程編集の設備グループ Select: `formatGroupLabel` を適用し共有グループに設備名を付記(例: `汎用グループ (設備A / 設備B)`)

## Test plan

- [ ] `GET /api/equipment-groups` のレスポンスに `member_names`, `member_count` が含まれること
- [ ] 設備マスタ > 設備一覧: 1台のシステムグループがバッジに表示されないこと
- [ ] 設備マスタ > グループ管理: 共有グループ(2台以上)のみ一覧に表示されること
- [ ] 工程編集 > 設備グループ Select: 共有グループに `グループ名 (設備名 / 設備名)` 形式で表示されること
- [ ] `pytest __tests__/unit/ __tests__/api/` が今回変更分でグリーンになること

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/app/repositories/supa_infra/master/equipment_repo.py` | `get_all_groups()` に embedded relation で member 情報を付与 |
| `backend/app/models/master/equipment_schemas.py` | `EquipmentGroupResponse` スキーマを追加 |
| `backend/app/routers/master/equipment_groups.py` | `GET /equipment-groups` に `response_model` を設定 |
| `backend/__tests__/api/routers/master/test_equipment_groups.py` | テストの期待値を新レスポンス形式に更新 |
| `frontend/src/lib/hooks/use-equipment-groups.ts` | `EquipmentGroup` 型に `member_names`/`member_count` 追加、`formatGroupLabel` 関数を追加 |
| `frontend/src/app/master/equipments/page.tsx` | 設備一覧列・グループ管理タブのフィルタ実装 |
| `frontend/src/components/product-routings-dialog.tsx` | Select ラベルに `formatGroupLabel` 適用 |

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)