### PR TITLE
fix: 製品編集ダイアログでnull品番によるinput valueエラーを修正

### DIFF
--- a/frontend/src/app/master/products/page.tsx
+++ b/frontend/src/app/master/products/page.tsx
@@ -127,7 +127,7 @@ export default function ProductsPage() {
   const handleOpenEditDialog = (product: Product) => {
     setSelectedProduct(product)
     setProductName(product.name)
-    setProductCode(product.code)
+    setProductCode(product.code ?? "")
     setProductType(product.type)
     setIsEditDialogOpen(true)
   }


### PR DESCRIPTION
## Summary
- `product.code` が `null` の場合に `<Input value={null}>` となりReactの警告が発生していた
- `setProductCode(product.code ?? "")` で `null` を空文字列にフォールバックするよう修正

## Test plan
- [ ] 品番が未設定の製品の編集ダイアログを開き、コンソールエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)