### PR TITLE
fix: 注文一覧の「登録日」ソートが機能しない問題を修正 (#237)

### DIFF
--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -43,6 +43,8 @@ def _map_order_response(order: dict) -> dict:
         mapped["order_no"] = mapped.pop("order_number")
     if "deadline_date" in mapped:
         mapped["desired_deadline"] = mapped.pop("deadline_date")
+    if "order_date" in mapped:
+        mapped["created_at"] = mapped.pop("order_date")
     return mapped
 
 

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -31,9 +31,9 @@ export function compareOrders(a: Order, b: Order, sortKey: SortKey): number {
     if (!a.created_at && !b.created_at) return 0
     if (!a.created_at) return 1
     if (!b.created_at) return -1
-    return sortKey === "created_at_desc"
-      ? b.created_at.localeCompare(a.created_at)
-      : a.created_at.localeCompare(b.created_at)
+    const timeA = new Date(a.created_at).getTime()
+    const timeB = new Date(b.created_at).getTime()
+    return sortKey === "created_at_desc" ? timeB - timeA : timeA - timeB
   }
   if (!a.desired_deadline && !b.desired_deadline) return 0
   if (!a.desired_deadline) return 1


### PR DESCRIPTION
## Summary

- `orders` テーブルの登録日カラム `order_date` が `_map_order_response` でフロントエンド向け `created_at` にマッピングされていなかったため、ソート時に常に `null` 比較になっていた
- `backend/app/routers/transaction/orders.py` に `order_date` → `created_at` のマッピングを追加
- `frontend/src/lib/order-utils.ts` の `compareOrders` 関数で `localeCompare` → `new Date().getTime()` 差分比較に変更（タイムゾーン形式の揺れに対応）

Closes #237

## Test plan

- [ ] 注文一覧で「登録日（新しい順）」「登録日（古い順）」を切り替えると正しく並び替えられること
- [ ] `pytest __tests__/api/routers/transaction/test_orders.py` が全件パスすること（12 passed）
- [ ] `tsc --noEmit` で型エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)