### PR TITLE
feat: 工程未登録製品の注文入力時に選択ダイアログを表示 (#208)

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -78,7 +78,7 @@ class TestOrderRouter:
             {"id": 1, "order_number": "ORD-001", "product_id": 1, "quantity": 100},
             {"id": 2, "order_number": "ORD-002", "product_id": 2, "quantity": 200},
         ]
-        mock_repo.get_all.return_value = db_data
+        mock_repo.get_all_with_routing_status.return_value = db_data
 
         response = client.get("/orders")
 
@@ -86,7 +86,7 @@ class TestOrderRouter:
         result = response.json()
         assert result[0]["order_no"] == "ORD-001"
         assert result[1]["order_no"] == "ORD-002"
-        mock_repo.get_all.assert_called_once()
+        mock_repo.get_all_with_routing_status.assert_called_once()
 
     def test_get_order_by_id(self, mock_repo):
         """GET /{id}: 1件取得のテスト"""
@@ -234,6 +234,26 @@ class TestOrderRouter:
         assert response.status_code == 404
         assert response.json()["detail"] == "Order not found"
 
+    def test_simulate_without_id_no_routing(
+        self,
+        headers,
+        mock_product_repo,
+        mock_equipment_repo,
+        mock_schedule_repo,
+    ):
+        """POST /simulate: 工程が未登録の製品に対するシミュレーションのテスト"""
+        mock_product_repo.get_routings_by_product.return_value = []
+
+        payload = {"product_id": 10009, "quantity": 1}
+        response = client.post("/orders/simulate", json=payload, headers=headers)
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["routing_status"] == "no_routing"
+        assert result["process_schedules"] == []
+        assert result["calculated_deadline"] is None
+        assert result["is_feasible"] is None
+
     def test_confirm_order(
         self,
         headers,
@@ -255,7 +275,7 @@ class TestOrderRouter:
         # Mockの設定
         mock_repo.get_by_id.return_value = order_data
 
-        # 工程データ
+        # 工程データ（is_confirmed=True で確定済み工程として設定）
         routings = [
             {
                 "id": 1,
@@ -263,6 +283,7 @@ class TestOrderRouter:
                 "setup_time_seconds": 1800,
                 "unit_time_seconds": 600,
                 "sequence_order": 1,
+                "is_confirmed": True,
             }
         ]
         mock_product_repo.get_routings_by_product.return_value = routings

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -189,6 +189,13 @@ def simulate_schedule_without_id(
         return build_simulate_response(
             result, order_data.deadline_date, product_repo, equipment_repo
         )
+    except RoutingUnconfirmedError as e:
+        return {
+            "routing_status": "no_routing" if e.no_routing else "unconfirmed",
+            "calculated_deadline": None,
+            "is_feasible": None,
+            "process_schedules": [],
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None
 

--- a/backend/app/scheduler_logic.py
+++ b/backend/app/scheduler_logic.py
@@ -31,11 +31,12 @@ _GAP_HORIZON_DAYS = 90
 
 
 class RoutingUnconfirmedError(ValueError):
-    """工程が未確定のためガント登録できない場合に送出する例外"""
+    """工程が未確定または未登録のためガント登録できない場合に送出する例外"""
 
-    def __init__(self, desired_deadline: str | None = None):
+    def __init__(self, desired_deadline: str | None = None, no_routing: bool = False):
         super().__init__("工程が未確定です。ガントチャートへの登録をスキップします")
         self.desired_deadline = desired_deadline
+        self.no_routing = no_routing
 
 
 def routings_are_confirmed(routings: list[dict[str, Any]]) -> bool:
@@ -86,7 +87,9 @@ def schedule_order(
     routings = product_repo.get_routings_by_product(product_id)
 
     if not routings:
-        raise ValueError(f"製品ID {product_id} に対する工程が見つかりません")
+        raise RoutingUnconfirmedError(
+            desired_deadline=desired_deadline, no_routing=True
+        )
 
     if not dry_run and not routings_are_confirmed(routings):
         raise RoutingUnconfirmedError(desired_deadline=desired_deadline)

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -92,3 +92,41 @@ Issue #197 / #199 / #200 で実装。
 | `components/orders/order-notification-cards.tsx` | アンバー系 STEP 3 カードを追加 |
 | `hooks/use-unconfirmed-routing-queue.ts` | 新規フック（TanStack Query） |
 | `app/page.tsx` | 5枚目 KPI カード「工程未確定」を追加（グリッドを `lg:grid-cols-5` に変更） |
+
+---
+
+## 工程未登録製品の注文入力フロー改善（Issue #208）
+
+工程が1件も登録されていない製品に対してシミュレーションを実行した際、エラーではなく選択ダイアログを表示する。
+
+### Backend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/scheduler_logic.py` | `RoutingUnconfirmedError` に `no_routing: bool = False` フィールドを追加。工程0件時は `ValueError` ではなく `RoutingUnconfirmedError(no_routing=True)` を送出 |
+| `app/routers/transaction/orders.py` | `POST /orders/simulate` で `RoutingUnconfirmedError` を catch し、HTTP 200 + `{"routing_status": "no_routing", ...}` を返す |
+
+### Frontend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `types/order.ts` | `OrderSimulateResponse` に `routing_status?: "no_routing" \| "unconfirmed"` を追加。`calculated_deadline` / `is_feasible` を nullable に変更 |
+| `app/orders/new/page.tsx` | `routing_status === "no_routing"` 検出時に選択ダイアログを表示。Path A: `ProductRoutingsDialog` をインライン表示し工程登録後に自動再シミュレーション。Path B: `createMutation` で draft 保存後 `/orders` にリダイレクト |
+| `components/simulation-result.tsx` | `calculated_deadline` が null の場合に null ガードを追加 |
+| `components/orders/bulk-simulate-summary-dialog.tsx` | `calculated_deadline` が null の場合のフォールバック表示を追加 |
+
+### フロー
+
+```
+シミュレーション実行（工程未登録製品）
+  → routing_status: "no_routing"（HTTP 200）
+  → 選択ダイアログ
+      ├─ A: 工程を登録してから注文する
+      │      → ProductRoutingsDialog を開く
+      │      → ダイアログを閉じると自動再シミュレーション
+      │      → 確定まで通常フローで完結
+      └─ B: 下書きで保存する
+             → draft 注文として保存
+             → /orders にリダイレクト
+             → 専門家キューに自動表示（has_unconfirmed_routings=true）
+```

--- a/frontend/src/app/orders/new/page.tsx
+++ b/frontend/src/app/orders/new/page.tsx
@@ -3,21 +3,30 @@
 import { useState } from "react"
 import { toast } from "sonner"
 import { useRouter } from "next/navigation"
-import { AlertTriangle, Calculator, Check, Save } from "lucide-react"
+import { AlertTriangle, BookOpen, Calculator, Check, Save } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { ProductSelector } from "@/components/product-selector"
 import { CustomerSelector } from "@/components/customer-selector"
 import { SimulationResult } from "@/components/simulation-result"
+import { ProductRoutingsDialog } from "@/components/product-routings-dialog"
 import { useSimulateOrder, useCreateOrder, useConfirmOrder } from "@/hooks/use-orders"
 import { useProducts } from "@/hooks/use-products"
 import { useCustomers } from "@/hooks/use-customers"
 import { getProductName, getCustomerName } from "@/lib/order-utils"
 import type { OrderSimulateResponse } from "@/types/order"
+import type { Product } from "@/types/product"
 
 /**
  * 注文登録・納期回答シミュレーション画面
@@ -32,12 +41,17 @@ export default function NewOrderPage() {
   const [desiredDeadline, setDesiredDeadline] = useState("")
   const [simulationResult, setSimulationResult] = useState<OrderSimulateResponse | null>(null)
   const [hasAttemptedSimulation, setHasAttemptedSimulation] = useState(false)
+  const [noRoutingDialogOpen, setNoRoutingDialogOpen] = useState(false)
+  const [routingDialogOpen, setRoutingDialogOpen] = useState(false)
 
   const simulateMutation = useSimulateOrder()
   const createMutation = useCreateOrder()
   const confirmMutation = useConfirmOrder()
   const { data: products } = useProducts()
   const { data: customers } = useCustomers()
+
+  const selectedProduct: Product | null =
+    products?.find((p) => p.id === parseInt(productId)) ?? null
 
   const handleSimulate = async () => {
     setHasAttemptedSimulation(true)
@@ -67,12 +81,49 @@ export default function NewOrderPage() {
         quantity: quantityNum,
         desired_deadline: desiredDeadline || undefined,
       })
+
+      if (result.routing_status === "no_routing") {
+        setNoRoutingDialogOpen(true)
+        return
+      }
+
       setSimulationResult(result)
       toast.success("シミュレーションが完了しました")
     } catch (error) {
       console.error("Simulation error:", error)
       toast.error("シミュレーションに失敗しました")
     }
+  }
+
+  const handleSaveAsDraft = async () => {
+    const productIdNum = parseInt(productId)
+    const quantityNum = parseInt(quantity)
+
+    if (isNaN(productIdNum) || isNaN(quantityNum)) {
+      toast.error("製品IDまたは数量が無効です")
+      return
+    }
+
+    try {
+      await createMutation.mutateAsync({
+        order_no: orderNo || undefined,
+        product_id: productIdNum,
+        customer_id: customerId ? parseInt(customerId) : undefined,
+        quantity: quantityNum,
+        desired_deadline: desiredDeadline || undefined,
+      })
+      setNoRoutingDialogOpen(false)
+      toast.success("下書き保存しました。工程登録後に専門家キューから確定できます")
+      router.push("/orders")
+    } catch (error) {
+      console.error("Draft save error:", error)
+      toast.error("下書き保存に失敗しました")
+    }
+  }
+
+  const handleOpenRoutingRegistration = () => {
+    setNoRoutingDialogOpen(false)
+    setRoutingDialogOpen(true)
   }
 
   const handleConfirm = async () => {
@@ -270,7 +321,7 @@ export default function NewOrderPage() {
           <SimulationResult
             result={simulationResult}
             desiredDeadline={desiredDeadline}
-            summaryContent={simulationResult && (
+            summaryContent={simulationResult && simulationResult.calculated_deadline && (
               <div className="rounded-lg border p-4 space-y-3 text-sm">
                 <p className="font-semibold">注文内容の確認</p>
                 <dl className="space-y-1.5">
@@ -319,6 +370,51 @@ export default function NewOrderPage() {
           />
         </div>
       </div>
+
+      {/* 工程未登録選択ダイアログ */}
+      <Dialog open={noRoutingDialogOpen} onOpenChange={setNoRoutingDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>この製品には工程が登録されていません</DialogTitle>
+            <DialogDescription>
+              「{selectedProduct?.name ?? "選択中の製品"}」の生産工程が未登録のため、納期のシミュレーションができません。次の操作を選択してください。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid grid-cols-2 gap-4 pt-2">
+            <button
+              onClick={handleOpenRoutingRegistration}
+              className="flex flex-col items-start gap-2 rounded-lg border-2 border-primary bg-primary/5 p-4 text-left hover:bg-primary/10 transition-colors"
+            >
+              <BookOpen className="h-6 w-6 text-primary" />
+              <p className="font-semibold text-sm">工程を登録してから注文する</p>
+              <p className="text-xs text-muted-foreground">
+                工程を登録し、その後シミュレーションを実行します
+              </p>
+            </button>
+            <button
+              onClick={handleSaveAsDraft}
+              disabled={createMutation.isPending}
+              className="flex flex-col items-start gap-2 rounded-lg border-2 border-muted bg-muted/30 p-4 text-left hover:bg-muted/50 transition-colors disabled:opacity-50"
+            >
+              <Save className="h-6 w-6 text-muted-foreground" />
+              <p className="font-semibold text-sm">下書きで保存する</p>
+              <p className="text-xs text-muted-foreground">
+                今すぐ下書き保存し、あとで工程登録・確定できます
+              </p>
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* 工程登録ダイアログ（既存コンポーネント流用） */}
+      <ProductRoutingsDialog
+        product={selectedProduct}
+        open={routingDialogOpen}
+        onOpenChange={(open) => {
+          setRoutingDialogOpen(open)
+          if (!open) handleSimulate()
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
+++ b/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
@@ -111,13 +111,13 @@ export function BulkSimulateSummaryDialog({ results, onClose, onBulkConfirm }: B
                       </p>
                       <p>
                         <span className="text-xs text-muted-foreground/70">回答　</span>
-                        {formatDate(r.result!.calculated_deadline)}
+                        {r.result!.calculated_deadline ? formatDate(r.result!.calculated_deadline) : "—"}
                       </p>
                     </>
                   ) : (
                     <p>
                       <span className="text-xs text-muted-foreground/70">回答　</span>
-                      {formatDate(r.result!.calculated_deadline)}
+                      {r.result!.calculated_deadline ? formatDate(r.result!.calculated_deadline) : "—"}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/simulation-result.tsx
+++ b/frontend/src/components/simulation-result.tsx
@@ -33,8 +33,8 @@ export function SimulationResult({
   }
 
   // 日付の検証
-  const calculatedDate = new Date(result.calculated_deadline)
-  if (isNaN(calculatedDate.getTime())) {
+  const calculatedDate = result.calculated_deadline ? new Date(result.calculated_deadline) : null
+  if (!calculatedDate || isNaN(calculatedDate.getTime())) {
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
         <div className="text-center">

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -52,10 +52,12 @@ export interface ProcessSchedule {
 
 /**
  * 注文シミュレーション結果のデータ型
+ * routing_status が "no_routing" の場合、calculated_deadline / is_feasible は null
  */
 export interface OrderSimulateResponse {
-  calculated_deadline: string // ISO 8601形式
-  is_feasible: boolean // 希望納期に間に合うか
+  routing_status?: "no_routing" | "unconfirmed"
+  calculated_deadline: string | null // ISO 8601形式
+  is_feasible: boolean | null // 希望納期に間に合うか
   process_schedules: ProcessSchedule[]
 }
 


### PR DESCRIPTION
## Summary

- 工程が1件も登録されていない製品でシミュレーションを実行した際、エラートーストではなく「工程を登録してから注文する」「下書きで保存する」の2択ダイアログを表示するよう変更
- Backend: 工程0件を `RoutingUnconfirmedError(no_routing=True)` として統一し、`/simulate` から HTTP 200 + `routing_status: "no_routing"` を返す
- Frontend: `ProductRoutingsDialog` をインライン表示して工程登録→自動再シミュレーションの一連フローを `/orders/new` 内で完結させる

Closes #208

## Test plan

- [ ] `/orders/new` で工程未登録製品を選択 → シミュレーション実行 → 選択ダイアログが表示される
- [ ] Path A: 「工程を登録してから注文する」→ 工程登録ダイアログが開く → 工程を追加 → 閉じると自動再シミュレーション → 確定まで完結する
- [ ] Path B: 「下書きで保存する」→ `/orders` にリダイレクト → draft として表示 → 専門家キューに表示される
- [ ] 工程登録済みの製品は従来どおりシミュレーション成功する
- [ ] `pytest __tests__/api/routers/transaction/test_orders.py` が全件パスする（11件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)