### PR TITLE
fix: 工程未設定の注文でシミュレーション実行時に422を返しフロントエンドで適切に処理する

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -234,6 +234,31 @@ class TestOrderRouter:
         assert response.status_code == 404
         assert response.json()["detail"] == "Order not found"
 
+    def test_simulate_schedule_no_routing(
+        self,
+        headers,
+        mock_repo,
+        mock_product_repo,
+        mock_equipment_repo,
+        mock_schedule_repo,
+    ):
+        """POST /{order_id}/simulate: 工程が未登録の場合に422を返すテスト"""
+        order_id = 1
+        order_data = {
+            "id": order_id,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+        }
+        mock_repo.get_by_id.return_value = order_data
+        mock_product_repo.get_routings_by_product.return_value = []
+
+        response = client.post(f"/orders/{order_id}/simulate", headers=headers)
+
+        assert response.status_code == 422
+        result = response.json()
+        assert result["detail"]["error"] == "no_routing"
+
     def test_simulate_without_id_no_routing(
         self,
         headers,

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -233,6 +233,13 @@ def simulate_schedule(
         return build_simulate_response(
             result, order.get("deadline_date"), product_repo, equipment_repo
         )
+    except RoutingUnconfirmedError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "no_routing" if e.no_routing else "routing_unconfirmed",
+            },
+        ) from None
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None
 

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -58,7 +58,13 @@ export default function OrderDetailPage() {
       toast.success("シミュレーションが完了しました")
     } catch (error) {
       if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
-        toast.error("工程が設定されていないため、シミュレーションを実行できません。製品の工程を設定してください。")
+        toast.error("工程が設定されていないため、シミュレーションを実行できません。", {
+          description: "製品マスタから工程を設定してください。",
+          action: {
+            label: "工程を設定する",
+            onClick: () => router.push("/master/products"),
+          },
+        })
       } else {
         toast.error("シミュレーションに失敗しました")
       }

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function OrderDetailPage() {
       setSimulationResult(result)
       toast.success("シミュレーションが完了しました")
     } catch (error) {
-      if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
+      if (error instanceof ApiError && error.status === 422 && error.errorCode === "no_routing") {
         toast.error("工程が設定されていないため、シミュレーションを実行できません。", {
           description: "製品マスタから工程を設定してください。",
           action: {

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   getStatusBadgeClass,
 } from "@/lib/order-utils"
 import type { OrderSimulateResponse } from "@/types/order"
+import { ApiError } from "@/lib/api-client"
 
 export default function OrderDetailPage() {
   const params = useParams()
@@ -55,8 +56,12 @@ export default function OrderDetailPage() {
       const result = await simulateMutation.mutateAsync(orderId)
       setSimulationResult(result)
       toast.success("シミュレーションが完了しました")
-    } catch {
-      toast.error("シミュレーションに失敗しました")
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
+        toast.error("工程が設定されていないため、シミュレーションを実行できません。製品の工程を設定してください。")
+      } else {
+        toast.error("シミュレーションに失敗しました")
+      }
     }
   }
 

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -20,6 +20,7 @@ import {
   type SortKey,
 } from "@/lib/order-utils"
 import type { Order, OrderSimulateResponse, BulkSimulateResult } from "@/types/order"
+import { ApiError } from "@/lib/api-client"
 
 const PAGE_SIZE = 20
 
@@ -136,9 +137,12 @@ export function useOrdersPage() {
       setExpandedOrderId(order.id)
       setExpandedSimResult(result)
     } catch (error) {
-      console.error("Simulation error:", error)
       setSimulationErrorOrderId(order.id)
-      toast.error("シミュレーションに失敗しました")
+      if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
+        toast.error("工程が設定されていないため、シミュレーションを実行できません。製品の工程を設定してください。")
+      } else {
+        toast.error("シミュレーションに失敗しました")
+      }
     } finally {
       setSimulatingOrderId(null)
     }

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -138,7 +138,7 @@ export function useOrdersPage() {
       setExpandedSimResult(result)
     } catch (error) {
       setSimulationErrorOrderId(order.id)
-      if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
+      if (error instanceof ApiError && error.status === 422 && error.errorCode === "no_routing") {
         toast.error("工程が設定されていないため、シミュレーションを実行できません。", {
           description: "製品マスタから工程を設定してください。",
           action: {

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -139,7 +139,13 @@ export function useOrdersPage() {
     } catch (error) {
       setSimulationErrorOrderId(order.id)
       if (error instanceof ApiError && error.status === 422 && error.data.error === "no_routing") {
-        toast.error("工程が設定されていないため、シミュレーションを実行できません。製品の工程を設定してください。")
+        toast.error("工程が設定されていないため、シミュレーションを実行できません。", {
+          description: "製品マスタから工程を設定してください。",
+          action: {
+            label: "工程を設定する",
+            onClick: () => router.push("/master/products"),
+          },
+        })
       } else {
         toast.error("シミュレーションに失敗しました")
       }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -15,6 +15,15 @@ export class ApiError extends Error {
         this.status = status
         this.data = data
     }
+
+    // FastAPI は {"detail": {"error": "..."}} の形で返すため detail.error を参照する
+    get errorCode(): string | undefined {
+        const detail = this.data.detail
+        if (detail && typeof detail === 'object' && 'error' in detail) {
+            return (detail as Record<string, unknown>).error as string
+        }
+        return undefined
+    }
 }
 
 /**

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -5,6 +5,18 @@ type FetchOptions = RequestInit & {
     headers?: Record<string, string>
 }
 
+export class ApiError extends Error {
+    status: number
+    data: Record<string, unknown>
+
+    constructor(status: number, data: Record<string, unknown>) {
+        super(typeof data.detail === 'string' ? data.detail : 'API Request Failed')
+        this.name = 'ApiError'
+        this.status = status
+        this.data = data
+    }
+}
+
 /**
  * カスタムAPIクライアント
  * AuthorizationヘッダーにJWTトークンを付与し、テナントIDをヘッダー(x-tenant-id)に付与する
@@ -48,7 +60,7 @@ export async function apiClient<T>(endpoint: string, options: FetchOptions = {})
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || 'API Request Failed')
+        throw new ApiError(response.status, errorData)
     }
 
     return response.json()


### PR DESCRIPTION
## Summary

- `POST /orders/{order_id}/simulate` に `RoutingUnconfirmedError` の専用キャッチを追加し、工程未設定時に HTTP 422 + `{"error": "no_routing"}` を返すよう修正（従来は `ValueError` 経由で 400 + 生メッセージが返っていた）
- `api-client.ts` に `ApiError` クラスを追加し、ステータスコードと構造化エラーデータを保持したままスロー
- 注文詳細ページ (`orders/[id]/page.tsx`) と注文一覧フック (`use-orders-page.ts`) で 422 + `error: "no_routing"` を判定し、「工程が設定されていないため、シミュレーションを実行できません。製品の工程を設定してください。」の専用トーストを表示

## Test plan

- [ ] 工程が未設定の下書き注文の詳細画面 (`/orders/{id}`) で「シミュレーションを実行する」を押す → 専用エラートーストが表示されること
- [ ] 注文一覧画面でも同様に専用トーストが表示されること
- [ ] コンソールにエラーが出力されないこと
- [ ] `pytest backend/__tests__/api/` が全パスすること（新規テスト `test_simulate_schedule_no_routing` を含む）
- [ ] TypeScript 型エラーがないこと

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)