### PR TITLE
feat: 新規注文フォームの製品プルダウンに工程未登録警告を表示する

### DIFF
--- a/frontend/src/app/orders/new/page.tsx
+++ b/frontend/src/app/orders/new/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { toast } from "sonner"
 import { useRouter } from "next/navigation"
+import Link from "next/link"
 import { AlertTriangle, BookOpen, Calculator, Check, Save } from "lucide-react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
@@ -251,6 +252,18 @@ export default function NewOrderPage() {
                 value={productId}
                 onValueChange={setProductId}
               />
+              {selectedProduct?.has_process === false && (
+                <div className="flex items-start gap-2 rounded-md border border-orange-200 bg-orange-50 px-3 py-2 text-sm text-orange-700">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>
+                    この製品は工程が登録されていないため、シミュレーションを実行できません。
+                    <Link href="/master/products" className="ml-1 underline underline-offset-2 hover:text-orange-900">
+                      マスタデータ &gt; 製品マスタ
+                    </Link>
+                    から工程を登録してください。
+                  </p>
+                </div>
+              )}
 
               {/* 顧客選択 */}
               <div>
@@ -300,7 +313,7 @@ export default function NewOrderPage() {
           <div className="flex gap-3">
             <Button
               onClick={handleSimulate}
-              disabled={simulateMutation.isPending}
+              disabled={simulateMutation.isPending || selectedProduct?.has_process === false}
               className="flex-1"
             >
               <Calculator className="mr-2 h-4 w-4" />

--- a/frontend/src/components/product-selector.tsx
+++ b/frontend/src/components/product-selector.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown } from "lucide-react"
+import { AlertTriangle, Check, ChevronsUpDown } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -98,7 +98,13 @@ export function ProductSelector({
                         value === product.id.toString() ? "opacity-100" : "opacity-0"
                       )}
                     />
-                    {[product.code, product.name].filter(Boolean).join(" - ")}
+                    {!product.has_process && (
+                      <AlertTriangle className="mr-1 h-3 w-3 shrink-0 text-orange-500" />
+                    )}
+                    <span className={!product.has_process ? "text-orange-600" : undefined}>
+                      {[product.code, product.name].filter(Boolean).join(" - ")}
+                      {!product.has_process && "（工程未登録）"}
+                    </span>
                   </CommandItem>
                 ))}
               </CommandGroup>


### PR DESCRIPTION
## Summary

- 製品プルダウンの選択肢で工程未登録の製品に `⚠` アイコンと `（工程未登録）` を付与（オレンジ表示）
- 工程未登録の製品を選択するとプルダウン直下にインライン警告を表示し、製品マスタへのリンクを提供
- 工程未登録の製品が選択されている場合はシミュレーション実行ボタンを disabled にする
- 既存の `no_routing` ダイアログ（PR #220）はそのまま残す（本 Issue は選択時の事前警告追加）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `frontend/src/components/product-selector.tsx` | 工程未登録品に `⚠` マーク・オレンジ表示を追加 |
| `frontend/src/app/orders/new/page.tsx` | インライン警告・製品マスタリンク・ボタン disabled 条件を追加 |

## Test plan

- [x] `tsc --noEmit` — エラーなし
- [ ] 工程未登録の製品のドロップダウン選択肢に `⚠` が表示されることを確認
- [ ] 工程未登録の製品を選択するとインライン警告が表示されることを確認
- [ ] インライン警告の「マスタデータ > 製品マスタ」リンクが `/master/products` に遷移することを確認
- [ ] 工程未登録の製品が選択された状態でシミュレーション実行ボタンが disabled になることを確認
- [ ] 工程登録済みの製品を選択した場合は警告が非表示でボタンが active になることを確認

## 依存関係

PR #225 (#222 `has_process` API 追加) のマージが前提。

## 関連 Issue

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)