### PR TITLE
feat: 注文一覧でGmail自動起票と手動起票を視覚的に区別する

### DIFF
--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { AlertCircle, Loader2, MoreHorizontal } from "lucide-react"
+import { AlertCircle, Loader2, Mail, MoreHorizontal } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { Badge } from "@/components/ui/badge"
@@ -63,8 +64,18 @@ export function OrderTableRow({
   onDelete,
   onToggleSelect,
 }: OrderTableRowProps) {
+  const router = useRouter()
+  const isEmailOrder = order.source_type === "email"
+
+  let rowClassName: string | undefined
+  if (hasBulkSimFailed) {
+    rowClassName = "border-l-[3px] border-l-destructive bg-destructive/5"
+  } else if (isEmailOrder) {
+    rowClassName = "bg-blue-50/60"
+  }
+
   return (
-      <TableRow className={hasBulkSimFailed ? "border-l-[3px] border-l-destructive bg-destructive/5" : undefined}>
+      <TableRow className={rowClassName}>
         <TableCell className="w-10">
           {order.status === "draft" ? (
             <div className="relative flex items-center justify-center">
@@ -82,7 +93,17 @@ export function OrderTableRow({
             </div>
           ) : null}
         </TableCell>
-        <TableCell className="font-medium">{order.order_no}</TableCell>
+        <TableCell className="font-medium">
+          <div className="flex flex-col gap-1">
+            {order.order_no}
+            {isEmailOrder && (
+              <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium bg-blue-100 text-blue-700 w-fit">
+                <Mail className="h-3 w-3" />
+                自動起票
+              </span>
+            )}
+          </div>
+        </TableCell>
         <TableCell>{getProductName(order.product_id, products)}</TableCell>
         <TableCell>
           {order.customer_id == null ? (
@@ -136,21 +157,31 @@ export function OrderTableRow({
               </Tooltip>
             )}
             {order.status === "draft" && !order.is_scheduled && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onSimulate(order)}
-                disabled={isSimulating || isBulkOperationInProgress}
-              >
-                {isSimulating ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    実行中...
-                  </>
-                ) : (
-                  "シミュレーション実行"
-                )}
-              </Button>
+              isEmailOrder ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => router.push(`/orders/${order.id}`)}
+                >
+                  確認する
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onSimulate(order)}
+                  disabled={isSimulating || isBulkOperationInProgress}
+                >
+                  {isSimulating ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      実行中...
+                    </>
+                  ) : (
+                    "シミュレーション実行"
+                  )}
+                </Button>
+              )
             )}
             {order.status === "draft" && order.is_scheduled && (
               <Button


### PR DESCRIPTION
## Summary

- `source_type === 'email'` の注文行に「自動起票」バッジ（Mail アイコン付き）を表示
- Gmail自動起票行に薄い青背景（`bg-blue-50/60`）を適用し、手動起票行と区別
- Gmail自動起票の下書き行の操作ボタンを「確認する」に変更し、注文詳細画面（`/orders/:id`）へ遷移

## Changes

`frontend/src/components/orders/order-table-row.tsx` のみ変更（スキーマ・API・型定義の変更なし）

- `isEmailOrder` フラグを `source_type === 'email'` で導出
- `TableRow` の `className` を `isEmailOrder` に応じて切り替え
- 注文番号セルに条件付き `<span>` バッジ（`bg-blue-100 text-blue-700`）を追加
- `シミュレーション実行` ボタンを `isEmailOrder` 時は `確認する`（詳細画面遷移）に切り替え

## Test plan

- [ ] `source_type === 'email'` の下書き注文行に「自動起票」バッジが表示される
- [ ] Gmail自動起票行の背景色が薄い青になっている
- [ ] Gmail自動起票の下書き行のボタンが「確認する」になり、クリックで `/orders/:id` へ遷移する
- [ ] `source_type === 'manual'` の行にバッジが表示されず、背景色も変わらない
- [ ] 手動起票の下書き行の「シミュレーション実行」ボタンが正常動作する

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)