### PR TITLE
feat(#248): 受注PDF添付のステージング保存対応

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,4 +35,11 @@
         "terraform",
         "softwareTerms"
     ],
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ],
 }

--- a/backend/__tests__/e2e/conftest.py
+++ b/backend/__tests__/e2e/conftest.py
@@ -284,22 +284,20 @@ def _cleanup_supabase(
 ) -> None:
     """
     E2E テストで作成した Supabase レコードと Storage ファイルを削除する。
-    source_raw に run_id が含まれる order を特定して削除する。
+    source_raw に run_id が含まれる order / order_attachments (ステージング行) を
+    特定して削除する。
     """
-    # run_id を含む order を検索
-    result = (
+    # run_id を含む order を検索（非PDF添付・添付なしメールの既存フロー）
+    order_result = (
         admin_db.table("orders")
         .select("id, tenant_id")
         .like("source_raw", f"%run_id={run_id}%")
         .execute()
     )
-    rows = cast(list[dict[str, Any]], result.data or [])
-    if not rows:
-        return
+    order_rows = cast(list[dict[str, Any]], order_result.data or [])
 
-    for row in rows:
+    for row in order_rows:
         order_id = row["id"]
-        tenant_id = row["tenant_id"]
 
         # order_attachments の storage_path を取得してから Storage を削除
         att_result = (
@@ -319,17 +317,19 @@ def _cleanup_supabase(
         # order を削除 (order_attachments は cascade で削除される)
         admin_db.table("orders").delete().eq("id", order_id).execute()
 
-    # Storage に残骸ファイルがないか確認・削除（念のため）
-    for row in rows:
-        tenant_id = row["tenant_id"]
-        try:
-            files = admin_db.storage.from_("order-attachments").list(
-                f"{tenant_id}/orders"
-            )
-            for f in files or []:
-                if run_id in f.get("name", ""):
-                    admin_db.storage.from_("order-attachments").remove(
-                        [f"{tenant_id}/orders/{f['name']}"]
-                    )
-        except Exception:
-            pass
+    # run_id を含む order_attachments ステージング行を検索（PDF添付メールの新フロー）
+    staging_result = (
+        admin_db.table("order_attachments")
+        .select("id, storage_path")
+        .is_("order_id", "null")
+        .like("source_raw", f"%run_id={run_id}%")
+        .execute()
+    )
+    for att in cast(list[dict[str, Any]], staging_result.data or []):
+        path = str(att.get("storage_path", ""))
+        if path:
+            try:
+                admin_db.storage.from_("order-attachments").remove([path])
+            except Exception:
+                pass
+        admin_db.table("order_attachments").delete().eq("id", att["id"]).execute()

--- a/backend/__tests__/e2e/test_gmail_attachment_flow.py
+++ b/backend/__tests__/e2e/test_gmail_attachment_flow.py
@@ -21,19 +21,20 @@ from app.services.gmail_service import poll_unread_emails
 class TestGmailAttachmentFlow:
     """Gmail → Supabase Storage の添付ファイル保存フロー E2E テスト"""
 
-    def test_pdf_attachment_is_saved_to_storage(
+    def test_pdf_attachment_is_staged_without_creating_order(
         self,
         inject_email_with_pdf: dict[str, Any],
         admin_db,
     ) -> None:
         """
-        PDF 添付付きメールを受信したとき:
-        - orders レコードが source_type='email' で作成される
-        - order_attachments レコードが parse_status='pending' で作成される
-        - Supabase Storage に PDF ファイルが保存される
+        PDF 添付付きメールを受信したとき (Issue #248):
+        - orders レコードは作成されない（パース処理は後続Issue）
+        - order_attachments にステージング行（order_id=NULL, parse_status='pending'）が作成される
+        - Supabase Storage の {tenant_id}/inbox/{gmail_message_id}/ に PDF ファイルが保存される
         """
         run_id = inject_email_with_pdf["run_id"]
         pdf_filename = inject_email_with_pdf["pdf_filename"]
+        message_id = inject_email_with_pdf["message_id"]
 
         # Gmail ポーリングを実行
         result = poll_unread_emails(admin_db)
@@ -43,39 +44,42 @@ class TestGmailAttachmentFlow:
         # Gmail の処理完了を少し待つ（ラベル移動が非同期のため）
         time.sleep(1)
 
-        # --- orders レコードの検証 ---
+        # --- orders レコードが作成されないことの検証 ---
         order_result = (
             admin_db.table("orders")
-            .select("id, source_type, source_raw, tenant_id")
+            .select("id")
             .like("source_raw", f"%run_id={run_id}%")
             .execute()
         )
-        orders = order_result.data or []
-        assert len(orders) == 1, f"Expected 1 order, got {len(orders)}. run_id={run_id}"
-        order = orders[0]
-        assert order["source_type"] == "email"
-        order_id = order["id"]
-        tenant_id = order["tenant_id"]
+        assert not (order_result.data or []), (
+            f"Expected no order to be created for PDF attachment email, "
+            f"got {order_result.data}"
+        )
 
-        # --- order_attachments レコードの検証 ---
+        # --- order_attachments ステージング行の検証 ---
         att_result = (
             admin_db.table("order_attachments")
             .select("*")
-            .eq("order_id", order_id)
+            .is_("order_id", "null")
+            .like("source_raw", f"%run_id={run_id}%")
             .execute()
         )
         attachments = att_result.data or []
         assert len(attachments) == 1, (
-            f"Expected 1 order_attachment, got {len(attachments)}. order_id={order_id}"
+            f"Expected 1 staged order_attachment, got {len(attachments)}. "
+            f"run_id={run_id}"
         )
         attachment = attachments[0]
+        assert attachment["order_id"] is None
+        assert attachment["gmail_message_id"] == message_id
         assert attachment["parse_status"] == "pending"
         assert attachment["original_filename"] == pdf_filename
         assert attachment["content_type"] == "application/pdf"
         assert attachment["size_bytes"] is not None and attachment["size_bytes"] > 0
 
+        tenant_id = attachment["tenant_id"]
         storage_path = attachment["storage_path"]
-        assert storage_path.startswith(f"{tenant_id}/orders/{order_id}/"), (
+        assert storage_path.startswith(f"{tenant_id}/inbox/{message_id}/"), (
             f"Unexpected storage_path prefix: {storage_path!r}"
         )
         assert storage_path.endswith(".pdf"), (
@@ -84,7 +88,7 @@ class TestGmailAttachmentFlow:
 
         # --- Supabase Storage にファイルが存在することを検証 ---
         storage_list = admin_db.storage.from_("order-attachments").list(
-            f"{tenant_id}/orders/{order_id}"
+            f"{tenant_id}/inbox/{message_id}"
         )
         stored_filenames = [f["name"] for f in (storage_list or [])]
         stored_name = storage_path.rsplit("/", 1)[-1]
@@ -138,14 +142,14 @@ class TestGmailAttachmentFlow:
         assert attachments[0]["parse_status"] == "failed_no_attachment"
         assert attachments[0]["storage_path"] == ""
 
-    def test_signed_url_is_accessible_via_api(
+    def test_signed_url_is_accessible_for_staged_attachment(
         self,
         inject_email_with_pdf: dict[str, Any],
         admin_db,
     ) -> None:
         """
-        order_attachments API が署名付き URL を返すことを確認する。
-        (Storage に保存済みの前提 — 前のテストと同じメールを使う場合は順序依存に注意)
+        PDF ステージング行 (order_id=NULL) の storage_path からも
+        署名付き URL を生成できることを確認する。
         """
         from app.services.attachment_service import create_signed_url
 
@@ -157,22 +161,12 @@ class TestGmailAttachmentFlow:
 
         time.sleep(1)
 
-        # order_id を取得
-        order_result = (
-            admin_db.table("orders")
-            .select("id")
-            .like("source_raw", f"%run_id={run_id}%")
-            .execute()
-        )
-        orders = order_result.data or []
-        assert len(orders) == 1
-        order_id = orders[0]["id"]
-
-        # order_attachments から storage_path を取得
+        # order_attachments ステージング行から storage_path を取得
         att_result = (
             admin_db.table("order_attachments")
             .select("storage_path, parse_status")
-            .eq("order_id", order_id)
+            .is_("order_id", "null")
+            .like("source_raw", f"%run_id={run_id}%")
             .execute()
         )
         attachments = att_result.data or []

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from app.services.gmail_service import poll_unread_emails
+from app.services.gmail_service import _process_message, poll_unread_emails
 
 
 @pytest.mark.unit
@@ -87,3 +87,124 @@ class TestPollUnreadEmails:
 
         assert result["processed"] == 0
         assert result["errors"] == 1
+
+
+@pytest.mark.unit
+class TestProcessMessagePdfStaging:
+    """PDF添付メールのステージング保存分岐 (Issue #248) の単体テスト。"""
+
+    def _mock_gmail_service(self):
+        mock_service = MagicMock()
+        mock_service.users().messages().get().execute.return_value = {
+            "payload": {"parts": []}
+        }
+        return mock_service
+
+    def test_pdf_attachment_stages_without_creating_order(self):
+        mock_service = self._mock_gmail_service()
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "app.services.gmail_service._lookup_tenant_id",
+                return_value="tenant-1",
+            ),
+            patch(
+                "app.services.gmail_service._get_attachments",
+                return_value=[
+                    {
+                        "filename": "order.pdf",
+                        "content_type": "application/pdf",
+                        "data": b"%PDF-1.4",
+                    }
+                ],
+            ),
+            patch(
+                "app.services.gmail_service.extract_sender_email",
+                return_value="customer@example.com",
+            ),
+            patch(
+                "app.services.gmail_service.resolve_or_create_customer",
+                return_value=42,
+            ) as mock_resolve_customer,
+            patch(
+                "app.services.gmail_service.upload_staged_attachment",
+                return_value="tenant-1/inbox/msg-1/abc.pdf",
+            ) as mock_upload_staged,
+            patch("app.services.gmail_service.extract_email_fields") as mock_extract,
+        ):
+            _process_message(mock_service, mock_db, "msg-1", "tenantA", {})
+
+        # Claudeによる単一フィールド抽出は呼ばれない（後続Issueに置き換わるため）
+        mock_extract.assert_not_called()
+
+        # orders テーブルへの INSERT は発生しない
+        assert not any(
+            call.args and call.args[0] == "orders"
+            for call in mock_db.table.call_args_list
+        )
+
+        mock_upload_staged.assert_called_once_with(
+            mock_db, "tenant-1", "msg-1", "order.pdf", b"%PDF-1.4", "application/pdf"
+        )
+        mock_resolve_customer.assert_called_once_with(
+            mock_db, "tenant-1", "customer@example.com"
+        )
+
+        inserted_row = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert inserted_row["order_id"] is None
+        assert inserted_row["tenant_id"] == "tenant-1"
+        assert inserted_row["customer_id"] == 42
+        assert inserted_row["gmail_message_id"] == "msg-1"
+        assert inserted_row["storage_path"] == "tenant-1/inbox/msg-1/abc.pdf"
+        assert inserted_row["parse_status"] == "pending"
+
+    def test_non_pdf_attachment_keeps_existing_immediate_order_flow(self):
+        mock_service = self._mock_gmail_service()
+        mock_db = MagicMock()
+        mock_db.table("orders").insert().execute.return_value = MagicMock(
+            data=[{"id": 99}]
+        )
+
+        with (
+            patch(
+                "app.services.gmail_service._lookup_tenant_id",
+                return_value="tenant-1",
+            ),
+            patch(
+                "app.services.gmail_service._get_attachments",
+                return_value=[
+                    {
+                        "filename": "memo.txt",
+                        "content_type": "text/plain",
+                        "data": b"hello",
+                    }
+                ],
+            ),
+            patch(
+                "app.services.gmail_service.extract_email_fields",
+                return_value={
+                    "product_name": "<UNKNOWN>",
+                    "quantity": "<UNKNOWN>",
+                    "deadline_date": "<UNKNOWN>",
+                    "order_number": "<UNKNOWN>",
+                },
+            ),
+            patch("app.services.gmail_service.extract_sender_email", return_value=None),
+            patch(
+                "app.services.gmail_service.upload_attachment",
+                return_value="tenant-1/orders/99/def.txt",
+            ) as mock_upload,
+            patch(
+                "app.services.gmail_service.upload_staged_attachment"
+            ) as mock_upload_staged,
+        ):
+            _process_message(mock_service, mock_db, "msg-2", "tenantA", {})
+
+        # 既存フロー: 添付が非PDFなら即時orderが作成され、ステージング保存は呼ばれない
+        mock_upload_staged.assert_not_called()
+        mock_upload.assert_called_once()
+        assert any(
+            call.args and call.args[0] == "orders"
+            for call in mock_db.table.call_args_list
+        )

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -39,6 +39,28 @@ def upload_attachment(
     return storage_path
 
 
+def upload_staged_attachment(
+    admin_client: Client,
+    tenant_id: str,
+    gmail_message_id: str,
+    filename: str,
+    content: bytes,
+    content_type: str,
+) -> str:
+    """
+    order 未確定の添付ファイルを Supabase Storage にステージング保存し、storage_path を返す。
+    パス形式: {tenant_id}/inbox/{gmail_message_id}/{safe_filename}
+    元のファイル名は呼び出し元が original_filename カラムに保存する。
+    """
+    storage_path = f"{tenant_id}/inbox/{gmail_message_id}/{_safe_filename(filename)}"
+    admin_client.storage.from_(_BUCKET).upload(
+        path=storage_path,
+        file=content,
+        file_options={"content-type": content_type, "upsert": "true"},
+    )
+    return storage_path
+
+
 def create_signed_url(
     admin_client: Client,
     storage_path: str,

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -7,7 +7,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
-from app.services.attachment_service import upload_attachment
+from app.services.attachment_service import upload_attachment, upload_staged_attachment
 from app.services.customer_matching_service import (
     extract_sender_email,
     resolve_or_create_customer,
@@ -171,12 +171,61 @@ def _process_message(
         if not tenant_id:
             raise ValueError(f"tenant not found for label: {tenant_name}")
 
-        # 4. Claude で注文フィールド抽出
+        # 4. 添付ファイル取得（PDF判定のため単一フィールド抽出より前に行う）
+        attachments = _get_attachments(service, msg_id, msg.get("payload", {}))
+        pdf_attachment = next(
+            (a for a in attachments if a["content_type"] == "application/pdf"), None
+        )
+
+        if pdf_attachment is not None:
+            # PDF添付メール: orderは作成せず、order_attachments にステージング保存する
+            # （パースして複数orderを生成する処理は後続Issueで実装）
+            sender_email = extract_sender_email(body)
+            customer_id = (
+                resolve_or_create_customer(db, tenant_id, sender_email)
+                if sender_email
+                else None
+            )
+
+            storage_path = upload_staged_attachment(
+                db,
+                tenant_id,
+                msg_id,
+                pdf_attachment["filename"],
+                pdf_attachment["data"],
+                pdf_attachment["content_type"],
+            )
+            db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+                {
+                    "order_id": None,
+                    "tenant_id": tenant_id,
+                    "customer_id": customer_id,
+                    "gmail_message_id": msg_id,
+                    "source_raw": body,
+                    "storage_path": storage_path,
+                    "original_filename": pdf_attachment["filename"],
+                    "content_type": pdf_attachment["content_type"],
+                    "size_bytes": len(pdf_attachment["data"]),
+                    "parse_status": "pending",
+                }
+            ).execute()
+            logger.info(
+                f"msg {msg_id}: PDF attachment staged at {storage_path} "
+                f"(tenant={tenant_id}, order not created)"
+            )
+
+            # 5. 処理中 → 処理済み
+            _move_label(service, msg_id, done_id, processing_id)
+            return
+
+        # 添付なし・非PDF添付メール: 既存フロー（即時order作成）を維持する
+
+        # 5. Claude で注文フィールド抽出
         raw_fields = extract_email_fields(body)
         fields = {k: (None if v == "<UNKNOWN>" else v) for k, v in raw_fields.items()}
         logger.info(f"msg {msg_id}: extracted fields={fields}")
 
-        # 5. 製品マッチング
+        # 6. 製品マッチング
         product_id: int | None = None
         candidates: list[dict] = []
         product_name: str | None = fields.get("product_name")
@@ -185,13 +234,13 @@ def _process_message(
             product_id = match["product_id"]
             candidates = match["candidates"]
 
-        # 6. 顧客マッチング
-        customer_id: int | None = None
+        # 7. 顧客マッチング
+        customer_id = None
         sender_email = extract_sender_email(body)
         if sender_email:
             customer_id = resolve_or_create_customer(db, tenant_id, sender_email)
 
-        # 7. ドラフト注文を Supabase に登録
+        # 8. ドラフト注文を Supabase に登録
         order_row: dict[str, Any] = {
             "tenant_id": tenant_id,
             "source_type": "email",
@@ -213,8 +262,7 @@ def _process_message(
             f"msg {msg_id}: order draft created (id={order_id}) for tenant {tenant_id}"
         )
 
-        # 8. 添付ファイルを Storage に保存し order_attachments に記録
-        attachments = _get_attachments(service, msg_id, msg.get("payload", {}))
+        # 9. 添付ファイル（非PDF）を Storage に保存し order_attachments に記録
         if attachments:
             # 現在は1メール1添付を前提とし、最初の添付のみ処理する
             att = attachments[0]
@@ -250,7 +298,7 @@ def _process_message(
             ).execute()
             logger.info(f"msg {msg_id}: no attachment found")
 
-        # 9. 処理中 → 処理済み
+        # 10. 処理中 → 処理済み
         _move_label(service, msg_id, done_id, processing_id)
 
     except Exception as exc:

--- a/docs/features/order-attachments.md
+++ b/docs/features/order-attachments.md
@@ -2,7 +2,12 @@
 
 Gmail 自動伝票起票フローで受信した注文書 PDF を Supabase Storage に保存し、
 注文詳細画面からダウンロードできるようにする。
-将来の PDF パース処理（Issue B）の前提インフラでもある。
+
+> [!IMPORTANT]
+> Issue #248 により、PDF 添付メールの取り込みフローは「メール受信時点で即時 order 作成」から
+> 「PDF をステージング保存し、パース処理（後続Issue）完了後に order を作成」に変更された。
+> 添付なし・非PDF添付メールの既存フロー（即時 order 作成）は変更されていない。
+> 詳細は本ドキュメント内の「PDF添付メールのステージング保存（Issue #248）」を参照。
 
 ---
 
@@ -13,7 +18,7 @@ Gmail 自動起票フロー（`gmail_service.py`）は現状メール本文の�
 
 - **ISO 対応**: 注文書の原本保管が必要（社長承認フローの証跡）
 - **パース元の参照**: 担当者が UI 上から添付ファイルを確認・ダウンロードできる必要がある
-- **将来の PDF パース基盤**: Issue B で実装する PDF パース処理の前提インフラ
+- **将来の PDF パース基盤**: 後続Issue（PDF パース＋複数 order 生成）の前提インフラ
 
 ---
 
@@ -26,23 +31,32 @@ Gmail 自動起票フロー（`gmail_service.py`）は現状メール本文の�
 
 ### パス構造
 
-```
-{tenant_id}/orders/{order_id}/{original_filename}
-```
+- 非PDF添付・添付なしメール（既存フロー、`order_id` 確定済み）:
+  ```
+  {tenant_id}/orders/{order_id}/{original_filename}
+  ```
+  `order_id` は orders INSERT 後に確定するため、Storage 保存は INSERT の後に実施する。
 
-`order_id` は orders INSERT 後に確定するため、Storage 保存は INSERT の後に実施する。
+- PDF添付メール（ステージング、`order_id` 未確定。Issue #248 で追加）:
+  ```
+  {tenant_id}/inbox/{gmail_message_id}/{original_filename}
+  ```
+  いずれのパスも `tenant_id` prefix を維持するため、既存のバケットポリシーでカバーされる。
 
 ---
 
 ## DB スキーマ
 
-### 新規テーブル: `order_attachments`
+### `order_attachments` テーブル
 
 ```sql
 create table order_attachments (
   id                uuid primary key default gen_random_uuid(),
-  order_id          uuid not null references orders(id) on delete cascade,
+  order_id          bigint references orders(id) on delete cascade,  -- nullable (Issue #248)
   tenant_id         uuid not null references tenants(id),
+  customer_id       bigint references customers(id),                 -- Issue #248 で追加
+  source_raw        text,                                             -- Issue #248 で追加
+  gmail_message_id  text,                                             -- Issue #248 で追加
   storage_path      text not null,
   original_filename text not null,
   content_type      text,
@@ -56,11 +70,15 @@ create policy "tenant isolation" on order_attachments
   using (tenant_id = (auth.jwt() ->> 'tenant_id')::uuid);
 ```
 
+`order_id` は当初 NOT NULL だったが、Issue #248 で nullable 化された。PDF添付メールの
+ステージング行は `order_id=NULL` で作成され、後続Issue（PDFパース）が実際の `orders` 行を
+生成した時点で `order_id` を持つ行が別途 INSERT される想定。
+
 ### `parse_status` の定義
 
 | 値                       | 意味                            |
 |--------------------------|---------------------------------|
-| `pending`                | 未処理（Issue B で更新）        |
+| `pending`                | 未処理（後続Issueで更新）       |
 | `success`                | テキスト抽出成功                |
 | `failed_encrypted`       | PPAP などパスワード保護         |
 | `failed_image`           | 画像 PDF で抽出不可             |
@@ -70,20 +88,43 @@ create policy "tenant isolation" on order_attachments
 
 ## バックエンド処理フロー
 
-既存の `_process_message()` (`backend/app/services/gmail_service.py:107`) に以下を追加:
+### 非PDF添付・添付なしメール（既存フロー、変更なし）
+
+`_process_message()` (`backend/app/services/gmail_service.py`):
 
 ```
 1. Gmail API で添付ファイルを取得（payload.parts から attachmentId を収集）
-2. orders INSERT（既存処理: 行 162-175）
+2. Claude で単一フィールド抽出 → 製品・顧客照合 → orders INSERT
 3. 添付ファイルを Supabase Storage にアップロード
    パス: {tenant_id}/orders/{order_id}/{original_filename}
 4. order_attachments に INSERT（parse_status='pending'）
 5. 添付なしの場合は parse_status='failed_no_attachment' で INSERT
 ```
 
+### PDF添付メール（ステージング、Issue #248 で追加）
+
+添付に `content_type == 'application/pdf'` のパートが含まれる場合、上記とは別の分岐に入る:
+
+```
+1. 送信者アドレスから顧客照合（既存 resolve_or_create_customer を再利用）
+2. Claudeによる単一フィールド抽出（extract_email_fields）は呼ばない
+3. orders 行は作成しない
+4. PDFを Storage の {tenant_id}/inbox/{gmail_message_id}/{filename} に保存
+   （upload_staged_attachment()）
+5. order_attachments にステージング行を INSERT:
+   order_id=NULL, tenant_id, customer_id, gmail_message_id, source_raw=body,
+   storage_path, original_filename, content_type, size_bytes, parse_status='pending'
+```
+
+このステージング行から実際の `orders` 行を生成する処理（PDFテキスト抽出・複数明細パース）は
+後続Issueで実装する。
+
 ### 新規ファイル: `backend/app/services/attachment_service.py`
 
 - `upload_attachment(admin_client, tenant_id, order_id, filename, content, content_type) -> str`
+  — 既存フロー用（`order_id` 確定済み）
+- `upload_staged_attachment(admin_client, tenant_id, gmail_message_id, filename, content, content_type) -> str`
+  — PDFステージング用（Issue #248 で追加）
 - `create_signed_url(admin_client, storage_path, expires_in=3600) -> str`
 
 ### 新規 API エンドポイント
@@ -133,22 +174,27 @@ export interface OrderAttachment {
 
 ## 受け入れ条件
 
-- [ ] Supabase Storage に `order-attachments` バケットが作成されている
-- [ ] テナント分離のバケットポリシーが設定されている
-- [ ] `order_attachments` テーブルが作成されている（マイグレーション済み）
-- [ ] メール処理時に添付 PDF が Storage に保存される
-- [ ] 添付なしメールでも処理が継続する（エラーにならない）
-- [ ] 注文詳細画面から添付ファイルをダウンロードできる
-- [ ] `parse_status` が失敗系の場合、UI に警告が表示される
+- [x] Supabase Storage に `order-attachments` バケットが作成されている
+- [x] テナント分離のバケットポリシーが設定されている
+- [x] `order_attachments` テーブルが作成されている（マイグレーション済み）
+- [x] 添付なしメールでも処理が継続する（エラーにならない）
+- [x] 注文詳細画面から添付ファイルをダウンロードできる
+- [x] `parse_status` が失敗系の場合、UI に警告が表示される
+- [x] PDF添付メール受信時、`orders` 行が作成されない（Issue #248）
+- [x] PDF添付メール受信時、`order_attachments` にステージング行
+      （`order_id=NULL`, `parse_status='pending'`）が作成される（Issue #248）
+- [x] PDFが `{tenant_id}/inbox/{gmail_message_id}/{filename}` に保存される（Issue #248）
+- [x] `order_attachments.order_id` が nullable になっている（Issue #248）
 
 ---
 
 ## スコープ外
 
-- PDF の内容パース・テキスト抽出（→ Issue B）
+- PDF の内容パース・テキスト抽出・ステージング行からの複数 order 生成（→ 後続Issue）
 - PPAP（パスワード付き PDF）の自動復号
 - 複数添付ファイルへの対応（まず 1 メール 1 添付を前提）
-- 注文変更時の添付ファイル更新（→ Issue C）
+- 注文変更時の添付ファイル更新（→ 将来Issue）
+- ステージング行が長時間 `pending` のまま停滞した場合のリトライ・タイムアウト処理
 
 ---
 

--- a/supabase/migrations/20260701000000_add_order_attachments_staging.sql
+++ b/supabase/migrations/20260701000000_add_order_attachments_staging.sql
@@ -1,0 +1,11 @@
+-- order_attachments のステージング保存対応
+-- PDF添付メールは受信時点で orders 行を作成せず、order_id=NULL の
+-- ステージング行として保存できるようにする (Issue #248)
+
+alter table order_attachments
+  alter column order_id drop not null;
+
+alter table order_attachments
+  add column customer_id      bigint references customers(id),
+  add column source_raw       text,
+  add column gmail_message_id text;


### PR DESCRIPTION
## Summary
- PDF添付メール受信時点での即時 `orders` 行作成を廃止し、`order_attachments` にステージング行（`order_id=NULL`, `parse_status='pending'`）として保存する方式に変更（後続の複数order生成Issueの前提基盤）
- `order_attachments.order_id` を nullable化し、`customer_id`/`source_raw`/`gmail_message_id` カラムを追加するマイグレーションを追加
- 新規ヘルパー `upload_staged_attachment()` を追加し、PDFを `{tenant_id}/inbox/{gmail_message_id}/{filename}` に保存
- 添付なし・非PDF添付メールの既存フロー（即時order作成、`{tenant_id}/orders/{order_id}/...`）は変更なし

Closes #248

## Test plan
- [x] `pytest __tests__/unit/services/test_gmail_service.py` — PDF添付分岐・非PDF添付の既存フロー回帰を含む新規ユニットテストがパス
- [x] `ruff check .` / `mypy .`
- [x] e2eテスト (`__tests__/e2e/test_gmail_attachment_flow.py`) をステージング仕様に合わせて更新（実行にはGmail/Supabase実接続が必要なため未実行）
- [x] `docs/features/order-attachments.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)