### PR TITLE
feat: 工程管理ダイアログに個数指定による完成日数目安カードを追加

### DIFF
--- a/backend/app/models/transaction/order_schema.py
+++ b/backend/app/models/transaction/order_schema.py
@@ -29,6 +29,7 @@ class OrderSimulateRequest(BaseSchema):
     product_id: int
     quantity: int
     deadline_date: str | None = Field(None, alias="desired_deadline")
+    standalone: bool = False
 
 
 class OrderUpdate(BaseSchema):

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -135,6 +135,7 @@ def simulate_schedule_without_id(
             schedule_repo=schedule_repo,
             tenant_id=tenant_id,
             dry_run=True,
+            standalone=order_data.standalone,
             settings_repo=settings_repo,
         )
         return build_simulate_response(

--- a/backend/app/scheduler_logic.py
+++ b/backend/app/scheduler_logic.py
@@ -41,6 +41,7 @@ def schedule_order(
     dry_run: bool = False,
     calendar_config: CalendarConfig | None = None,
     settings_repo: SchedulingSettingsRepository | None = None,
+    standalone: bool = False,
 ) -> list[dict[str, Any]]:
     """
     注文に対してスケジュールを作成する。
@@ -56,6 +57,7 @@ def schedule_order(
         dry_run: Trueの場合、DBに保存せずに計算結果のみを返す
         calendar_config: カレンダー設定（Noneの場合はデフォルト設定を使用）
         settings_repo: スケジューリング設定リポジトリ（Noneの場合はデフォルトパラメータ使用）
+        standalone: Trueの場合、既存スケジュールを無視して純粋な工程所要時間のみで計算する
 
     Returns:
         作成されたスケジュールのリスト
@@ -100,6 +102,7 @@ def schedule_order(
                 product_repo=product_repo,
                 schedule_repo=schedule_repo,
                 calendar_config=calendar_config,
+                standalone=standalone,
             )
 
         chosen_start = best["start"]
@@ -149,6 +152,7 @@ def _select_best_machine(
     product_repo: ProductRepository,
     schedule_repo: ScheduleRepository,
     calendar_config: CalendarConfig | None,
+    standalone: bool = False,
 ) -> dict:
     """設備グループから最も早く完了できる設備を選定してその候補情報を返す。"""
     machine_ids = _get_equipment_ids_by_group(product_repo, equipment_group_id)
@@ -157,36 +161,10 @@ def _select_best_machine(
 
     candidates = []
     for machine_id in machine_ids:
-        params = _resolve_params(
-            machine_id, equipment_group_id, tenant_id, settings_repo, product_repo
-        )
-        gap_result = _try_gap_fill(
-            machine_id=machine_id,
-            current_process_start=current_process_start,
-            total_duration_min=total_duration_min,
-            params=params,
-            schedule_repo=schedule_repo,
-            calendar_config=calendar_config,
-        )
-        if gap_result is not None:
-            candidates.append(
-                {
-                    "machine_id": machine_id,
-                    "start": gap_result[0][0],
-                    "duration_sec": total_duration_sec,
-                    "segments": gap_result,
-                    "completion": gap_result[-1][1],
-                }
-            )
-        else:
-            last_end = schedule_repo.get_last_end_time(machine_id)
-            base_start = (
-                max(last_end, current_process_start)
-                if last_end
-                else current_process_start
-            )
+        if standalone:
+            # 既存スケジュールを無視: current_process_start からそのまま計算
             actual_start = get_next_available_start_time(
-                base_start, total_duration_min, calendar_config
+                current_process_start, total_duration_min, calendar_config
             )
             fb_segments = split_work_across_days(
                 actual_start, total_duration_min, calendar_config
@@ -200,6 +178,50 @@ def _select_best_machine(
                     "completion": fb_segments[-1][1],
                 }
             )
+        else:
+            params = _resolve_params(
+                machine_id, equipment_group_id, tenant_id, settings_repo, product_repo
+            )
+            gap_result = _try_gap_fill(
+                machine_id=machine_id,
+                current_process_start=current_process_start,
+                total_duration_min=total_duration_min,
+                params=params,
+                schedule_repo=schedule_repo,
+                calendar_config=calendar_config,
+            )
+            if gap_result is not None:
+                candidates.append(
+                    {
+                        "machine_id": machine_id,
+                        "start": gap_result[0][0],
+                        "duration_sec": total_duration_sec,
+                        "segments": gap_result,
+                        "completion": gap_result[-1][1],
+                    }
+                )
+            else:
+                last_end = schedule_repo.get_last_end_time(machine_id)
+                base_start = (
+                    max(last_end, current_process_start)
+                    if last_end
+                    else current_process_start
+                )
+                actual_start = get_next_available_start_time(
+                    base_start, total_duration_min, calendar_config
+                )
+                fb_segments = split_work_across_days(
+                    actual_start, total_duration_min, calendar_config
+                )
+                candidates.append(
+                    {
+                        "machine_id": machine_id,
+                        "start": actual_start,
+                        "duration_sec": total_duration_sec,
+                        "segments": None,
+                        "completion": fb_segments[-1][1],
+                    }
+                )
 
     return min(candidates, key=lambda x: x["completion"])  # type: ignore
 

--- a/docs/features/simulation-engine.md
+++ b/docs/features/simulation-engine.md
@@ -50,6 +50,7 @@ PATCH /production-schedules/{id}  ← ガントチャート上でドラッグ手
 | `start_time` | `datetime \| None` | シミュレーション開始基準時刻。`None` の場合は現在時刻 |
 | `dry_run` | `bool` | `True` = 算出のみ / `False` = DB 保存 |
 | `calendar_config` | `CalendarConfig \| None` | 稼働カレンダー設定 |
+| `standalone` | `bool` | `True` = 既存スケジュールを無視した単体換算モード（後述） |
 
 ### アルゴリズムステップ
 
@@ -108,6 +109,21 @@ PATCH /production-schedules/{id}  ← ガントチャート上でドラッグ手
 | `True` | スケジュールを計算して返すのみ。DB への書き込みなし |
 | `False` | 計算後に `production_schedules` へ INSERT。受注ステータスも更新 |
 
+### standalone モード
+
+`standalone=True` を渡すと、設備の選択時に `production_schedules` の参照をスキップし、
+稼働カレンダーのみに基づいた純粋な工程所要時間を計算する。
+
+| `standalone` | 動作 |
+|---|---|
+| `False`（デフォルト） | 確定済みスケジュールのギャップ埋め・末尾追加を行う通常モード |
+| `True` | 既存スケジュールを無視。`current_process_start` から即時割り当て |
+
+**用途**: 工程管理モーダルの「個数からの目安」カード。  
+単位時間の入力ミス検出のため「他の受注がない場合に N 個でおよそ何日かかるか」を表示する際に使用する。  
+受注管理側の通常シミュレーション（`standalone=False`）とは計算ロジックを共有しており、  
+カレンダー・稼働時間・複数日分割のルールは同一のエンジンが適用される。
+
 ---
 
 ## カレンダーロジック
@@ -160,9 +176,17 @@ class CalendarConfig:
 {
   "product_id": 100,
   "quantity": 50,
-  "desired_deadline": "2024-12-31T17:00:00+00:00"
+  "desired_deadline": "2024-12-31T17:00:00+00:00",
+  "standalone": false
 }
 ```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `product_id` | `int` | 製品 ID |
+| `quantity` | `int` | 生産数量 |
+| `desired_deadline` | `string \| null` | 希望納期（ISO 8601）。未指定時は `is_feasible` が常に `true` |
+| `standalone` | `bool` | `true` = 単体換算モード（既存スケジュール無視）。デフォルト `false` |
 
 **レスポンス**
 ```json
@@ -309,7 +333,8 @@ class CalendarConfig:
 | `backend/app/repositories/supa_infra/transaction/schedule_repo.py` | `production_schedules` DB 操作 |
 | `backend/app/models/transaction/order_schema.py` | `OrderSimulateRequest`, `OrderSimulateResponse` Pydantic スキーマ |
 | `frontend/src/hooks/use-orders.ts` | `useSimulateOrder`, `useConfirmOrder` TanStack Query フック |
-| `frontend/src/types/order.ts` | `OrderSimulateResponse`, `ProcessSchedule` TypeScript 型 |
+| `frontend/src/types/order.ts` | `OrderSimulateRequest`, `OrderSimulateResponse`, `ProcessSchedule` TypeScript 型 |
+| `frontend/src/components/product-routings-dialog.tsx` | 工程管理モーダル（`standalone: true` でカードの単体換算表示） |
 | `frontend/src/types/schedule.ts` | `Schedule` TypeScript 型 |
 | `frontend/src/components/simulation-result.tsx` | シミュレーション結果表示コンポーネント |
 

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -92,7 +92,7 @@ export function ProductRoutingsDialog({
     }, 500)
     return () => clearTimeout(timer)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [estimateQuantity, routings?.length, product?.id])
+  }, [estimateQuantity, routings, product?.id])
 
   // 工程 start〜end の経過日数を計算
   const estimateDays = (() => {
@@ -331,12 +331,22 @@ export function ProductRoutingsDialog({
                     type="number"
                     min="1"
                     value={estimateQuantity}
-                    onChange={(e) =>
-                      setEstimateQuantity(e.target.value === "" ? "" : Number(e.target.value))
-                    }
+                    onChange={(e) => {
+                      if (e.target.value === "") {
+                        setEstimateQuantity("")
+                      } else {
+                        const n = Number(e.target.value)
+                        if (Number.isFinite(n)) setEstimateQuantity(n)
+                      }
+                    }}
                     disabled={!routings || routings.length === 0}
                     className="h-8 text-sm"
                     placeholder="個数"
+                    onKeyDown={(e) => {
+                      if (e.key === "e" || e.key === "E" || e.key === "+" || e.key === "-") {
+                        e.preventDefault()
+                      }
+                    }}
                   />
                   <span className="text-sm text-muted-foreground whitespace-nowrap">個</span>
                 </div>
@@ -350,7 +360,7 @@ export function ProductRoutingsDialog({
                     </span>
                   ) : simulateMutation.isError ? (
                     <span className="text-destructive">計算に失敗しました</span>
-                  ) : estimateDays !== null ? (
+                  ) : estimateDays !== null && estimateQuantity !== "" && estimateQuantity >= 1 ? (
                     <span>
                       {estimateQuantity}個で <strong>{estimateDays}日</strong>（単体換算）
                     </span>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Pencil, Trash2, Plus } from "lucide-react"
+import { Pencil, Trash2, Plus, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import {
   Dialog,
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Table,
   TableBody,
@@ -38,6 +39,7 @@ import {
   useDeleteProcessRouting,
 } from "@/hooks/use-process-routings"
 import { useEquipmentGroups, formatGroupLabel } from "@/lib/hooks/use-equipment-groups"
+import { useSimulateOrder } from "@/hooks/use-orders"
 import type { Product } from "@/types/product"
 import type { ProcessRouting } from "@/types/process-routing"
 
@@ -67,14 +69,39 @@ export function ProductRoutingsDialog({
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [routingToDelete, setRoutingToDelete] = useState<ProcessRouting | null>(null)
 
+  // 個数からの目安
+  const [estimateQuantity, setEstimateQuantity] = useState<number | "">(1000)
+
   // データ取得
   const { data: routings, isLoading: isLoadingRoutings } = useProcessRoutings(product?.id ?? null)
   const { data: equipmentGroups, isLoading: isLoadingGroups } = useEquipmentGroups()
-  
+
   // ミューテーション
   const createMutation = useCreateProcessRouting()
   const updateMutation = useUpdateProcessRouting()
   const deleteMutation = useDeleteProcessRouting()
+  const simulateMutation = useSimulateOrder()
+
+  // 個数・工程が変わったら500ms debounce でシミュレーション実行
+  useEffect(() => {
+    if (!product || !routings || routings.length === 0) return
+    if (estimateQuantity === "" || estimateQuantity <= 0) return
+
+    const timer = setTimeout(() => {
+      simulateMutation.mutate({ product_id: product.id, quantity: estimateQuantity })
+    }, 500)
+    return () => clearTimeout(timer)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [estimateQuantity, routings?.length, product?.id])
+
+  // 工程 start〜end の経過日数を計算
+  const estimateDays = (() => {
+    const schedules = simulateMutation.data?.process_schedules
+    if (!schedules || schedules.length === 0) return null
+    const start = new Date(schedules[0].start_time)
+    const end = new Date(schedules[schedules.length - 1].end_time)
+    return Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+  })()
 
   // フォームをリセット
   const resetForm = () => {
@@ -292,11 +319,53 @@ export function ProductRoutingsDialog({
           </div>
 
           {/* 右側: 編集/追加フォーム */}
-          <div className="flex flex-col border rounded-md p-4">
-            <h3 className="text-sm font-semibold mb-4">
+          <div className="flex flex-col border rounded-md p-4 gap-4 overflow-y-auto">
+            {/* 個数からの目安カード */}
+            <Card className="shrink-0">
+              <CardHeader className="pb-2 pt-3 px-3">
+                <CardTitle className="text-xs font-semibold">個数からの目安</CardTitle>
+              </CardHeader>
+              <CardContent className="px-3 pb-3 space-y-2">
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min="1"
+                    value={estimateQuantity}
+                    onChange={(e) =>
+                      setEstimateQuantity(e.target.value === "" ? "" : Number(e.target.value))
+                    }
+                    disabled={!routings || routings.length === 0}
+                    className="h-8 text-sm"
+                    placeholder="個数"
+                  />
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">個</span>
+                </div>
+                <div className="text-sm font-medium min-h-[1.25rem]">
+                  {!routings || routings.length === 0 ? (
+                    <span className="text-muted-foreground">工程を登録すると計算できます</span>
+                  ) : simulateMutation.isPending ? (
+                    <span className="flex items-center gap-1 text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      計算中...
+                    </span>
+                  ) : simulateMutation.isError ? (
+                    <span className="text-destructive">計算に失敗しました</span>
+                  ) : estimateDays !== null ? (
+                    <span>
+                      {estimateQuantity}個で <strong>{estimateDays}日</strong>（単体換算）
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-[10px] text-muted-foreground leading-snug">
+                  他の受注がない場合の単体シミュレーション値です。実際の納期は設備の競合により異なる場合があります。
+                </p>
+              </CardContent>
+            </Card>
+
+            <h3 className="text-sm font-semibold">
               {editingRouting ? "工程編集" : "工程追加"}
             </h3>
-            
+
             <div className="space-y-4 flex-1">
               <div className="space-y-2">
                 <Label htmlFor="process-name">工程名</Label>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -88,7 +88,7 @@ export function ProductRoutingsDialog({
     if (estimateQuantity === "" || estimateQuantity <= 0) return
 
     const timer = setTimeout(() => {
-      simulateMutation.mutate({ product_id: product.id, quantity: estimateQuantity })
+      simulateMutation.mutate({ product_id: product.id, quantity: estimateQuantity, standalone: true })
     }, 500)
     return () => clearTimeout(timer)
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -357,7 +357,7 @@ export function ProductRoutingsDialog({
                   ) : null}
                 </div>
                 <p className="text-[10px] text-muted-foreground leading-snug">
-                  他の受注がない場合の単体シミュレーション値です。実際の納期は設備の競合により異なる場合があります。
+                  他の受注がない場合の単体換算値です。実際の納期は設備の混雑状況により長くなる場合があります。
                 </p>
               </CardContent>
             </Card>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -242,8 +242,8 @@ export function ProductRoutingsDialog({
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-6xl h-[700px] flex flex-col">
-        <DialogHeader>
+      <DialogContent className="max-w-6xl max-h-[85vh] flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>工程管理 - {product?.name}</DialogTitle>
           <DialogDescription>
             製品の製造工程（ルーティング）を管理します
@@ -254,14 +254,14 @@ export function ProductRoutingsDialog({
           {/* 左側: 工程リスト */}
           <div className="flex flex-col min-h-0">
             <h3 className="text-sm font-semibold mb-3">登録済み工程</h3>
-            <div className="border rounded-md flex-1 overflow-auto">
+            <div className="border rounded-md flex-1 overflow-y-auto">
               {isLoadingRoutings ? (
                 <div className="flex items-center justify-center h-full">
                   <p className="text-sm text-muted-foreground">読み込み中...</p>
                 </div>
               ) : routings && routings.length > 0 ? (
                 <Table>
-                  <TableHeader>
+                  <TableHeader className="sticky top-0 z-10 bg-background">
                     <TableRow>
                       <TableHead className="w-[80px]">順序</TableHead>
                       <TableHead>工程名</TableHead>
@@ -319,7 +319,7 @@ export function ProductRoutingsDialog({
           </div>
 
           {/* 右側: 編集/追加フォーム */}
-          <div className="flex flex-col border rounded-md p-4 gap-4 overflow-y-auto">
+          <div className="flex flex-col border rounded-md p-4 gap-4 overflow-y-auto min-h-0">
             {/* 個数からの目安カード */}
             <Card className="shrink-0">
               <CardHeader className="pb-2 pt-3 px-3">
@@ -340,10 +340,15 @@ export function ProductRoutingsDialog({
                       }
                     }}
                     disabled={!routings || routings.length === 0}
-                    className="h-8 text-sm"
+                    className="h-8 text-sm [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     placeholder="個数"
+                    onWheel={(e) => e.currentTarget.blur()}
                     onKeyDown={(e) => {
-                      if (e.key === "e" || e.key === "E" || e.key === "+" || e.key === "-") {
+                      if (
+                        e.key === "e" || e.key === "E" ||
+                        e.key === "+" || e.key === "-" ||
+                        e.key === "ArrowUp" || e.key === "ArrowDown"
+                      ) {
                         e.preventDefault()
                       }
                     }}
@@ -419,28 +424,30 @@ export function ProductRoutingsDialog({
                 )}
               </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="sequence-order">順序</Label>
-                <Input
-                  id="sequence-order"
-                  type="number"
-                  min="0"
-                  value={sequenceOrder}
-                  onChange={(e) => setSequenceOrder(e.target.value === "" ? "" : Number(e.target.value))}
-                  disabled={isPending}
-                />
-              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="sequence-order">順序</Label>
+                  <Input
+                    id="sequence-order"
+                    type="number"
+                    min="0"
+                    value={sequenceOrder}
+                    onChange={(e) => setSequenceOrder(e.target.value === "" ? "" : Number(e.target.value))}
+                    disabled={isPending}
+                  />
+                </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="setup-time">段取り時間 (秒)</Label>
-                <Input
-                  id="setup-time"
-                  type="number"
-                  min="0"
-                  value={setupTime}
-                  onChange={(e) => setSetupTime(e.target.value === "" ? "" : Number(e.target.value))}
-                  disabled={isPending}
-                />
+                <div className="space-y-2">
+                  <Label htmlFor="setup-time">段取り時間 (秒)</Label>
+                  <Input
+                    id="setup-time"
+                    type="number"
+                    min="0"
+                    value={setupTime}
+                    onChange={(e) => setSetupTime(e.target.value === "" ? "" : Number(e.target.value))}
+                    disabled={isPending}
+                  />
+                </div>
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -36,6 +36,7 @@ export interface OrderSimulateRequest {
   product_id: number
   quantity: number
   desired_deadline?: string
+  standalone?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary
- 工程管理モーダルの右パネル上部に「個数からの目安」カードを追加
- 個数入力（デフォルト1000）に対し、500ms debounce 後に既存の `POST /orders/simulate` を呼び出し、単体換算の完成日数を即時表示
- 工程の `process_schedules` の start〜end から経過日数を算出し「N個でD日（単体換算）」形式で表示
- 工程未登録時は入力無効化＋ガイダンス表示、計算中はスピナー、エラー時はメッセージを表示
- カード内に「他の受注がない場合の単体シミュレーション値」の注記を表示

## Test plan
- [ ] 工程が登録されている製品で工程管理モーダルを開き、個数からの目安カードが表示されることを確認
- [ ] デフォルト個数が 1000 になっていることを確認
- [ ] 個数を変更すると（ボタン押下なしで）日数が再計算・更新されることを確認
- [ ] 工程が0件の状態では入力欄が無効化され「工程を登録すると計算できます」が表示されることを確認
- [ ] 計算中はスピナーが表示されることを確認

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)