### PR TITLE
fix: ログイン直後にサイドバーが表示されない問題を修正

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { createClient } from '@/utils/supabase/client'
 import { fetchMyTenantId } from '@/lib/auth-actions'
 import { Button } from '@/components/ui/button'
@@ -14,7 +13,6 @@ const DEFAULT_USER = process.env.NODE_ENV === 'development' ? process.env.NEXT_P
 const DEFAULT_PASSWORD = process.env.NODE_ENV === 'development' ? process.env.NEXT_PUBLIC_TEST_PASSWORD : ''
 
 export default function LoginPage() {
-    const router = useRouter()
     const [email, setEmail] = useState(DEFAULT_USER || '')
     const [password, setPassword] = useState(DEFAULT_PASSWORD || '')
     const [loading, setLoading] = useState(false)
@@ -50,9 +48,8 @@ export default function LoginPage() {
                 description: 'ダッシュボードへ移動します',
             })
 
-            // 4. リダイレクト (ルーターキャッシュをクリアして遷移)
-            router.refresh()
-            router.push('/')
+            // 4. リダイレクト (フルページリロードでサーバーが新セッションを確実に認識)
+            window.location.href = '/'
 
         } catch (error: any) {
             console.error(error)


### PR DESCRIPTION
## Summary
- ログイン後の `router.refresh()` + `router.push('/')` によるソフトナビゲーションを `window.location.href = '/'` に変更
- フルページリロードを強制することで、サーバーサイドが Supabase のセッション cookie を確実に認識できるようにした
- `useRouter` が不要になったため関連 import も削除

## 原因
`router.push('/')` はクライアントサイドルーティング（ソフトナビゲーション）のため、`signInWithPassword` で設定された cookie の認識タイミングと競合し、`layout.tsx` のサーバーサイド `getUser()` が null を返すことがあった。手動リロードでは完全な HTTP リクエストが発生するため cookie が正しく読み取れていた。

## Test plan
- [ ] ローカルでログインし、サイドバーが表示されることを確認
- [ ] 本番環境（Vercel）でログインし、リロードなしでサイドバーが表示されることを確認

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)