### PR TITLE
feat: 工程未設定の製品はシミュレーションボタンを disabled にしてインラインヒントを表示

### DIFF
--- a/backend/app/repositories/supa_infra/transaction/order_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_repo.py
@@ -38,6 +38,24 @@ class OrderRepository(BaseRepository):
             result.append({**order, "has_unconfirmed_routings": has_unconfirmed})
         return result
 
+    def get_by_id_with_routing_status(self, order_id: int) -> dict | None:
+        """注文を1件取得し has_unconfirmed_routings フラグを付与"""
+        order = self.get_by_id(order_id)
+        if not order:
+            return None
+        pid = order.get("product_id")
+        if pid is None:
+            return {**order, "has_unconfirmed_routings": True}
+        res = (
+            self.client.table(SupabaseTableName.PROCESS_ROUTINGS.value)
+            .select("product_id, is_confirmed")
+            .eq("product_id", pid)
+            .execute()
+        )
+        routings = cast(list[dict[str, Any]], res.data or [])
+        has_unconfirmed = not routings or any(not r["is_confirmed"] for r in routings)
+        return {**order, "has_unconfirmed_routings": has_unconfirmed}
+
     def mark_as_scheduled(self, order_id: int) -> None:
         """
         注文をスケジュール済みとしてマークする。

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -121,9 +121,9 @@ def get_unconfirmed_routing_queue(
 
 @orders_router.get("/{order_id}")
 def get_order(order_id: int, repo: OrderRepository = Depends(get_order_repo)):
-    """注文を1件取得"""
+    """注文を1件取得（has_unconfirmed_routings フラグ付き）"""
     logger.info(f"Fetching order {order_id}")
-    result = repo.get_by_id(order_id)
+    result = repo.get_by_id_with_routing_status(order_id)
     if not result:
         raise HTTPException(status_code=404, detail="Not found")
     return _map_order_response(result)

--- a/frontend/src/app/master/products/page.tsx
+++ b/frontend/src/app/master/products/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useMemo, useState, useEffect } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { AlertTriangle, Circle, MoreHorizontal, Plus, Search } from "lucide-react"
+import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 import {
   useProducts,
@@ -65,6 +66,7 @@ export default function ProductsPage() {
   const router = useRouter()
   const sortKey = (searchParams.get("sort") as SortKey) ?? "created_at"
   const page = Number(searchParams.get("page") ?? "1")
+  const highlightId = Number(searchParams.get("highlight") ?? "") || null
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
@@ -117,6 +119,26 @@ export default function ProductsPage() {
     const offset = (page - 1) * PAGE_SIZE
     return filteredProducts.slice(offset, offset + PAGE_SIZE)
   }, [filteredProducts, page])
+
+  // highlight パラメータが指すページへ自動移動
+  useEffect(() => {
+    if (!highlightId || !filteredProducts.length) return
+    const idx = filteredProducts.findIndex((p) => p.id === highlightId)
+    if (idx === -1) return
+    const targetPage = Math.floor(idx / PAGE_SIZE) + 1
+    if (targetPage === page) return
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("page", String(targetPage))
+    router.replace(`/master/products?${params.toString()}`)
+  }, [highlightId, filteredProducts, page, searchParams, router])
+
+  // highlight 対象行へスクロール
+  useEffect(() => {
+    if (!highlightId) return
+    const el = document.getElementById(`product-row-${highlightId}`)
+    if (!el) return
+    el.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [highlightId, pagedProducts])
 
   const handleOpenCreateDialog = () => {
     setProductName("")
@@ -310,7 +332,11 @@ export default function ProductsPage() {
                   const displayCode = product.code || "品番なし"
                   const displayName = product.name || null
                   return (
-                    <TableRow key={product.id}>
+                    <TableRow
+                      key={product.id}
+                      id={`product-row-${product.id}`}
+                      className={cn(highlightId === product.id && "ring-2 ring-inset ring-primary bg-primary/5")}
+                    >
                       <TableCell>
                         <div className="text-xs text-muted-foreground">{displayCode}</div>
                         {displayName ? (

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -116,6 +116,7 @@ export default function OrderDetailPage() {
 
   const isDraft = order.status === "draft"
   const canDelete = order.status === "draft" || order.status === "canceled"
+  const hasNoRouting = order.has_unconfirmed_routings === true && !order.is_scheduled
 
   return (
     <div className="container mx-auto py-6 px-4">
@@ -184,14 +185,27 @@ export default function OrderDetailPage() {
           {/* アクションボタン */}
           <div className="flex flex-wrap gap-3">
             {isDraft && (
-              <Button
-                onClick={handleSimulate}
-                disabled={simulateMutation.isPending}
-                className="flex-1"
-              >
-                <Calculator className="mr-2 h-4 w-4" />
-                {simulateMutation.isPending ? "計算中..." : "シミュレーション実行"}
-              </Button>
+              <div className="flex-1 space-y-1">
+                <Button
+                  onClick={handleSimulate}
+                  disabled={simulateMutation.isPending || hasNoRouting}
+                  className="w-full"
+                >
+                  <Calculator className="mr-2 h-4 w-4" />
+                  {simulateMutation.isPending ? "計算中..." : "シミュレーション実行"}
+                </Button>
+                {hasNoRouting && (
+                  <p className="text-xs text-muted-foreground">
+                    工程が設定されていません。{" "}
+                    <a
+                      href={`/master/products?highlight=${order.product_id}`}
+                      className="underline text-primary"
+                    >
+                      製品マスタから工程を設定してください。
+                    </a>
+                  </p>
+                )}
+              </div>
             )}
             {isDraft && order.is_scheduled && (
               <Button


### PR DESCRIPTION
## Summary

- 工程未設定の製品の注文詳細でシミュレーションボタンを `disabled` にし、ボタン直下に工程設定へのインラインヒントを表示
- インラインヒントのリンクから製品マスタへ遷移すると、該当行に自動スクロール＆ハイライトされる

## 変更内容

### Backend

**`backend/app/repositories/supa_infra/transaction/order_repo.py`**
`get_by_id_with_routing_status()` を追加。`GET /orders/{id}` 単件取得でも `has_unconfirmed_routings` フラグを返せるようにした（従来は一覧 API `get_all_with_routing_status()` のみ計算していた）。

**`backend/app/routers/transaction/orders.py`**
`GET /{order_id}` で `get_by_id_with_routing_status()` を使用するよう変更。

### Frontend

**`frontend/src/app/orders/[id]/page.tsx`**
- `hasNoRouting = order.has_unconfirmed_routings === true && !order.is_scheduled` を算出
- `disabled={simulateMutation.isPending || hasNoRouting}` でボタンを制御
- `hasNoRouting` 時はボタン直下に製品マスタへのリンク付きヒントを表示（リンク: `/master/products?highlight={product_id}`）

**`frontend/src/app/master/products/page.tsx`**
- `?highlight` パラメータを読み取り、対象製品が別ページにある場合は `router.replace` でページ自動移動
- `scrollIntoView({ behavior: "smooth" })` で対象行へスクロール
- `TableRow` に `id="product-row-{id}"` を付与し、ハイライト時は `ring-2 ring-inset ring-primary bg-primary/5` を適用

## Test plan

- [ ] 工程未設定の製品の注文詳細でシミュレーションボタンが `disabled` 表示になること
- [ ] ボタン直下にインラインヒントと「製品マスタから工程を設定してください。」リンクが表示されること
- [ ] リンクをクリックすると `/master/products?highlight={product_id}` へ遷移すること
- [ ] 製品マスタで該当行にスクロールされ、リングハイライトが表示されること
- [ ] 該当製品が2ページ目以降にある場合、正しいページへ自動移動すること
- [ ] 工程が設定されている製品ではボタンが有効で従来どおり動作すること

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)