### PR TITLE
fix: 注文一覧フィルタータブを orders.status のみに限定する (#215)

### DIFF
--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -2,15 +2,13 @@ import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
 import type { Customer } from "@/types/customer"
 
-export type StatusFilter = "" | "draft" | "confirmed" | "incomplete" | "completed" | "canceled" | "unconfirmed_routing"
+export type StatusFilter = "" | "draft" | "confirmed" | "completed" | "canceled"
 export type SortKey = "created_at_desc" | "created_at_asc" | "desired_deadline_asc"
 
 export const STATUS_TABS: { label: string; value: StatusFilter }[] = [
   { label: "すべて", value: "" },
   { label: "下書き", value: "draft" },
   { label: "確定済", value: "confirmed" },
-  { label: "情報不足", value: "incomplete" },
-  { label: "工程未確定", value: "unconfirmed_routing" },
   { label: "完了", value: "completed" },
   { label: "キャンセル", value: "canceled" },
 ]
@@ -24,8 +22,6 @@ export const SORT_OPTIONS: { label: string; value: SortKey }[] = [
 ]
 
 export function filterOrder(order: Order, statusFilter: StatusFilter): boolean {
-  if (statusFilter === "incomplete") return !order.customer_id || !order.desired_deadline
-  if (statusFilter === "unconfirmed_routing") return order.status === "draft" && !!order.has_unconfirmed_routings
   if (statusFilter) return order.status === statusFilter
   return true
 }


### PR DESCRIPTION
## 変更内容

`frontend/src/lib/order-utils.ts` のみ変更。バックエンド変更なし。

- `StatusFilter` 型から `"incomplete" | "unconfirmed_routing"` を削除
- `STATUS_TABS` から「情報不足」「工程未確認」の 2 エントリを削除（7→5タブ）
- `filterOrder()` から `incomplete` / `unconfirmed_routing` の分岐を削除

STEP1〜3 バナーの件数カウント（`incompleteCount`, `unconfirmedRoutingCount`）は `use-orders-page.ts` で直接算出しており、今回の変更の影響を受けない。

## 確認方法

- [ ] フィルタータブが「すべて / 下書き / 確定済 / 完了 / キャンセル」の 5 つになっている
- [ ] 「情報不足」「工程未確認」タブが消えている
- [ ] STEP1〜3 バナー（件数表示）に変化がない
- [ ] 各タブでの絞り込み結果に変化がない

## 関連

closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)