### PR TITLE
feat: 製品一覧APIに has_process フラグを追加する

### DIFF
--- a/backend/app/models/master/product_schemas.py
+++ b/backend/app/models/master/product_schemas.py
@@ -25,6 +25,9 @@ class Product(ProductBase):
     """読み取り用製品のスキーマ"""
 
     id: int
+    has_process: bool = Field(
+        default=False, description="工程が1件以上登録されているか"
+    )
 
 
 class ProductUpdateSchema(BaseSchema):

--- a/backend/app/repositories/supa_infra/master/product_repo.py
+++ b/backend/app/repositories/supa_infra/master/product_repo.py
@@ -10,6 +10,21 @@ class ProductRepository(BaseRepository[T]):
     def __init__(self, client):
         super().__init__(client, SupabaseTableName.PRODUCTS.value)
 
+    def get_all(self) -> list[T]:
+        """製品を全件取得。process_routings の有無を has_process フラグとして付与する。"""
+        res = (
+            self.client.table(SupabaseTableName.PRODUCTS.value)
+            .select(f"*, {SupabaseTableName.PROCESS_ROUTINGS.value}(id)")
+            .execute()
+        )
+        result: list[dict[str, Any]] = []
+        for item in res.data or []:
+            row = cast(dict[str, Any], item)
+            routings = row.pop(SupabaseTableName.PROCESS_ROUTINGS.value, None) or []
+            row["has_process"] = len(routings) > 0
+            result.append(row)
+        return cast(list[T], result)
+
     def get_routings_by_product(self, product_id: int) -> list[T]:
         """製品IDに紐づく工程順序を取得"""
         res = (

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -7,6 +7,7 @@ export interface Product {
   code: string
   type: string
   is_active: boolean
+  has_process: boolean
   tenant_id: string
   created_at: string
   updated_at: string


### PR DESCRIPTION
## Summary

- `GET /products` のレスポンスに `has_process: boolean` フィールドを追加
- `ProductRepository.get_all()` をオーバーライドし、`process_routings` テーブルと LEFT JOIN して工程の有無を判定
- バックエンドの `Product` Pydantic スキーマおよびフロントエンドの `Product` TypeScript 型にフィールドを追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `backend/app/repositories/supa_infra/master/product_repo.py` | `get_all()` をオーバーライドし `process_routings` との LEFT JOIN + `has_process` 付与 |
| `backend/app/models/master/product_schemas.py` | `Product` に `has_process: bool` フィールドを追加 |
| `frontend/src/types/product.ts` | `Product` インターフェースに `has_process: boolean` を追加 |

## Test plan

- [x] `pytest __tests__/api/routers/master/test_products_router.py` — 7 passed
- [x] `ruff check` — 変更ファイルにエラーなし
- [x] `mypy` — エラーなし
- [x] `tsc --noEmit` — エラーなし
- [ ] ローカル Supabase 起動後、`GET /products` を呼び出して `has_process` が返ることを確認

## 関連 Issue

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)