### PR TITLE
feat: 工程確定UIの追加とadminロール制限 (#199)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -119,6 +119,33 @@ def get_customer_repo(
     return CustomerRepository(client)
 
 
+def get_current_user_role(tenant_id: str, user_id: str, client: Client) -> str:
+    """organization_members から現在ユーザーのロールを取得する。
+
+    Returns:
+        "admin" または "member"
+
+    Raises:
+        HTTPException 403: テナントメンバーでない場合
+    """
+    res = (
+        client.table("organization_members")
+        .select("role")
+        .eq("tenant_id", tenant_id)
+        .eq("user_id", user_id)
+        .single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="テナントのメンバーではありません",
+        )
+    data = res.data
+    assert isinstance(data, dict)
+    return str(data["role"])
+
+
 def get_supabase_admin_client() -> Client:
     """
     Service Role Key を使ったSupabase管理者クライアントを返す。

--- a/backend/app/models/master/__init__.py
+++ b/backend/app/models/master/__init__.py
@@ -1,6 +1,6 @@
 # backend/app/models/master/__init__.py
 from .customer_schemas import CustomerCreateSchema, CustomerUpdateSchema
-from .process_routings import RoutingCreate, RoutingUpdate
+from .process_routings import RoutingCreate, RoutingResponse, RoutingUpdate
 from .product_schemas import ProductCreateSchema, ProductUpdateSchema
 
 __all__ = [
@@ -8,6 +8,7 @@ __all__ = [
     "ProductUpdateSchema",
     "RoutingCreate",
     "RoutingUpdate",
+    "RoutingResponse",
     "CustomerCreateSchema",
     "CustomerUpdateSchema",
 ]

--- a/backend/app/routers/master/process_routings.py
+++ b/backend/app/routers/master/process_routings.py
@@ -1,10 +1,19 @@
 # routers/master/process_routings.py
-from fastapi import APIRouter, Depends, HTTPException, Query
+from datetime import UTC, datetime
 
-from app.dependencies import get_current_tenant_id, get_product_repo
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.dependencies import (
+    get_current_tenant_id,
+    get_current_user_id,
+    get_current_user_role,
+    get_product_repo,
+    get_supabase_client,
+)
 from app.models.master import RoutingCreate, RoutingUpdate
 from app.repositories.supa_infra.master.product_repo import ProductRepository
 from app.utils.logger import get_logger
+from supabase import Client  # type: ignore
 
 process_routing_router = APIRouter(
     prefix="/process-routings", tags=["Master (Process Routings)"]
@@ -50,13 +59,31 @@ def get_process_routing(
 def update_process_routing(
     routing_id: int,
     routing_data: RoutingUpdate,
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
     repo: ProductRepository = Depends(get_product_repo),
 ):
-    """工程順序を更新"""
+    """工程順序を更新。is_confirmed の変更は admin のみ可能"""
     logger.info(f"Updating process routing {routing_id}")
-    result = repo.update_routing(
-        routing_id, routing_data.model_dump(exclude_unset=True)
-    )
+
+    update_dict = routing_data.model_dump(exclude_unset=True)
+
+    if "is_confirmed" in update_dict:
+        role = get_current_user_role(tenant_id, user_id, client)
+        if role != "admin":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="工程の確定・確定取消は管理者のみ操作できます",
+            )
+        if update_dict["is_confirmed"] is True:
+            update_dict["confirmed_by"] = user_id
+            update_dict["confirmed_at"] = datetime.now(UTC).isoformat()
+        else:
+            update_dict["confirmed_by"] = None
+            update_dict["confirmed_at"] = None
+
+    result = repo.update_routing(routing_id, update_dict)
     if not result:
         raise HTTPException(status_code=404, detail="Not found")
     return result

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -1,0 +1,46 @@
+# 工程確定UI（is_confirmed）
+
+Issue #197 / #199 で実装。
+
+## 概要
+
+工程ルーティング（`process_routings`）に確定フラグを追加し、`admin` ロールのみが確定操作を行えるよう制限する機能。
+
+## DB スキーマ変更
+
+`supabase/migrations/20260620000000_add_confirmed_fields_to_process_routings.sql` にて追加:
+
+| カラム | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `is_confirmed` | boolean NOT NULL | false | 確定フラグ |
+| `confirmed_by` | uuid (FK auth.users) | NULL | 確定操作を行ったユーザーID |
+| `confirmed_at` | timestamptz | NULL | 確定日時 |
+
+## Backend
+
+### ロール取得ヘルパー
+
+`backend/app/dependencies.py` に `get_current_user_role(tenant_id, user_id, client) -> str` を追加。`organization_members` テーブルから `role` を取得する。
+
+### PATCH エンドポイントのガード
+
+`PATCH /process-routings/{id}` で `is_confirmed` を含むリクエストの場合:
+- 呼び出し元ユーザーのロールを確認
+- `admin` でなければ HTTP 403 を返す
+- `is_confirmed=true` の場合、`confirmed_by` と `confirmed_at` を自動セット
+- `is_confirmed=false`（取消）の場合、両フィールドを NULL にリセット
+
+## Frontend
+
+### 型定義
+
+`frontend/src/types/process-routing.ts` の `ProcessRouting` に `is_confirmed`, `confirmed_by`, `confirmed_at` を追加。`ProcessRoutingUpdate` に `is_confirmed?: boolean` を追加。
+
+### UI（`product-routings-dialog.tsx`）
+
+- 工程リストに「確定」列を追加
+  - `admin` ユーザー: チェックボックス形式のトグルボタンを表示。クリックで確定/取消
+  - `member` ユーザー: 鍵アイコン（`Lock`）を表示し操作不可
+- 確定済み工程の工程名に緑色バッジ（「確定済み」）を表示
+- 確定取消時は AlertDialog で「確定を取り消しますか？」確認ダイアログを表示
+- `useCurrentMember()` フックでロールを判定

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Pencil, Trash2, Plus, Loader2 } from "lucide-react"
+import { Pencil, Trash2, Plus, Loader2, Lock, CheckCircle2 } from "lucide-react"
 import { toast } from "sonner"
 import {
   Dialog,
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import {
   Table,
   TableBody,
@@ -40,6 +41,7 @@ import {
 } from "@/hooks/use-process-routings"
 import { useEquipmentGroups, formatGroupLabel } from "@/lib/hooks/use-equipment-groups"
 import { useSimulateOrder } from "@/hooks/use-orders"
+import { useCurrentMember } from "@/hooks/use-tenant-members"
 import type { Product } from "@/types/product"
 import type { ProcessRouting } from "@/types/process-routing"
 
@@ -64,10 +66,14 @@ export function ProductRoutingsDialog({
   const [sequenceOrder, setSequenceOrder] = useState<number | "">(1)
   const [setupTime, setSetupTime] = useState<number | "">(0)
   const [unitTime, setUnitTime] = useState<number | "">(0)
-  
+
   // 削除確認ダイアログの状態
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [routingToDelete, setRoutingToDelete] = useState<ProcessRouting | null>(null)
+
+  // 確定取消確認ダイアログの状態
+  const [unconfirmDialogOpen, setUnconfirmDialogOpen] = useState(false)
+  const [routingToUnconfirm, setRoutingToUnconfirm] = useState<ProcessRouting | null>(null)
 
   // 個数からの目安
   const [estimateQuantity, setEstimateQuantity] = useState<number | "">(1000)
@@ -75,6 +81,9 @@ export function ProductRoutingsDialog({
   // データ取得
   const { data: routings, isLoading: isLoadingRoutings } = useProcessRoutings(product?.id ?? null)
   const { data: equipmentGroups, isLoading: isLoadingGroups } = useEquipmentGroups()
+  const { data: currentMember } = useCurrentMember()
+
+  const isAdmin = currentMember?.role === "admin"
 
   // ミューテーション
   const createMutation = useCreateProcessRouting()
@@ -216,7 +225,7 @@ export function ProductRoutingsDialog({
         productId: product.id,
       })
       toast.success("工程を削除しました")
-      
+
       // 削除した工程を編集中だった場合はフォームをリセット
       if (editingRouting?.id === routingToDelete.id) {
         resetForm()
@@ -227,6 +236,45 @@ export function ProductRoutingsDialog({
     } finally {
       setDeleteConfirmOpen(false)
       setRoutingToDelete(null)
+    }
+  }
+
+  // 確定トグルのハンドラ
+  const handleConfirmToggle = async (routing: ProcessRouting) => {
+    if (routing.is_confirmed) {
+      // 確定取消 → 確認ダイアログを表示
+      setRoutingToUnconfirm(routing)
+      setUnconfirmDialogOpen(true)
+    } else {
+      // 確定ON → 即時実行
+      try {
+        await updateMutation.mutateAsync({
+          id: routing.id,
+          data: { is_confirmed: true },
+        })
+        toast.success(`工程「${routing.process_name}」を確定しました`)
+      } catch (error) {
+        toast.error("確定操作に失敗しました")
+        console.error(error)
+      }
+    }
+  }
+
+  // 確定取消の実行
+  const handleUnconfirmConfirm = async () => {
+    if (!routingToUnconfirm) return
+    try {
+      await updateMutation.mutateAsync({
+        id: routingToUnconfirm.id,
+        data: { is_confirmed: false },
+      })
+      toast.success(`工程「${routingToUnconfirm.process_name}」の確定を取り消しました`)
+    } catch (error) {
+      toast.error("確定取消に失敗しました")
+      console.error(error)
+    } finally {
+      setUnconfirmDialogOpen(false)
+      setRoutingToUnconfirm(null)
     }
   }
 
@@ -268,6 +316,7 @@ export function ProductRoutingsDialog({
                       <TableHead>設備グループ</TableHead>
                       <TableHead className="w-[120px]">段取り時間(秒)</TableHead>
                       <TableHead className="w-[120px]">単位時間(秒)</TableHead>
+                      <TableHead className="w-[80px] text-center">確定</TableHead>
                       <TableHead className="w-[100px] text-right">操作</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -275,15 +324,50 @@ export function ProductRoutingsDialog({
                     {routings
                       .sort((a, b) => a.sequence_order - b.sequence_order)
                       .map((routing) => (
-                        <TableRow 
+                        <TableRow
                           key={routing.id}
                           className={editingRouting?.id === routing.id ? "bg-muted/50" : ""}
                         >
                           <TableCell className="font-medium">{routing.sequence_order}</TableCell>
-                          <TableCell>{routing.process_name}</TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-2">
+                              {routing.process_name}
+                              {routing.is_confirmed && (
+                                <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-500 text-green-600 bg-green-50">
+                                  <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
+                                  確定済み
+                                </Badge>
+                              )}
+                            </div>
+                          </TableCell>
                           <TableCell>{getEquipmentGroupName(routing.equipment_group_id)}</TableCell>
                           <TableCell>{routing.setup_time_seconds}</TableCell>
                           <TableCell>{routing.unit_time_seconds}</TableCell>
+                          <TableCell className="text-center">
+                            {isAdmin ? (
+                              <button
+                                type="button"
+                                onClick={() => handleConfirmToggle(routing)}
+                                disabled={isPending}
+                                aria-label={routing.is_confirmed ? "確定を取り消す" : "確定する"}
+                                className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
+                                  routing.is_confirmed
+                                    ? "bg-green-500 border-green-500"
+                                    : "bg-background border-input hover:border-green-400"
+                                } disabled:opacity-50 disabled:cursor-not-allowed`}
+                              >
+                                {routing.is_confirmed && (
+                                  <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 12 12">
+                                    <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                  </svg>
+                                )}
+                              </button>
+                            ) : (
+                              <div className="flex items-center justify-center" aria-label="管理者のみ操作可能">
+                                <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+                              </div>
+                            )}
+                          </TableCell>
                           <TableCell className="text-right">
                             <div className="flex justify-end gap-1">
                               <Button
@@ -509,6 +593,23 @@ export function ProductRoutingsDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>キャンセル</AlertDialogCancel>
           <AlertDialogAction onClick={handleDeleteConfirm}>削除</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+
+    {/* 確定取消確認ダイアログ */}
+    <AlertDialog open={unconfirmDialogOpen} onOpenChange={setUnconfirmDialogOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>確定を取り消しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            工程「{routingToUnconfirm?.process_name}」の確定を取り消します。
+            再度確定するまで、この工程は未確定状態になります。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction onClick={handleUnconfirmConfirm}>確定を取り消す</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/supabase/migrations/20260620000000_add_confirmed_fields_to_process_routings.sql
+++ b/supabase/migrations/20260620000000_add_confirmed_fields_to_process_routings.sql
@@ -1,0 +1,7 @@
+-- Add is_confirmed, confirmed_by, confirmed_at to process_routings
+-- These fields support admin-only routing confirmation workflow (Issue #197, #199)
+
+ALTER TABLE public.process_routings
+  ADD COLUMN IF NOT EXISTS is_confirmed boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS confirmed_by uuid REFERENCES auth.users(id),
+  ADD COLUMN IF NOT EXISTS confirmed_at timestamptz;


### PR DESCRIPTION
## Summary

- **DB**: `process_routings` テーブルに `is_confirmed`/`confirmed_by`/`confirmed_at` カラムを追加するマイグレーション
- **Backend**: `dependencies.py` に `get_current_user_role()` ヘルパーを追加し、`PATCH /process-routings/{id}` で `is_confirmed` 変更時に admin ガードと audit フィールドの自動セットを実装
- **Frontend**: `ProcessRouting` 型を更新し、工程管理ダイアログに確定トグル・緑色バッジ・確定取消確認ダイアログを追加

## Changes

### DB Migration
- `supabase/migrations/20260620000000_add_confirmed_fields_to_process_routings.sql`

### Backend
- `backend/app/dependencies.py`: `get_current_user_role(tenant_id, user_id, client)` 追加
- `backend/app/models/master/process_routings.py`: `RoutingCreate`/`RoutingUpdate` に `is_confirmed` 追加、`RoutingResponse` 追加
- `backend/app/routers/master/process_routings.py`: PATCH に admin ガード実装。`is_confirmed=true` 時に `confirmed_by`/`confirmed_at` 自動セット

### Frontend
- `frontend/src/types/process-routing.ts`: `is_confirmed`/`confirmed_by`/`confirmed_at` フィールド追加
- `frontend/src/components/product-routings-dialog.tsx`: 確定トグル列・緑バッジ・確定取消 AlertDialog 追加

## Test plan

- [ ] admin ユーザーで工程ダイアログを開き、確定トグルをクリックして確定できる
- [ ] 確定後、緑色「確定済み」バッジが表示される
- [ ] 確定取消時に「確定を取り消しますか？」ダイアログが表示される
- [ ] member ユーザーでダイアログを開き、確定列に鍵アイコンが表示されて操作できない
- [ ] member ユーザーが API で直接 `is_confirmed=true` を送ると HTTP 403 が返る
- [ ] DB に `confirmed_by` と `confirmed_at` が記録される

Closes #199
Related: #197, #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)