### PR TITLE
fix: 重複マイグレーションファイルを削除

### DIFF
--- a/supabase/migrations/20260620000000_add_is_confirmed_to_process_routings.sql
+++ b/supabase/migrations/20260620000000_add_is_confirmed_to_process_routings.sql
@@ -1,4 +1,0 @@
-ALTER TABLE process_routings
-  ADD COLUMN IF NOT EXISTS is_confirmed boolean NOT NULL DEFAULT false,
-  ADD COLUMN IF NOT EXISTS confirmed_by uuid REFERENCES auth.users(id),
-  ADD COLUMN IF NOT EXISTS confirmed_at timestamptz;


### PR DESCRIPTION
## Summary

- 同一タイムスタンプ `20260620000000` を持つ重複マイグレーションファイルを削除
- `supabase migration up` 実行時に `schema_migrations_pkey` の unique constraint violation が発生していた原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)