### PR TITLE
feat: Gmail受注下書きサンプルデータ登録スクリプトを追加 (#235)

### DIFF
--- a/backend/data/gmail_drafts/orders.json
+++ b/backend/data/gmail_drafts/orders.json
@@ -1,0 +1,81 @@
+[
+  {
+    "_comment": "パターンA-1: 単一製品マッチ済み（product_idは実行時にproduct_codeから解決）",
+    "order_number": "GMAIL-SEED-A001",
+    "product_code": "PRD-A001",
+    "quantity": 200,
+    "deadline_date": "2026-08-15",
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "スタンダード ウィジェット",
+    "product_candidates": null,
+    "source_raw": "From: suzuki.taro@example-mfg.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 受注依頼 PO-2026-A001\n\nいつもお世話になっております。\n鈴木製作所の鈴木太郎でございます。\n\n下記の通り受注をお願いいたします。\n\n品目：スタンダード ウィジェット\n数量：200個\n納期：2026年8月15日\n発注番号：PO-2026-A001\n\nご確認のほどよろしくお願いいたします。\n\n鈴木製作所\n鈴木 太郎\nTEL: 03-1234-5678"
+  },
+  {
+    "_comment": "パターンA-2: 単一製品マッチ済み",
+    "order_number": "GMAIL-SEED-A002",
+    "product_code": "PRD-C003",
+    "quantity": 500,
+    "deadline_date": "2026-07-31",
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "エコノミー パーツ",
+    "product_candidates": null,
+    "source_raw": "From: yamada.hanako@takeda-ind.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 【発注】エコノミーパーツ 500個\n\n貴社ますますご隆盛のこととお喜び申し上げます。\n武田工業の山田花子と申します。\n\n以下の商品を発注させていただきたく存じます。\n\n▼ 発注内容\n商品名：エコノミー パーツ\n発注数：500個\n希望納期：令和8年7月31日\n社内整理番号：TKD-2026-0731\n\nご対応のほどよろしくお願いいたします。\n\n武田工業株式会社\n購買部 山田 花子\nEmail: yamada.hanako@takeda-ind.co.jp"
+  },
+  {
+    "_comment": "パターンB-1: 複数候補あり（product_idはnull、candidatesはproduct_codeで指定し実行時にIDへ変換）",
+    "order_number": "GMAIL-SEED-B001",
+    "product_code": null,
+    "quantity": 150,
+    "deadline_date": "2026-09-01",
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "プレミアム ガジェット モデルX",
+    "product_candidates": [
+      {"product_code": "PRD-B002", "name": "プレミアム・ガジェット", "score": 0.78},
+      {"product_code": "PRD-D004", "name": "カスタム・モジュール", "score": 0.45},
+      {"product_code": "PRD-A001", "name": "スタンダード・ウィジェット", "score": 0.32}
+    ],
+    "source_raw": "From: kobayashi@maruichi-seiki.jp\nTo: orders@yourcompany.co.jp\nSubject: Re: お見積もりの件 → 正式発注\n\nお世話になっております。丸一精機の小林です。\n先日のお見積もり内容で正式発注いたします。\n\n品名：プレミアム ガジェット モデルX\n数量：150\n納期：2026/09/01\n\n請求書は月末締めでお願いします。\n\n---\n丸一精機株式会社\n小林 誠\nkobayashi@maruichi-seiki.jp\n☎ 06-9876-5432"
+  },
+  {
+    "_comment": "パターンB-2: 複数候補あり",
+    "order_number": "GMAIL-SEED-B002",
+    "product_code": null,
+    "quantity": 80,
+    "deadline_date": "2026-08-20",
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "ヘビーデューティー ユニット 大型",
+    "product_candidates": [
+      {"product_code": "PRD-E005", "name": "ヘビーデューティー・ユニット", "score": 0.85},
+      {"product_code": "PRD-D004", "name": "カスタム・モジュール", "score": 0.38}
+    ],
+    "source_raw": "From: nakamura.j@k-techno.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 発注書送付について\n\n関係者各位\n\nKテクノの中村と申します。\n添付の発注書に基づきご手配をお願いします。\n\n品目：ヘビーデューティー ユニット 大型\n数量：80台\n納期：2026年8月20日\n発注番号：KT-2026-0820-001\n\n納品書は弊社倉庫（神奈川県）宛にご送付ください。\n\nKテクノ株式会社\n購買担当 中村 純一\nTEL: 045-123-4567"
+  },
+  {
+    "_comment": "パターンC-1: マッチなし（product_idもcandidatesもnull）",
+    "order_number": "GMAIL-SEED-C001",
+    "product_code": null,
+    "quantity": 30,
+    "deadline_date": "2026-10-01",
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "超耐熱セラミックコーティング治具 φ50mm",
+    "product_candidates": null,
+    "source_raw": "From: ito.s@sunrise-mfg.com\nTo: orders@yourcompany.co.jp\nSubject: 新規部品の発注打診\n\nお世話になります。サンライズ製造の伊藤です。\n\n今回初めてのご依頼となります。\n以下の特注品について対応可否と納期をご確認いただけますでしょうか。\n\n品名：超耐熱セラミックコーティング治具 φ50mm\n数量：30個\n希望納期：2026年10月1日\n\n仕様書を別途メールにてお送りします。\nご検討よろしくお願いいたします。\n\nサンライズ製造株式会社\n技術部 伊藤 翔\nito.s@sunrise-mfg.com"
+  },
+  {
+    "_comment": "パターンC-2: マッチなし・数量も未抽出（量が不明な場合）",
+    "order_number": "GMAIL-SEED-C002",
+    "product_code": null,
+    "quantity": null,
+    "deadline_date": null,
+    "status": "draft",
+    "source_type": "email",
+    "extracted_product_name": "産業用ロボットアーム交換部品 型番TBD",
+    "product_candidates": null,
+    "source_raw": "From: logistics@fujisawa-corp.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 部品補充依頼\n\nお世話になっております。\n藤沢コーポレーションのロジスティクス部です。\n\n緊急の補充依頼です。詳細は担当者から追って連絡いたします。\n品名は産業用ロボットアーム交換部品（型番は手配中）です。\n\n取り急ぎご連絡まで。\n\n藤沢コーポレーション\n物流管理部\nlogistics@fujisawa-corp.co.jp\nTEL: 0466-XX-XXXX"
+  }
+]

--- a/backend/data/gmail_drafts/orders.json
+++ b/backend/data/gmail_drafts/orders.json
@@ -1,63 +1,51 @@
 [
   {
-    "_comment": "パターンA-1: 単一製品マッチ済み（product_idは実行時にproduct_codeから解決）",
+    "_comment": "パターンA-1: 単一製品マッチ済み",
     "order_number": "GMAIL-SEED-A001",
-    "product_code": "PRD-A001",
+    "product_name": "B115105",
     "quantity": 200,
     "deadline_date": "2026-08-15",
     "status": "draft",
     "source_type": "email",
-    "extracted_product_name": "スタンダード ウィジェット",
+    "extracted_product_name": "B115105",
     "product_candidates": null,
     "source_raw": "From: suzuki.taro@example-mfg.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 受注依頼 PO-2026-A001\n\nいつもお世話になっております。\n鈴木製作所の鈴木太郎でございます。\n\n下記の通り受注をお願いいたします。\n\n品目：スタンダード ウィジェット\n数量：200個\n納期：2026年8月15日\n発注番号：PO-2026-A001\n\nご確認のほどよろしくお願いいたします。\n\n鈴木製作所\n鈴木 太郎\nTEL: 03-1234-5678"
   },
   {
-    "_comment": "パターンA-2: 単一製品マッチ済み",
-    "order_number": "GMAIL-SEED-A002",
-    "product_code": "PRD-C003",
-    "quantity": 500,
-    "deadline_date": "2026-07-31",
-    "status": "draft",
-    "source_type": "email",
-    "extracted_product_name": "エコノミー パーツ",
-    "product_candidates": null,
-    "source_raw": "From: yamada.hanako@takeda-ind.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 【発注】エコノミーパーツ 500個\n\n貴社ますますご隆盛のこととお喜び申し上げます。\n武田工業の山田花子と申します。\n\n以下の商品を発注させていただきたく存じます。\n\n▼ 発注内容\n商品名：エコノミー パーツ\n発注数：500個\n希望納期：令和8年7月31日\n社内整理番号：TKD-2026-0731\n\nご対応のほどよろしくお願いいたします。\n\n武田工業株式会社\n購買部 山田 花子\nEmail: yamada.hanako@takeda-ind.co.jp"
-  },
-  {
-    "_comment": "パターンB-1: 複数候補あり（product_idはnull、candidatesはproduct_codeで指定し実行時にIDへ変換）",
+    "_comment": "パターンB-1: 複数候補あり（product_idはnull、candidatesはproduct_nameで指定し実行時にIDへ変換）",
     "order_number": "GMAIL-SEED-B001",
-    "product_code": null,
+    "product_name": null,
     "quantity": 150,
     "deadline_date": "2026-09-01",
     "status": "draft",
     "source_type": "email",
     "extracted_product_name": "プレミアム ガジェット モデルX",
     "product_candidates": [
-      {"product_code": "PRD-B002", "name": "プレミアム・ガジェット", "score": 0.78},
-      {"product_code": "PRD-D004", "name": "カスタム・モジュール", "score": 0.45},
-      {"product_code": "PRD-A001", "name": "スタンダード・ウィジェット", "score": 0.32}
+      {"product_name": "プレミアム・ガジェット", "name": "プレミアム・ガジェット", "score": 0.78},
+      {"product_name": "カスタム・モジュール", "name": "カスタム・モジュール", "score": 0.45},
+      {"product_name": "ヘビーデューティー・ユニット", "name": "ヘビーデューティー・ユニット", "score": 0.32}
     ],
     "source_raw": "From: kobayashi@maruichi-seiki.jp\nTo: orders@yourcompany.co.jp\nSubject: Re: お見積もりの件 → 正式発注\n\nお世話になっております。丸一精機の小林です。\n先日のお見積もり内容で正式発注いたします。\n\n品名：プレミアム ガジェット モデルX\n数量：150\n納期：2026/09/01\n\n請求書は月末締めでお願いします。\n\n---\n丸一精機株式会社\n小林 誠\nkobayashi@maruichi-seiki.jp\n☎ 06-9876-5432"
   },
   {
     "_comment": "パターンB-2: 複数候補あり",
     "order_number": "GMAIL-SEED-B002",
-    "product_code": null,
+    "product_name": null,
     "quantity": 80,
     "deadline_date": "2026-08-20",
     "status": "draft",
     "source_type": "email",
     "extracted_product_name": "ヘビーデューティー ユニット 大型",
     "product_candidates": [
-      {"product_code": "PRD-E005", "name": "ヘビーデューティー・ユニット", "score": 0.85},
-      {"product_code": "PRD-D004", "name": "カスタム・モジュール", "score": 0.38}
+      {"product_name": "ヘビーデューティー・ユニット", "name": "ヘビーデューティー・ユニット", "score": 0.85},
+      {"product_name": "カスタム・モジュール", "name": "カスタム・モジュール", "score": 0.38}
     ],
     "source_raw": "From: nakamura.j@k-techno.co.jp\nTo: orders@yourcompany.co.jp\nSubject: 発注書送付について\n\n関係者各位\n\nKテクノの中村と申します。\n添付の発注書に基づきご手配をお願いします。\n\n品目：ヘビーデューティー ユニット 大型\n数量：80台\n納期：2026年8月20日\n発注番号：KT-2026-0820-001\n\n納品書は弊社倉庫（神奈川県）宛にご送付ください。\n\nKテクノ株式会社\n購買担当 中村 純一\nTEL: 045-123-4567"
   },
   {
     "_comment": "パターンC-1: マッチなし（product_idもcandidatesもnull）",
     "order_number": "GMAIL-SEED-C001",
-    "product_code": null,
+    "product_name": null,
     "quantity": 30,
     "deadline_date": "2026-10-01",
     "status": "draft",
@@ -69,7 +57,7 @@
   {
     "_comment": "パターンC-2: マッチなし・数量も未抽出（量が不明な場合）",
     "order_number": "GMAIL-SEED-C002",
-    "product_code": null,
+    "product_name": null,
     "quantity": null,
     "deadline_date": null,
     "status": "draft",

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -1,14 +1,97 @@
 # スクリプト使い方ガイド
 
+## 共通前提条件
+
+`backend/scripts/` 配下のスクリプトはすべて以下の前提を共有しています。
+
+### 環境変数
+
+`backend/.env` に以下を設定してください。
+
+| 変数名 | 説明 |
+|--------|------|
+| `SUPABASE_URL` | ローカル Supabase の URL（`supabase start` で表示される `API URL`） |
+| `SUPABASE_PUBLISHABLE_KEY` | Supabase の anon/publishable キー |
+| `TEST_USER_EMAIL` | データ投入に使うユーザーのメールアドレス |
+| `TEST_USER_PASS` | 同パスワード |
+| `TEST_TENANT_ID` | データを投入するテナントの UUID |
+
+### 実行環境
+
+```bash
+# backend ディレクトリで仮想環境を有効にしてから実行
+cd backend
+source .venv/bin/activate   # または Windows: .venv\Scripts\activate
+```
+
+### ローカル Supabase の起動
+
+```bash
+supabase start
+```
+
+---
+
+## スクリプト一覧
+
+| スクリプト | 用途 | 実行コマンド |
+|-----------|------|-------------|
+| `seed_scenario.py` | シナリオ単位のデモデータ一括投入 | `python scripts/seed_scenario.py <シナリオ名>` |
+| `seed_gmail_drafts.py` | Gmail受注下書きサンプルデータ投入 | `python scripts/seed_gmail_drafts.py` |
+
+---
+
+## seed_scenario.py — シナリオデータ投入
+
+指定されたシナリオに基づいて Supabase にデモデータを投入します。設備・製品・工程・注文の順序依存関係を考慮して一括登録します。
+
+### データファイル構成
+
+`backend/data/scenarios/<シナリオ名>/` に以下の JSON を配置します。
+
+| ファイル | 内容 |
+|----------|------|
+| `01_groups.json` | 設備グループと設備の定義 |
+| `02_products.json` | 製品の定義 |
+| `03_routings.json` | 製造工程（ルーティング）の定義 |
+| `04_orders.json` | 注文データの定義 |
+
+### 使い方
+
+```bash
+python scripts/seed_scenario.py <シナリオ名>
+
+# 例: 標準デモデータ
+python scripts/seed_scenario.py standard_demo
+```
+
+### 処理の流れ
+
+1. **認証** — 環境変数でサインインし JWT を取得
+2. **設備・グループ** — `equipment_groups` / `equipments` / `equipment_group_members` を作成
+3. **製品** — `products` を作成
+4. **工程** — 製品コード・グループ名を解決し `process_routings` を登録
+5. **注文** — 製品コードを解決し `orders` を登録
+
+各ステップは UPSERT のため、複数回実行しても安全です。
+
+### エラーハンドリング
+
+- 環境変数不足 → エラーメッセージを表示して終了
+- シナリオディレクトリ不在 → エラー終了
+- 参照先コードが見つからない場合 → 該当行をスキップして警告表示
+
 ---
 
 ## seed_gmail_drafts.py — Gmail受注下書きサンプルデータ投入
 
-Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`source_type='email'`）のサンプルデータをローカル開発環境に投入します。下書き確認UI開発・動作確認用です。
+Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`source_type='email'`）のサンプルをローカルに投入します。下書き確認UI（フェーズ7）の開発・動作確認用です。
+
+> **注意:** 製品データが必要なため、先に `seed_scenario.py standard_demo` を実行してください。
 
 ### 投入されるデータ
 
-`backend/data/gmail_drafts/orders.json` に定義された以下の3パターン × 2件、計6件の `draft` 受注が作成されます。
+`backend/data/gmail_drafts/orders.json` に定義された3パターン × 2件、計6件の `draft` 受注を作成します。
 
 | パターン | `product_id` | `product_candidates` | 説明 |
 |----------|-------------|----------------------|------|
@@ -16,22 +99,9 @@ Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`so
 | B（複数候補あり） | null | JSON配列あり | 候補が複数あり、ユーザーが選択するケース |
 | C（マッチなし） | null | null | 製品を特定できなかったケース |
 
-### 前提条件
-
-以下の環境変数が `.env` に設定されている必要があります（`seed_scenario.py` と共通）。
-
-- `SUPABASE_URL`
-- `SUPABASE_PUBLISHABLE_KEY`
-- `TEST_USER_EMAIL`
-- `TEST_USER_PASS`
-- `TEST_TENANT_ID`
-
-> **注意:** `standard_demo` シナリオ（`seed_scenario.py standard_demo`）を先に実行して製品データが存在していること。製品コードが見つからない場合はその注文はスキップされます。
-
 ### 使い方
 
 ```bash
-# backend ディレクトリで実行
 python scripts/seed_gmail_drafts.py
 ```
 
@@ -60,69 +130,3 @@ python scripts/seed_gmail_drafts.py
 ```
 
 冪等性が保証されているため、複数回実行しても重複インサートは発生しません。
-
----
-
-## seed_scenario.py — シナリオデータ投入
-
-このスクリプトは、指定されたシナリオに基づいてSupabaseデータベースにデモデータを投入するためのツールです。
-順序依存関係を考慮して、設備、製品、工程、注文データを一括で登録します。
-
-## 前提条件
-
-### 1. 環境設定
-以下の環境変数が `.env` ファイルに設定されている必要があります。
-
-- `SUPABASE_URL`: SupabaseのプロジェクトURL
-- `SUPABASE_API_KEY`: Supabaseのサービスロールキー（またはanonキー）
-- `TEST_USER_EMAIL`: データ投入に使用するユーザーのメールアドレス
-- `TEST_USER_PASS`: データ投入に使用するユーザーのパスワード
-- `TEST_TENANT_ID`: データを投入するテナントのID
-
-### 2. データファイル
-データは以下のディレクトリ構成で配置されている必要があります。
-`backend/data/scenarios/<シナリオ名>/` に以下のJSONファイルが必要です。
-
-1. `01_groups.json`: 設備グループと設備の定義
-2. `02_products.json`: 製品の定義
-3. `03_routings.json`: 製造工程（ルーティング）の定義
-4. `04_orders.json`: 注文データの定義
-
-## 使い方
-
-`backend` ディレクトリ直下で以下のコマンドを実行します。
-
-```bash
-# 仮想環境が有効であることを確認してください
-python scripts/seed_scenario.py <シナリオ名>
-```
-
-### 実行例
-
-`standard_demo` シナリオ（標準デモデータ）を投入する場合:
-
-```bash
-python scripts/seed_scenario.py standard_demo
-```
-
-## 処理の流れ
-
-スクリプトは以下の順序でデータを処理・登録します。
-
-1. **認証**: 環境変数の情報を使ってSupabaseにサインインします。
-2. **設備・グループ定義 (`01_groups.json`)**: 
-   - 設備グループ (`equipment_groups`) を作成
-   - 設備 (`equipments`) を作成
-   - グループと設備の紐付け (`equipment_group_members`) を作成
-3. **製品定義 (`02_products.json`)**:
-   - 製品 (`products`) を作成
-4. **工程定義 (`03_routings.json`)**:
-   - 製品コードと設備グループ名を解決し、工程 (`process_routings`) を登録
-5. **注文定義 (`04_orders.json`)**:
-   - 製品コードを解決し、注文 (`orders`) を登録
-
-## エラーハンドリング
-
-- 必要な環境変数が不足している場合、エラーメッセージを表示して終了します。
-- 指定されたシナリオディレクトリが存在しない場合、エラーになります。
-- データの整合性が取れない場合（例：存在しない製品コードを参照している等）、その項目はスキップされ警告が表示されます。

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -87,7 +87,15 @@ python scripts/seed_scenario.py standard_demo
 
 Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`source_type='email'`）のサンプルをローカルに投入します。下書き確認UI（フェーズ7）の開発・動作確認用です。
 
-> **注意:** 製品データが必要なため、先に `seed_scenario.py standard_demo` を実行してください。
+バックエンドAPIを経由してデータを登録します（直接DBアクセスなし）。
+
+### 追加の前提条件
+
+- バックエンドが起動していること（`func host start`）
+- `SUPABASE_API_KEY`（`get_token.py` が参照するキー）
+- `BACKEND_URL`（省略時: `http://localhost:7071`）
+
+> **注意:** 先に `seed_scenario.py standard_demo` を実行して製品データを用意してください。`orders.json` 内の製品コードが見つからない場合はその注文はスキップされます。
 
 ### 投入されるデータ
 

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -102,7 +102,11 @@ Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`so
 ### 使い方
 
 ```bash
+# 実際に投入する
 python scripts/seed_gmail_drafts.py
+
+# DBに書き込まず投入予定内容を確認する（ドライラン）
+python scripts/seed_gmail_drafts.py --dry-run
 ```
 
 ### 実行例

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -1,4 +1,69 @@
-# シナリオデータ投入スクリプト (seed_scenario.py)
+# スクリプト使い方ガイド
+
+---
+
+## seed_gmail_drafts.py — Gmail受注下書きサンプルデータ投入
+
+Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`source_type='email'`）のサンプルデータをローカル開発環境に投入します。下書き確認UI開発・動作確認用です。
+
+### 投入されるデータ
+
+`backend/data/gmail_drafts/orders.json` に定義された以下の3パターン × 2件、計6件の `draft` 受注が作成されます。
+
+| パターン | `product_id` | `product_candidates` | 説明 |
+|----------|-------------|----------------------|------|
+| A（単一マッチ済み） | 解決済み | null | Claudeが1件に絞り込んだケース |
+| B（複数候補あり） | null | JSON配列あり | 候補が複数あり、ユーザーが選択するケース |
+| C（マッチなし） | null | null | 製品を特定できなかったケース |
+
+### 前提条件
+
+以下の環境変数が `.env` に設定されている必要があります（`seed_scenario.py` と共通）。
+
+- `SUPABASE_URL`
+- `SUPABASE_PUBLISHABLE_KEY`
+- `TEST_USER_EMAIL`
+- `TEST_USER_PASS`
+- `TEST_TENANT_ID`
+
+> **注意:** `standard_demo` シナリオ（`seed_scenario.py standard_demo`）を先に実行して製品データが存在していること。製品コードが見つからない場合はその注文はスキップされます。
+
+### 使い方
+
+```bash
+# backend ディレクトリで実行
+python scripts/seed_gmail_drafts.py
+```
+
+### 実行例
+
+```
+============================================================
+🚀 Seeding Gmail draft orders
+============================================================
+✅ Authenticated as admin@example.com
+
+📦 Fetching product map...
+  Found 5 products: ['PRD-A001', 'PRD-B002', 'PRD-C003', 'PRD-D004', 'PRD-E005']
+
+📦 Inserting draft orders...
+  ✓ GMAIL-SEED-A001 — パターンA（単一マッチ）
+  ✓ GMAIL-SEED-A002 — パターンA（単一マッチ）
+  ✓ GMAIL-SEED-B001 — パターンB（複数候補）
+  ✓ GMAIL-SEED-B002 — パターンB（複数候補）
+  ✓ GMAIL-SEED-C001 — パターンC（マッチなし）
+  ✓ GMAIL-SEED-C002 — パターンC（マッチなし）
+
+============================================================
+✅ Done: 6 orders inserted/updated, 0 skipped
+============================================================
+```
+
+冪等性が保証されているため、複数回実行しても重複インサートは発生しません。
+
+---
+
+## seed_scenario.py — シナリオデータ投入
 
 このスクリプトは、指定されたシナリオに基づいてSupabaseデータベースにデモデータを投入するためのツールです。
 順序依存関係を考慮して、設備、製品、工程、注文データを一括で登録します。

--- a/backend/scripts/get_token.py
+++ b/backend/scripts/get_token.py
@@ -10,9 +10,9 @@ load_dotenv()
 
 def get_supabase_client():
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_API_KEY")
+    key = os.environ.get("SUPABASE_PUBLISHABLE_KEY")
     if not url or not key:
-        raise ValueError("SUPABASE_URL or SUPABASE_API_KEY is not set")
+        raise ValueError("SUPABASE_URL or SUPABASE_PUBLISHABLE_KEY is not set")
 
     supabase = create_client(url, key)
     return supabase

--- a/backend/scripts/seed_gmail_drafts.py
+++ b/backend/scripts/seed_gmail_drafts.py
@@ -21,7 +21,7 @@ Required environment variables (.env):
     TEST_USER_EMAIL
     TEST_USER_PASS
     TEST_TENANT_ID
-    BACKEND_URL  # 省略時: http://localhost:7071
+    BACKEND_URL  # 省略時: http://localhost:8081 (docker-compose) / http://localhost:8000 (uvicorn直接)
 """
 
 import argparse
@@ -56,7 +56,7 @@ def build_headers(token: str, tenant_id: str) -> dict:
 
 def fetch_product_map(headers: dict, backend_url: str) -> dict[str, int]:
     """製品コード → product_id のマッピングを取得する."""
-    res = requests.get(f"{backend_url}/api/products/", headers=headers)
+    res = requests.get(f"{backend_url}/products/", headers=headers)
     if res.status_code != 200:
         raise Exception(f"Failed to fetch products: {res.status_code} {res.text}")
     return {p["code"]: int(p["id"]) for p in res.json() if p.get("code")}
@@ -95,7 +95,7 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
     email = os.environ.get("TEST_USER_EMAIL", "")
     password = os.environ.get("TEST_USER_PASS", "")
     tenant_id = os.environ.get("TEST_TENANT_ID", "")
-    backend_url = os.environ.get("BACKEND_URL", "http://localhost:7071")
+    backend_url = os.environ.get("BACKEND_URL", "http://localhost:8081")
 
     if not all([email, password, tenant_id]):
         raise ValueError(
@@ -165,7 +165,7 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
             inserted += 1
             continue
 
-        res = requests.post(f"{backend_url}/api/orders/", headers=headers, json=payload)
+        res = requests.post(f"{backend_url}/orders/", headers=headers, json=payload)
 
         if res.status_code == 400 and "注文番号は既に使用" in res.text:
             print(f"  - {order_number} — スキップ（既存）")

--- a/backend/scripts/seed_gmail_drafts.py
+++ b/backend/scripts/seed_gmail_drafts.py
@@ -9,7 +9,7 @@ Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注のサ
   B: 複数候補あり     (product_id=null、product_candidates=[...])
   C: マッチなし       (product_id=null、product_candidates=null)
 
-冪等性: order_number の一意制約を利用してupsertするため、複数回実行しても安全。
+冪等性: order_number が重複した場合はスキップするため、複数回実行しても安全。
 
 Usage:
     python scripts/seed_gmail_drafts.py           # 実際に投入
@@ -17,10 +17,11 @@ Usage:
 
 Required environment variables (.env):
     SUPABASE_URL
-    SUPABASE_PUBLISHABLE_KEY
+    SUPABASE_API_KEY
     TEST_USER_EMAIL
     TEST_USER_PASS
     TEST_TENANT_ID
+    BACKEND_URL  # 省略時: http://localhost:7071
 """
 
 import argparse
@@ -30,9 +31,9 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+import requests
 from dotenv import load_dotenv
-
-from supabase import Client, create_client  # type: ignore
+from get_token import get_access_token
 
 load_dotenv()
 
@@ -45,34 +46,20 @@ DATA_FILE = os.path.join(
 )
 
 
-def init_client() -> tuple[Client, str]:
-    url = os.environ.get("SUPABASE_URL", "")
-    key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
-    email = os.environ.get("TEST_USER_EMAIL", "")
-    password = os.environ.get("TEST_USER_PASS", "")
-    tenant_id = os.environ.get("TEST_TENANT_ID", "")
-
-    if not all([url, key, email, password, tenant_id]):
-        raise ValueError(
-            "Required environment variables are missing: "
-            "SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, TEST_USER_EMAIL, TEST_USER_PASS, TEST_TENANT_ID"
-        )
-
-    client = create_client(url, key)
-    res = client.auth.sign_in_with_password({"email": email, "password": password})
-    if not res.session:
-        raise ValueError("Authentication failed")
-
-    print(f"✅ Authenticated as {email}")
-    return client, tenant_id
+def build_headers(token: str, tenant_id: str) -> dict:
+    return {
+        "Authorization": f"Bearer {token}",
+        "x-tenant-id": tenant_id,
+        "Content-Type": "application/json",
+    }
 
 
-def fetch_product_map(client: Client, tenant_id: str) -> dict[str, int]:
+def fetch_product_map(headers: dict, backend_url: str) -> dict[str, int]:
     """製品コード → product_id のマッピングを取得する."""
-    res = (
-        client.table("products").select("id, code").eq("tenant_id", tenant_id).execute()
-    )
-    return {row["code"]: int(row["id"]) for row in (res.data or [])}
+    res = requests.get(f"{backend_url}/api/products/", headers=headers)
+    if res.status_code != 200:
+        raise Exception(f"Failed to fetch products: {res.status_code} {res.text}")
+    return {p["code"]: int(p["id"]) for p in res.json() if p.get("code")}
 
 
 def resolve_candidates(
@@ -105,13 +92,28 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
     print("🚀 Seeding Gmail draft orders" + (" [DRY RUN]" if dry_run else ""))
     print("=" * 60)
 
-    client, tenant_id = init_client()
+    email = os.environ.get("TEST_USER_EMAIL", "")
+    password = os.environ.get("TEST_USER_PASS", "")
+    tenant_id = os.environ.get("TEST_TENANT_ID", "")
+    backend_url = os.environ.get("BACKEND_URL", "http://localhost:7071")
+
+    if not all([email, password, tenant_id]):
+        raise ValueError(
+            "Required environment variables are missing: "
+            "TEST_USER_EMAIL, TEST_USER_PASS, TEST_TENANT_ID"
+        )
+
+    token = get_access_token(email, password)
+    if not token:
+        raise ValueError("Authentication failed")
+
+    headers = build_headers(token, tenant_id)
 
     with open(DATA_FILE, encoding="utf-8") as f:
         orders_data = json.load(f)
 
     print("\n📦 Fetching product map...")
-    product_map = fetch_product_map(client, tenant_id)
+    product_map = fetch_product_map(headers, backend_url)
     print(f"  Found {len(product_map)} products: {list(product_map.keys())}")
 
     action = "Would insert" if dry_run else "Inserting"
@@ -135,13 +137,11 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
 
         candidates = resolve_candidates(order.get("product_candidates"), product_map)
 
-        record: dict = {
-            "tenant_id": tenant_id,
+        payload = {
             "order_number": order_number,
             "product_id": product_id,
             "quantity": order.get("quantity"),
             "deadline_date": order.get("deadline_date"),
-            "status": order.get("status", "draft"),
             "source_type": order.get("source_type", "email"),
             "source_raw": order.get("source_raw"),
             "extracted_product_name": order.get("extracted_product_name"),
@@ -157,28 +157,33 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
         if dry_run:
             print(f"  [DRY RUN] {order_number} — パターン{pattern}")
             print(
-                f"    product_id={product_id}, quantity={record['quantity']}, deadline={record['deadline_date']}"
+                f"    product_id={product_id}, quantity={payload['quantity']}, deadline={payload['deadline_date']}"
             )
-            print(f"    extracted_product_name={record['extracted_product_name']!r}")
+            print(f"    extracted_product_name={payload['extracted_product_name']!r}")
             n_candidates = len(candidates) if candidates else 0
             print(f"    product_candidates={n_candidates}件")
-        else:
-            client.table("orders").upsert(
-                record,
-                on_conflict="tenant_id, order_number",
-            ).execute()
-            print(f"  ✓ {order_number} — パターン{pattern}")
+            inserted += 1
+            continue
 
-        inserted += 1
+        res = requests.post(f"{backend_url}/api/orders/", headers=headers, json=payload)
+
+        if res.status_code == 400 and "注文番号は既に使用" in res.text:
+            print(f"  - {order_number} — スキップ（既存）")
+            skipped += 1
+        elif res.status_code != 200:
+            raise Exception(
+                f"Failed to create order {order_number}: {res.status_code} {res.text}"
+            )
+        else:
+            print(f"  ✓ {order_number} — パターン{pattern}")
+            inserted += 1
 
     print(f"\n{'=' * 60}")
     if dry_run:
-        print(
-            f"✅ Dry run: {inserted} orders would be inserted/updated, {skipped} skipped"
-        )
+        print(f"✅ Dry run: {inserted} orders would be inserted, {skipped} skipped")
         print("   実際に投入するには --dry-run を外して実行してください")
     else:
-        print(f"✅ Done: {inserted} orders inserted/updated, {skipped} skipped")
+        print(f"✅ Done: {inserted} orders inserted, {skipped} skipped")
     print(f"{'=' * 60}\n")
 
 

--- a/backend/scripts/seed_gmail_drafts.py
+++ b/backend/scripts/seed_gmail_drafts.py
@@ -17,11 +17,14 @@ Usage:
 
 Required environment variables (.env):
     SUPABASE_URL
-    SUPABASE_API_KEY
+    SUPABASE_PUBLISHABLE_KEY
     TEST_USER_EMAIL
     TEST_USER_PASS
     TEST_TENANT_ID
-    BACKEND_URL  # 省略時: http://localhost:8081 (docker-compose) / http://localhost:8000 (uvicorn直接)
+    BACKEND_URL  # 省略時: http://localhost:8000 (docker-compose) / http://localhost:8000 (uvicorn直接)
+
+注意: orders.json の product_name はDBに登録されている製品名と完全一致させること。
+      product_code は任意項目のため、名前ベースで解決します。
 """
 
 import argparse
@@ -55,34 +58,34 @@ def build_headers(token: str, tenant_id: str) -> dict:
 
 
 def fetch_product_map(headers: dict, backend_url: str) -> dict[str, int]:
-    """製品コード → product_id のマッピングを取得する."""
-    res = requests.get(f"{backend_url}/products/", headers=headers)
+    """製品名 → product_id のマッピングを取得する."""
+    res = requests.get(f"{backend_url}/products", headers=headers)
     if res.status_code != 200:
         raise Exception(f"Failed to fetch products: {res.status_code} {res.text}")
-    return {p["code"]: int(p["id"]) for p in res.json() if p.get("code")}
+    return {p["name"]: int(p["id"]) for p in res.json() if p.get("name")}
 
 
 def resolve_candidates(
     candidates: list[dict] | None, product_map: dict[str, int]
 ) -> list[dict] | None:
-    """product_candidatesのproduct_codeをproduct_idに変換する."""
+    """product_candidatesのproduct_nameをproduct_idに変換する."""
     if not candidates:
         return None
 
     resolved = []
     for c in candidates:
-        code = c.get("product_code")
-        if code and code in product_map:
+        product_name = c.get("product_name")
+        if product_name and product_name in product_map:
             resolved.append(
                 {
-                    "product_id": product_map[code],
+                    "product_id": product_map[product_name],
                     "name": c["name"],
                     "score": c["score"],
                 }
             )
         else:
             print(
-                f"  ⚠️  Product code not found in candidates: {code}, skipping candidate"
+                f"  ⚠️  Product name not found in candidates: {product_name}, skipping candidate"
             )
     return resolved if resolved else None
 
@@ -95,7 +98,7 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
     email = os.environ.get("TEST_USER_EMAIL", "")
     password = os.environ.get("TEST_USER_PASS", "")
     tenant_id = os.environ.get("TEST_TENANT_ID", "")
-    backend_url = os.environ.get("BACKEND_URL", "http://localhost:8081")
+    backend_url = os.environ.get("BACKEND_URL", "http://localhost:8000")
 
     if not all([email, password, tenant_id]):
         raise ValueError(
@@ -114,7 +117,9 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
 
     print("\n📦 Fetching product map...")
     product_map = fetch_product_map(headers, backend_url)
-    print(f"  Found {len(product_map)} products: {list(product_map.keys())}")
+    print(
+        f"  Found {len(product_map)} products: {list(product_map.keys())[:5]}{'...' if len(product_map) > 5 else ''}"
+    )
 
     action = "Would insert" if dry_run else "Inserting"
     print(f"\n📦 {action} draft orders...")
@@ -123,17 +128,17 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
 
     for order in orders_data:
         order_number = order["order_number"]
-        product_code = order.get("product_code")
+        product_name = order.get("product_name")
 
         product_id: int | None = None
-        if product_code:
-            if product_code not in product_map:
+        if product_name:
+            if product_name not in product_map:
                 print(
-                    f"  ⚠️  Product code not found: {product_code}, skipping {order_number}"
+                    f"  ⚠️  Product name not found: {product_name}, skipping {order_number}"
                 )
                 skipped += 1
                 continue
-            product_id = product_map[product_code]
+            product_id = product_map[product_name]
 
         candidates = resolve_candidates(order.get("product_candidates"), product_map)
 
@@ -165,7 +170,7 @@ def seed_gmail_drafts(dry_run: bool = False) -> None:
             inserted += 1
             continue
 
-        res = requests.post(f"{backend_url}/orders/", headers=headers, json=payload)
+        res = requests.post(f"{backend_url}/orders", headers=headers, json=payload)
 
         if res.status_code == 400 and "注文番号は既に使用" in res.text:
             print(f"  - {order_number} — スキップ（既存）")

--- a/backend/scripts/seed_gmail_drafts.py
+++ b/backend/scripts/seed_gmail_drafts.py
@@ -1,0 +1,171 @@
+"""
+Gmail受注下書きサンプルデータ投入スクリプト.
+
+Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注のサンプルを
+ローカル開発環境に投入します。下書き確認UI（フェーズ7）の開発・動作確認用。
+
+以下の3パターンを2件ずつ、計6件のdraft orderを作成します:
+  A: 単一製品マッチ済み (product_id解決済み、product_candidates=null)
+  B: 複数候補あり     (product_id=null、product_candidates=[...])
+  C: マッチなし       (product_id=null、product_candidates=null)
+
+冪等性: order_number の一意制約を利用してupsertするため、複数回実行しても安全。
+
+Usage:
+    python scripts/seed_gmail_drafts.py
+
+Required environment variables (.env):
+    SUPABASE_URL
+    SUPABASE_PUBLISHABLE_KEY
+    TEST_USER_EMAIL
+    TEST_USER_PASS
+    TEST_TENANT_ID
+"""
+
+import json
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from dotenv import load_dotenv
+
+from supabase import Client, create_client  # type: ignore
+
+load_dotenv()
+
+DATA_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "data",
+    "gmail_drafts",
+    "orders.json",
+)
+
+
+def init_client() -> tuple[Client, str]:
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+    email = os.environ.get("TEST_USER_EMAIL", "")
+    password = os.environ.get("TEST_USER_PASS", "")
+    tenant_id = os.environ.get("TEST_TENANT_ID", "")
+
+    if not all([url, key, email, password, tenant_id]):
+        raise ValueError(
+            "Required environment variables are missing: "
+            "SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, TEST_USER_EMAIL, TEST_USER_PASS, TEST_TENANT_ID"
+        )
+
+    client = create_client(url, key)
+    res = client.auth.sign_in_with_password({"email": email, "password": password})
+    if not res.session:
+        raise ValueError("Authentication failed")
+
+    print(f"✅ Authenticated as {email}")
+    return client, tenant_id
+
+
+def fetch_product_map(client: Client, tenant_id: str) -> dict[str, int]:
+    """製品コード → product_id のマッピングを取得する."""
+    res = (
+        client.table("products").select("id, code").eq("tenant_id", tenant_id).execute()
+    )
+    return {row["code"]: int(row["id"]) for row in (res.data or [])}
+
+
+def resolve_candidates(
+    candidates: list[dict] | None, product_map: dict[str, int]
+) -> list[dict] | None:
+    """product_candidatesのproduct_codeをproduct_idに変換する."""
+    if not candidates:
+        return None
+
+    resolved = []
+    for c in candidates:
+        code = c.get("product_code")
+        if code and code in product_map:
+            resolved.append(
+                {
+                    "product_id": product_map[code],
+                    "name": c["name"],
+                    "score": c["score"],
+                }
+            )
+        else:
+            print(
+                f"  ⚠️  Product code not found in candidates: {code}, skipping candidate"
+            )
+    return resolved if resolved else None
+
+
+def seed_gmail_drafts() -> None:
+    print("\n" + "=" * 60)
+    print("🚀 Seeding Gmail draft orders")
+    print("=" * 60)
+
+    client, tenant_id = init_client()
+
+    with open(DATA_FILE, encoding="utf-8") as f:
+        orders_data = json.load(f)
+
+    print("\n📦 Fetching product map...")
+    product_map = fetch_product_map(client, tenant_id)
+    print(f"  Found {len(product_map)} products: {list(product_map.keys())}")
+
+    print("\n📦 Inserting draft orders...")
+    inserted = 0
+    skipped = 0
+
+    for order in orders_data:
+        order_number = order["order_number"]
+        product_code = order.get("product_code")
+
+        product_id: int | None = None
+        if product_code:
+            if product_code not in product_map:
+                print(
+                    f"  ⚠️  Product code not found: {product_code}, skipping {order_number}"
+                )
+                skipped += 1
+                continue
+            product_id = product_map[product_code]
+
+        candidates = resolve_candidates(order.get("product_candidates"), product_map)
+
+        record: dict = {
+            "tenant_id": tenant_id,
+            "order_number": order_number,
+            "product_id": product_id,
+            "quantity": order.get("quantity"),
+            "deadline_date": order.get("deadline_date"),
+            "status": order.get("status", "draft"),
+            "source_type": order.get("source_type", "email"),
+            "source_raw": order.get("source_raw"),
+            "extracted_product_name": order.get("extracted_product_name"),
+            "product_candidates": candidates,
+        }
+
+        client.table("orders").upsert(
+            record,
+            on_conflict="tenant_id, order_number",
+        ).execute()
+
+        pattern = (
+            "A（単一マッチ）"
+            if product_id
+            else ("B（複数候補）" if candidates else "C（マッチなし）")
+        )
+        print(f"  ✓ {order_number} — パターン{pattern}")
+        inserted += 1
+
+    print(f"\n{'=' * 60}")
+    print(f"✅ Done: {inserted} orders upserted, {skipped} skipped")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    try:
+        seed_gmail_drafts()
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)

--- a/backend/scripts/seed_gmail_drafts.py
+++ b/backend/scripts/seed_gmail_drafts.py
@@ -12,7 +12,8 @@ Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注のサ
 冪等性: order_number の一意制約を利用してupsertするため、複数回実行しても安全。
 
 Usage:
-    python scripts/seed_gmail_drafts.py
+    python scripts/seed_gmail_drafts.py           # 実際に投入
+    python scripts/seed_gmail_drafts.py --dry-run  # DBに書き込まず内容を確認
 
 Required environment variables (.env):
     SUPABASE_URL
@@ -22,6 +23,7 @@ Required environment variables (.env):
     TEST_TENANT_ID
 """
 
+import argparse
 import json
 import os
 import sys
@@ -98,9 +100,9 @@ def resolve_candidates(
     return resolved if resolved else None
 
 
-def seed_gmail_drafts() -> None:
+def seed_gmail_drafts(dry_run: bool = False) -> None:
     print("\n" + "=" * 60)
-    print("🚀 Seeding Gmail draft orders")
+    print("🚀 Seeding Gmail draft orders" + (" [DRY RUN]" if dry_run else ""))
     print("=" * 60)
 
     client, tenant_id = init_client()
@@ -112,7 +114,8 @@ def seed_gmail_drafts() -> None:
     product_map = fetch_product_map(client, tenant_id)
     print(f"  Found {len(product_map)} products: {list(product_map.keys())}")
 
-    print("\n📦 Inserting draft orders...")
+    action = "Would insert" if dry_run else "Inserting"
+    print(f"\n📦 {action} draft orders...")
     inserted = 0
     skipped = 0
 
@@ -145,27 +148,53 @@ def seed_gmail_drafts() -> None:
             "product_candidates": candidates,
         }
 
-        client.table("orders").upsert(
-            record,
-            on_conflict="tenant_id, order_number",
-        ).execute()
-
         pattern = (
             "A（単一マッチ）"
             if product_id
             else ("B（複数候補）" if candidates else "C（マッチなし）")
         )
-        print(f"  ✓ {order_number} — パターン{pattern}")
+
+        if dry_run:
+            print(f"  [DRY RUN] {order_number} — パターン{pattern}")
+            print(
+                f"    product_id={product_id}, quantity={record['quantity']}, deadline={record['deadline_date']}"
+            )
+            print(f"    extracted_product_name={record['extracted_product_name']!r}")
+            n_candidates = len(candidates) if candidates else 0
+            print(f"    product_candidates={n_candidates}件")
+        else:
+            client.table("orders").upsert(
+                record,
+                on_conflict="tenant_id, order_number",
+            ).execute()
+            print(f"  ✓ {order_number} — パターン{pattern}")
+
         inserted += 1
 
     print(f"\n{'=' * 60}")
-    print(f"✅ Done: {inserted} orders upserted, {skipped} skipped")
+    if dry_run:
+        print(
+            f"✅ Dry run: {inserted} orders would be inserted/updated, {skipped} skipped"
+        )
+        print("   実際に投入するには --dry-run を外して実行してください")
+    else:
+        print(f"✅ Done: {inserted} orders inserted/updated, {skipped} skipped")
     print(f"{'=' * 60}\n")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Gmail受注下書きサンプルデータ投入スクリプト"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="DBに書き込まず、投入予定の内容を表示する",
+    )
+    args = parser.parse_args()
+
     try:
-        seed_gmail_drafts()
+        seed_gmail_drafts(dry_run=args.dry_run)
     except Exception as e:
         print(f"\n❌ Error: {e}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- `backend/scripts/seed_gmail_drafts.py` を新規追加 — Gmail連携で生成されるdraft orderのサンプルを `python scripts/seed_gmail_drafts.py` 1コマンドでローカルDBに投入できる
- `backend/data/gmail_drafts/orders.json` に3パターン × 2件のサンプルデータを定義（単一マッチ済み／複数候補あり／マッチなし）
- 既存の `seed_scenario.py` と同じ認証・環境変数パターンを踏襲、upsertにより複数回実行しても安全（冪等）

## Motivation
Gmail受注自動取り込み機能（#235）の下書き確認UI（フェーズ7）を開発するにあたり、`source_type='email'` かつ `status='draft'` の受注データがローカルに存在しない問題を解消する。

## Test plan
- [ ] `supabase start` でローカルSupabase起動済みの状態で `python scripts/seed_gmail_drafts.py` を実行し `✅ Done: 6 orders upserted, 0 skipped` が出力されること
- [ ] Supabase Studio で `orders` テーブルを確認し、`GMAIL-SEED-A001`〜`GMAIL-SEED-C002` の6件が存在し、各パターンで `product_id` / `product_candidates` が期待通りであること
- [ ] 2回目の実行でも同じ結果になり、重複インサートが発生しないこと

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)