### PR TITLE
feat(#249): 受注PDF自動パース＋複数order生成（内示ステータス対応）

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -49,6 +49,9 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 # デフォルトのまま変更不要な場合はコメントアウト
 # PRODUCT_MATCH_THRESHOLD=0.3
 # PRODUCT_MATCH_TOP_N=5
+# 自動確定に必要な最上位候補スコアの下限 / 次点候補とのスコア差の下限
+# PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD=0.75
+# PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15
 
 # ============================================================
 # テスト用 (ローカル開発のみ)

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -41,6 +41,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 
 # 使用モデル (デフォルトのまま変更不要な場合はコメントアウト)
 # EMAIL_EXTRACTION_MODEL=claude-haiku-4-5-20251001
+# PDF_EXTRACTION_MODEL=claude-sonnet-5
 
 # ============================================================
 # 製品マッチング (pg_trgm)

--- a/backend/__tests__/api/routers/cron/test_parse_order_pdfs.py
+++ b/backend/__tests__/api/routers/cron/test_parse_order_pdfs.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+import pytest
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+VALID_SECRET = "test-cron-secret-abc123"
+
+
+@pytest.mark.api
+class TestParseOrderPdfsRouter:
+    def test_missing_auth_header_returns_401(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        response = client.get("/api/cron/parse-order-pdfs")
+        assert response.status_code == 401
+
+    def test_wrong_secret_returns_401(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        response = client.get(
+            "/api/cron/parse-order-pdfs",
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+        assert response.status_code == 401
+
+    def test_valid_secret_returns_result(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        with patch(
+            "app.routers.cron.parse_order_pdfs.parse_pending_order_pdfs",
+            return_value={"processed": 2, "orders_created": 3, "errors": 0},
+        ):
+            response = client.get(
+                "/api/cron/parse-order-pdfs",
+                headers={"Authorization": f"Bearer {VALID_SECRET}"},
+            )
+        assert response.status_code == 200
+        assert response.json() == {"processed": 2, "orders_created": 3, "errors": 0}
+
+    def test_missing_cron_secret_env_returns_500(self, monkeypatch):
+        monkeypatch.delenv("CRON_SECRET", raising=False)
+        response = client.get(
+            "/api/cron/parse-order-pdfs",
+            headers={"Authorization": f"Bearer {VALID_SECRET}"},
+        )
+        assert response.status_code == 500
+
+    def test_parsing_error_returns_502(self, monkeypatch):
+        monkeypatch.setenv("CRON_SECRET", VALID_SECRET)
+        with patch(
+            "app.routers.cron.parse_order_pdfs.parse_pending_order_pdfs",
+            side_effect=Exception("storage unavailable"),
+        ):
+            response = client.get(
+                "/api/cron/parse-order-pdfs",
+                headers={"Authorization": f"Bearer {VALID_SECRET}"},
+            )
+        assert response.status_code == 502

--- a/backend/__tests__/e2e/conftest.py
+++ b/backend/__tests__/e2e/conftest.py
@@ -12,6 +12,13 @@ E2E テスト共通フィクスチャ
   E2E_GMAIL_TENANT_NAME     Gmailラベルのテナント名部分 (例: "株式会社テスト")
                             このテナントが gmail_label_tenants テーブルに登録済みであること
 
+test_pdf_order_parsing_flow.py の実行には追加で以下が必要:
+  ANTHROPIC_API_KEY         実際にClaude APIを呼び出すため
+  E2E_PDF_SAMPLE_STORAGE_PATH  order-attachments バケットに事前アップロード済みの
+                            実PDFのstorage_path（省略時は開発環境の既知のパスを使用）
+  E2E_GMAIL_TENANT_NAME のテナントの products テーブルに、上記PDF内の品番と
+  一致する製品（品名に品番文字列を含むもの）が登録されていること
+
 テスト実行:
   cd backend && pytest __tests__/e2e/ -v --run-e2e
 """
@@ -144,6 +151,89 @@ def admin_db(e2e_config: dict[str, str]) -> Client:
         e2e_config["SUPABASE_URL"],
         e2e_config["SUPABASE_SERVICE_ROLE_KEY"],
     )
+
+
+@pytest.fixture(scope="session")
+def e2e_tenant_id(admin_db: Client, e2e_config: dict[str, str]) -> str:
+    """E2E_GMAIL_TENANT_NAME に対応する tenant_id を返す。"""
+    tenant_name = e2e_config["E2E_GMAIL_TENANT_NAME"]
+    result = (
+        admin_db.table("gmail_label_tenants")
+        .select("tenant_id")
+        .eq("label_name", tenant_name)
+        .limit(1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    if not rows:
+        pytest.skip(f"gmail_label_tenants に '{tenant_name}' が登録されていません。")
+    return str(rows[0]["tenant_id"])
+
+
+# ---------------------------------------------------------------------------
+# 受注PDF自動パース (Issue #249) 用フィクスチャ
+# ---------------------------------------------------------------------------
+
+# order-attachments バケットに事前アップロード済みの実PDF（飯野製作所フォーマット）。
+# PDF自体はfixtureとして使い回すため、テストのteardownで削除しない。
+_PDF_ORDER_PARSING_SAMPLE_STORAGE_PATH = os.environ.get(
+    "E2E_PDF_SAMPLE_STORAGE_PATH",
+    "22222222-2222-2222-2222-222222222222/inbox/"
+    "19f11bf6c43e9fb3/95b05a24b202428a9cf07ece25a8290d.pdf",
+)
+
+
+@pytest.fixture()
+def pdf_order_parsing_staging_row(
+    admin_db: Client, e2e_tenant_id: str
+) -> Generator[dict[str, Any], None, None]:
+    """
+    order-attachments バケットに既にアップロード済みの実PDFを指す
+    order_attachments ステージング行 (order_id=NULL, parse_status='pending') を
+    DBへ直接INSERTし、テスト後に削除する。PDF実体はStorageに残したまま。
+
+    yield するdict: ステージング行 + "_run_id" (このテスト実行を識別する文字列)
+    """
+    from app.services.customer_matching_service import resolve_or_create_customer
+
+    run_id = uuid.uuid4().hex[:8]
+    # 実際のPDF送信元（飯野製作所）を模したE2Eテスト専用顧客。
+    # resolve_or_create_customer は既存顧客があれば再利用するため、
+    # 複数回のテスト実行で顧客レコードが増殖することはない。
+    customer_id = resolve_or_create_customer(
+        admin_db, e2e_tenant_id, "e2e-pdf-parsing-test@example.com"
+    )
+
+    inserted = (
+        admin_db.table("order_attachments")
+        .insert(
+            {
+                "order_id": None,
+                "tenant_id": e2e_tenant_id,
+                "customer_id": customer_id,
+                "gmail_message_id": f"e2e-pdf-parsing-{run_id}",
+                "source_raw": f"E2Eテスト(PDFパース) run_id={run_id}",
+                "storage_path": _PDF_ORDER_PARSING_SAMPLE_STORAGE_PATH,
+                "original_filename": "sample_order.pdf",
+                "content_type": "application/pdf",
+                "size_bytes": None,
+                "parse_status": "pending",
+            }
+        )
+        .execute()
+    )
+    row = cast(list[dict[str, Any]], inserted.data)[0]
+    row["_run_id"] = run_id
+
+    yield row
+
+    # --- teardown ---
+    # このテスト実行で生成された orders を削除（order_attachments は cascade で削除される）
+    admin_db.table("orders").delete().eq("tenant_id", e2e_tenant_id).like(
+        "source_raw", f"%run_id={run_id}%"
+    ).execute()
+    # ステージング行自体を削除（order_parse_log は cascade で削除される）
+    admin_db.table("order_attachments").delete().eq("id", row["id"]).execute()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/__tests__/e2e/test_pdf_order_parsing_flow.py
+++ b/backend/__tests__/e2e/test_pdf_order_parsing_flow.py
@@ -1,0 +1,168 @@
+"""
+E2E テスト: 受注PDF自動パース＋複数order生成フロー (Issue #249)
+
+order-attachments バケットに事前アップロード済みの実PDF（飯野製作所フォーマット、
+複数品番・複数納期・確度混在の注文一覧表）を対象に、実際の Supabase と Claude API
+を使って parse_pending_order_pdfs() を実行し、以下を検証する:
+
+  - 配線・データフロー: ステージング行 → テキスト抽出 → Claude抽出 → 製品照合 →
+    order生成 → order_attachments紐付け、という一連の処理が実際に完走すること
+  - 抽出精度: 実在する製品については正しい数量・納期でorderが生成されること、
+    実在しない製品については誤って別製品にマッチせず no_product_match として
+    スキップされること（品番が1文字違いの類似製品が製品マスタに存在するケース）
+
+事前準備:
+  1. conftest.py の pdf_order_parsing_staging_row フィクスチャのドキュメント参照
+     （対象PDFのstorage_path、ANTHROPIC_API_KEY、対象テナントの製品マスタ）
+
+実行:
+  cd backend && pytest __tests__/e2e/test_pdf_order_parsing_flow.py -v --run-e2e
+"""
+
+from typing import Any, cast
+
+import pytest
+from app.services.attachment_service import create_signed_url
+from app.services.pdf_order_parsing_service import parse_pending_order_pdfs
+
+# PDF内に実在する製品の品番。product_matching_service の名寄せ
+# (pg_trgm, 自動確定しきい値あり) 経由でマッチすることを想定。
+# 製品マスタ側の登録名は "22750-50P-0000-1"（末尾の0埋めなし）のため、
+# 検索には両表記に共通するプレフィックスを用いる。
+_EXISTING_PRODUCT_NUMBER = "22750-50P-0000-01"
+_EXISTING_PRODUCT_NAME_SEARCH_PREFIX = "22750-50P"
+# PDF内に記載されているが、製品マスタには存在しない品番。
+# よく似た別製品 (1文字違い) が製品マスタに存在するため、
+# 誤って別製品にマッチしないことを検証する対象。
+_MISSING_PRODUCT_NUMBER = "25760-63C-0000-01-01"
+
+
+@pytest.mark.e2e
+class TestPdfOrderParsingFlow:
+    def test_staged_pdf_is_parsed_into_orders_with_correct_matching(
+        self,
+        pdf_order_parsing_staging_row: dict[str, Any],
+        admin_db,
+        e2e_tenant_id: str,
+    ) -> None:
+        attachment_id = pdf_order_parsing_staging_row["id"]
+        run_id = pdf_order_parsing_staging_row["_run_id"]
+
+        # --- パース実行（実 Supabase Storage + 実 Claude API を使用） ---
+        result = parse_pending_order_pdfs(admin_db)
+        assert result["errors"] == 0, (
+            f"parse_pending_order_pdfs returned errors: {result}"
+        )
+
+        # --- 配線・データフロー: ステージング行が success になる ---
+        staging_result = (
+            admin_db.table("order_attachments")
+            .select("parse_status")
+            .eq("id", attachment_id)
+            .execute()
+        )
+        staging_rows = cast(list[dict[str, Any]], staging_result.data or [])
+        assert len(staging_rows) == 1
+        assert staging_rows[0]["parse_status"] == "success"
+
+        # --- このテスト実行で生成された orders を取得 ---
+        orders_result = (
+            admin_db.table("orders")
+            .select("*")
+            .eq("tenant_id", e2e_tenant_id)
+            .like("source_raw", f"%run_id={run_id}%")
+            .execute()
+        )
+        orders = cast(list[dict[str, Any]], orders_result.data or [])
+        assert len(orders) >= 1, (
+            "実在する製品について少なくとも1件orderが生成されるはず"
+        )
+
+        # --- 抽出精度: 実在する製品 (22750-50P-...) について正しくマッチし、
+        #     正しい数量・妥当な納期で order が生成されていること ---
+        products_result = (
+            admin_db.table("products")
+            .select("id")
+            .eq("tenant_id", e2e_tenant_id)
+            .ilike("name", f"%{_EXISTING_PRODUCT_NAME_SEARCH_PREFIX}%")
+            .execute()
+        )
+        existing_product_rows = cast(list[dict[str, Any]], products_result.data or [])
+        assert len(existing_product_rows) == 1, (
+            f"テスト前提: 製品マスタに '{_EXISTING_PRODUCT_NAME_SEARCH_PREFIX}' を含む製品が"
+            "1件だけ登録されている必要があります"
+        )
+        existing_product_id = existing_product_rows[0]["id"]
+
+        orders_for_existing_product = [
+            order for order in orders if order["product_id"] == existing_product_id
+        ]
+        assert len(orders_for_existing_product) >= 1, (
+            f"'{_EXISTING_PRODUCT_NUMBER}' に対応する製品(id={existing_product_id})の"
+            f"orderが生成されていません。生成されたorders: {orders}"
+        )
+        for order in orders_for_existing_product:
+            assert order["quantity"] == 15000
+            assert order["status"] in ("confirmed", "forecast", "forecast_tentative")
+            assert order["customer_id"] == pdf_order_parsing_staging_row["customer_id"]
+
+        deadline_dates = {
+            order["deadline_date"] for order in orders_for_existing_product
+        }
+        assert deadline_dates <= {"2026-07-13", "2026-07-27"}, (
+            f"想定外の納期でorderが生成されました: {deadline_dates}"
+        )
+
+        # --- 抽出精度: 存在しない製品 (25760-63C-...) は、1文字違いの類似デコイ製品
+        #     (22760-63C-...) に誤ってマッチせず、無理に order を生成しないこと ---
+        decoy_products_result = (
+            admin_db.table("products")
+            .select("id")
+            .eq("tenant_id", e2e_tenant_id)
+            .ilike("name", "%22760-63C%")
+            .execute()
+        )
+        decoy_product_rows = cast(
+            list[dict[str, Any]], decoy_products_result.data or []
+        )
+        assert len(decoy_product_rows) == 1, (
+            "テスト前提: 製品マスタにデコイ製品 '22760-63C-...' が"
+            "1件だけ登録されている必要があります"
+        )
+        decoy_product_id = decoy_product_rows[0]["id"]
+        assert not any(order["product_id"] == decoy_product_id for order in orders), (
+            f"'{_MISSING_PRODUCT_NUMBER}' がデコイ製品(id={decoy_product_id})に"
+            f"誤ってマッチしました: {orders}"
+        )
+
+        log_result = (
+            admin_db.table("order_parse_log")
+            .select("*")
+            .eq("order_attachment_id", attachment_id)
+            .execute()
+        )
+        logs = cast(list[dict[str, Any]], log_result.data or [])
+        no_match_logs = [log for log in logs if log["reason"] == "no_product_match"]
+        assert any(
+            _MISSING_PRODUCT_NUMBER in str(log.get("detail", {}))
+            for log in no_match_logs
+        ), (
+            f"'{_MISSING_PRODUCT_NUMBER}' が no_product_match として "
+            f"order_parse_log に記録されていません: {logs}"
+        )
+
+        # --- 生成された order の添付ファイルが既存エンドポイント経由で
+        #     ダウンロード可能であること（/orders/{order_id}/attachments が
+        #     変更なしで流用できることの確認） ---
+        att_result = (
+            admin_db.table("order_attachments")
+            .select("storage_path, parse_status")
+            .eq("order_id", orders_for_existing_product[0]["id"])
+            .execute()
+        )
+        attachments = cast(list[dict[str, Any]], att_result.data or [])
+        assert len(attachments) == 1
+        assert attachments[0]["parse_status"] == "success"
+
+        signed_url = create_signed_url(admin_db, attachments[0]["storage_path"])
+        assert signed_url.startswith("http")

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -1,0 +1,179 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.services.pdf_order_parsing_service import (
+    _process_line_item,
+    parse_pending_order_pdfs,
+)
+from app.services.pdf_text_service import PdfTextResult
+
+
+@pytest.mark.unit
+class TestParsePendingOrderPdfs:
+    def _staging_row(self, **overrides):
+        row = {
+            "id": "att-1",
+            "tenant_id": "tenant-1",
+            "customer_id": 7,
+            "source_raw": "本文 run_id=abc123",
+            "storage_path": "tenant-1/inbox/msg-1/order.pdf",
+            "original_filename": "order.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 1234,
+            "parse_status": "pending",
+        }
+        row.update(overrides)
+        return row
+
+    def test_no_pending_rows_returns_zero_counts(self):
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(data=[])
+
+        result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 0, "orders_created": 0, "errors": 0}
+
+    def test_encrypted_pdf_marks_failed_and_creates_no_order(self):
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row()]
+        )
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment",
+                return_value=b"%PDF-fake",
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text",
+                return_value=PdfTextResult(
+                    text=None, failure_reason="failed_encrypted"
+                ),
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_order_lines"
+            ) as mock_extract_lines,
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        mock_extract_lines.assert_not_called()
+        assert result == {"processed": 1, "orders_created": 0, "errors": 0}
+
+        update_calls = mock_db.table().update.call_args_list
+        assert any(
+            c.args[0] == {"parse_status": "failed_encrypted"} for c in update_calls
+        )
+
+    def test_exception_during_processing_counts_as_error(self):
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row()]
+        )
+
+        with patch(
+            "app.services.pdf_order_parsing_service.download_attachment",
+            side_effect=Exception("storage error"),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 0, "orders_created": 0, "errors": 1}
+
+
+@pytest.mark.unit
+class TestProcessLineItem:
+    def _staging_row(self, **overrides):
+        row = {
+            "id": "att-1",
+            "tenant_id": "tenant-1",
+            "customer_id": 7,
+            "source_raw": "本文",
+            "storage_path": "tenant-1/inbox/msg-1/order.pdf",
+            "original_filename": "order.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 1234,
+        }
+        row.update(overrides)
+        return row
+
+    def test_no_product_match_logs_and_skips(self):
+        mock_db = MagicMock()
+        line = {
+            "product_name_raw": "謎の製品",
+            "product_number_raw": None,
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "confirmed",
+        }
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+                return_value=None,
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_products",
+                return_value={"product_id": None, "candidates": []},
+            ),
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is False
+        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        assert log_insert["reason"] == "no_product_match"
+        assert log_insert["order_attachment_id"] == "att-1"
+
+    def test_duplicate_order_logs_and_skips(self):
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"id": None, "inserted": False}]
+        )
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "confirmed",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is False
+        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        assert log_insert["reason"] == "duplicate_skipped"
+
+    def test_successful_line_creates_order_and_attachment(self):
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"id": 555, "inserted": True}]
+        )
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "forecast",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is True
+
+        rpc_call_args = mock_db.rpc.call_args_list[-1]
+        assert rpc_call_args.args[0] == "create_order_skip_duplicate"
+        rpc_params = rpc_call_args.args[1]
+        assert rpc_params["p_product_id"] == 100
+        assert rpc_params["p_status"] == "forecast"
+        assert rpc_params["p_customer_id"] == 7
+
+        attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert attachment_insert["order_id"] == 555
+        assert attachment_insert["parse_status"] == "success"
+        assert attachment_insert["storage_path"] == "tenant-1/inbox/msg-1/order.pdf"

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -122,6 +122,48 @@ class TestProcessLineItem:
         assert log_insert["reason"] == "no_product_match"
         assert log_insert["order_attachment_id"] == "att-1"
 
+    def test_falls_back_to_name_search_using_product_number_raw(self):
+        """
+        products.code が未整備で name 列に品番文字列が入っているテナントでは、
+        code完全一致に失敗した後、product_number_raw で products.name を
+        pg_trgm検索するフォールバックが機能すること。
+        """
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"id": 555, "inserted": True}]
+        )
+        line = {
+            "product_name_raw": "FILTER COMP （φ10.6）",
+            "product_number_raw": "22750-50P-0000-01",
+            "quantity": 15000,
+            "delivery_date": "2026-07-13",
+            "certainty": "confirmed",
+        }
+
+        def fake_match_products(db, tenant_id, query_text):
+            if query_text == "22750-50P-0000-01":
+                return {"product_id": 10534, "candidates": []}
+            return {"product_id": None, "candidates": []}
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+                return_value=None,
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_products",
+                side_effect=fake_match_products,
+            ) as mock_match_products,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is True
+        # product_name_raw ではなく product_number_raw で先にマッチしたはず
+        first_call_query = mock_match_products.call_args_list[0].args[2]
+        assert first_call_query == "22750-50P-0000-01"
+        rpc_params = mock_db.rpc.call_args_list[-1].args[1]
+        assert rpc_params["p_product_id"] == 10534
+
     def test_duplicate_order_logs_and_skips(self):
         mock_db = MagicMock()
         mock_db.rpc().execute.return_value = MagicMock(

--- a/backend/__tests__/unit/services/test_pdf_text_service.py
+++ b/backend/__tests__/unit/services/test_pdf_text_service.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+import pytest
+from app.services.pdf_text_service import extract_text
+from pdfminer.pdfdocument import PDFPasswordIncorrect
+from pdfplumber.utils.exceptions import PdfminerException
+
+_BLANK_PDF = b"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+trailer
+<< /Size 4 /Root 1 0 R >>
+"""
+
+
+def _build_text_pdf(text: str) -> bytes:
+    content_stream = f"BT /F1 24 Tf 50 700 Td ({text}) Tj ET".encode()
+    return (
+        b"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length """
+        + str(len(content_stream)).encode()
+        + b""" >>
+stream
+"""
+        + content_stream
+        + b"""
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+trailer
+<< /Size 6 /Root 1 0 R >>
+"""
+    )
+
+
+@pytest.mark.unit
+class TestExtractText:
+    def test_pdf_with_text_returns_text(self):
+        result = extract_text(_build_text_pdf("Hello Order PDF"))
+        assert result.failure_reason is None
+        assert result.text is not None
+        assert "Hello Order PDF" in result.text
+
+    def test_blank_pdf_returns_failed_image(self):
+        result = extract_text(_BLANK_PDF)
+        assert result.failure_reason == "failed_image"
+        assert result.text is None
+
+    def test_unreadable_content_raises(self):
+        with pytest.raises(PdfminerException):
+            extract_text(b"not a pdf at all")
+
+    def test_encrypted_pdf_returns_failed_encrypted(self):
+        with patch(
+            "app.services.pdf_text_service.pdfplumber.open",
+            side_effect=PDFPasswordIncorrect("password required"),
+        ):
+            result = extract_text(_BLANK_PDF)
+        assert result.failure_reason == "failed_encrypted"
+        assert result.text is None

--- a/backend/__tests__/unit/services/test_product_matching_service.py
+++ b/backend/__tests__/unit/services/test_product_matching_service.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+import pytest
+from app.services.product_matching_service import match_product_by_code
+
+
+@pytest.mark.unit
+class TestMatchProductByCode:
+    def test_single_match_returns_product_id(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[{"id": 42}]
+        )
+
+        result = match_product_by_code(mock_db, "tenant-1", "22750-50P-0000-01")
+
+        assert result == 42
+
+    def test_no_match_returns_none(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[]
+        )
+
+        result = match_product_by_code(mock_db, "tenant-1", "unknown-code")
+
+        assert result is None
+
+    def test_multiple_matches_returns_none(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[{"id": 1}, {"id": 2}]
+        )
+
+        result = match_product_by_code(mock_db, "tenant-1", "ambiguous-code")
+
+        assert result is None

--- a/backend/__tests__/unit/services/test_product_matching_service.py
+++ b/backend/__tests__/unit/services/test_product_matching_service.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from app.services.product_matching_service import match_product_by_code
+from app.services.product_matching_service import match_product_by_code, match_products
 
 
 @pytest.mark.unit
@@ -35,3 +35,55 @@ class TestMatchProductByCode:
         result = match_product_by_code(mock_db, "tenant-1", "ambiguous-code")
 
         assert result is None
+
+
+@pytest.mark.unit
+class TestMatchProducts:
+    def _mock_db_with_rpc_result(self, rows):
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(data=rows)
+        return mock_db
+
+    def test_high_confidence_single_candidate_auto_confirms(self):
+        mock_db = self._mock_db_with_rpc_result(
+            [{"id": 10534, "name": "22750-50P-0000-1", "score": 0.9}]
+        )
+
+        result = match_products(mock_db, "tenant-1", "22750-50P-0000-01")
+
+        assert result["product_id"] == 10534
+
+    def test_low_confidence_single_candidate_does_not_auto_confirm(self):
+        """
+        品番のようにわずか1文字違いで別製品を指しうる文字列の場合、
+        候補が1件だけでもスコアが低ければ自動確定してはいけない
+        （デコイ製品への誤マッチを防ぐ）。
+        """
+        mock_db = self._mock_db_with_rpc_result(
+            [{"id": 10535, "name": "22760-63C-0000-01-01", "score": 0.68}]
+        )
+
+        result = match_products(mock_db, "tenant-1", "25760-63C-0000-01-01")
+
+        assert result["product_id"] is None
+        assert result["candidates"][0]["product_id"] == 10535
+
+    def test_close_second_candidate_does_not_auto_confirm(self):
+        mock_db = self._mock_db_with_rpc_result(
+            [
+                {"id": 1, "name": "A-0001", "score": 0.85},
+                {"id": 2, "name": "A-0002", "score": 0.80},
+            ]
+        )
+
+        result = match_products(mock_db, "tenant-1", "A-0001")
+
+        assert result["product_id"] is None
+
+    def test_no_candidates_returns_none(self):
+        mock_db = self._mock_db_with_rpc_result([])
+
+        result = match_products(mock_db, "tenant-1", "nonexistent-product")
+
+        assert result["product_id"] is None
+        assert result["candidates"] == []

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers.admin import admin_router
-from app.routers.cron import cron_router
+from app.routers.cron import cron_router, parse_order_pdfs_router
 from app.routers.master import (
     calendar_router,
     customer_router,
@@ -58,6 +58,7 @@ app.include_router(scheduling_settings_router)
 app.include_router(member_router)
 app.include_router(admin_router)
 app.include_router(cron_router)
+app.include_router(parse_order_pdfs_router)
 
 
 @app.get("/health")

--- a/backend/app/repositories/supa_infra/common/table_name.py
+++ b/backend/app/repositories/supa_infra/common/table_name.py
@@ -18,3 +18,4 @@ class SupabaseTableName(Enum):
     SCHEDULING_SETTINGS = "scheduling_settings"
     GMAIL_LABEL_TENANTS = "gmail_label_tenants"
     ORDER_ATTACHMENTS = "order_attachments"
+    ORDER_PARSE_LOG = "order_parse_log"

--- a/backend/app/routers/cron/__init__.py
+++ b/backend/app/routers/cron/__init__.py
@@ -1,3 +1,4 @@
 from app.routers.cron.gmail_poll import cron_router
+from app.routers.cron.parse_order_pdfs import parse_order_pdfs_router
 
-__all__ = ["cron_router"]
+__all__ = ["cron_router", "parse_order_pdfs_router"]

--- a/backend/app/routers/cron/_auth.py
+++ b/backend/app/routers/cron/_auth.py
@@ -1,0 +1,25 @@
+import os
+import secrets
+
+from fastapi import HTTPException, Request, status
+
+
+def validate_cron_secret(request: Request) -> None:
+    cron_secret = os.environ.get("CRON_SECRET")
+    if not cron_secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="CRON_SECRET not configured.",
+        )
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header.",
+        )
+    token = auth_header.removeprefix("Bearer ")
+    if not secrets.compare_digest(token.encode(), cron_secret.encode()):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid CRON_SECRET.",
+        )

--- a/backend/app/routers/cron/gmail_poll.py
+++ b/backend/app/routers/cron/gmail_poll.py
@@ -1,9 +1,7 @@
-import os
-import secrets
-
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Request
 
 from app.dependencies import get_supabase_admin_client
+from app.routers.cron._auth import validate_cron_secret
 from app.services.gmail_service import poll_unread_emails
 from app.utils.logger import get_logger
 
@@ -11,30 +9,9 @@ cron_router = APIRouter(prefix="/api/cron", tags=["Cron"])
 logger = get_logger(__name__)
 
 
-def _validate_cron_secret(request: Request) -> None:
-    cron_secret = os.environ.get("CRON_SECRET")
-    if not cron_secret:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="CRON_SECRET not configured.",
-        )
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing Authorization header.",
-        )
-    token = auth_header.removeprefix("Bearer ")
-    if not secrets.compare_digest(token.encode(), cron_secret.encode()):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid CRON_SECRET.",
-        )
-
-
 @cron_router.get("/gmail-poll")
 def gmail_poll(request: Request):
-    _validate_cron_secret(request)
+    validate_cron_secret(request)
     try:
         db_client = get_supabase_admin_client()
         return poll_unread_emails(db_client)

--- a/backend/app/routers/cron/parse_order_pdfs.py
+++ b/backend/app/routers/cron/parse_order_pdfs.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, HTTPException, Request
+
+from app.dependencies import get_supabase_admin_client
+from app.routers.cron._auth import validate_cron_secret
+from app.services.pdf_order_parsing_service import parse_pending_order_pdfs
+from app.utils.logger import get_logger
+
+parse_order_pdfs_router = APIRouter(prefix="/api/cron", tags=["Cron"])
+logger = get_logger(__name__)
+
+
+@parse_order_pdfs_router.get("/parse-order-pdfs")
+def parse_order_pdfs(request: Request):
+    validate_cron_secret(request)
+    try:
+        db_client = get_supabase_admin_client()
+        return parse_pending_order_pdfs(db_client)
+    except Exception as exc:
+        logger.error(f"PDF order parsing failed: {exc}", exc_info=True)
+        raise HTTPException(
+            status_code=502, detail=f"PDF order parsing error: {exc}"
+        ) from exc

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -61,6 +61,11 @@ def upload_staged_attachment(
     return storage_path
 
 
+def download_attachment(admin_client: Client, storage_path: str) -> bytes:
+    """Supabase Storage から添付ファイルの内容をダウンロードする。"""
+    return bytes(admin_client.storage.from_(_BUCKET).download(storage_path))
+
+
 def create_signed_url(
     admin_client: Client,
     storage_path: str,

--- a/backend/app/services/customer_matching_service.py
+++ b/backend/app/services/customer_matching_service.py
@@ -23,7 +23,7 @@ def extract_sender_email(body: str) -> str | None:
 def resolve_or_create_customer(db: Client, tenant_id: str, email: str) -> int:
     """
     メールアドレスで顧客を検索し、存在すれば customer_id を返す。
-    存在しなければ draft 顧客を自動作成して返す。
+    存在しなければ顧客を自動作成して返す。
     """
     table = SupabaseTableName.CUSTOMERS.value
     result = (
@@ -41,9 +41,7 @@ def resolve_or_create_customer(db: Client, tenant_id: str, email: str) -> int:
 
     created = (
         db.table(table)
-        .insert(
-            {"tenant_id": tenant_id, "email": email, "name": email, "status": "draft"}
-        )
+        .insert({"tenant_id": tenant_id, "email": email, "name": email})
         .execute()
     )
     created_rows = cast(list[dict[str, Any]], created.data or [])

--- a/backend/app/services/pdf_order_extraction_service.py
+++ b/backend/app/services/pdf_order_extraction_service.py
@@ -1,0 +1,89 @@
+import os
+from typing import Any, cast
+
+import anthropic
+
+_client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+_EXTRACT_TOOL: Any = {
+    "name": "extract_order_lines",
+    "description": (
+        "受注PDFのテキストから明細行を抽出する。"
+        "1つのPDFに複数品番・複数納期・複数の確度（確定/内示/内々示）の明細が"
+        "含まれる場合、行ごとに分けて返すこと。"
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "line_items": {
+                "type": "array",
+                "description": "PDF内の明細行の配列。明細が見つからない場合は空配列。",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "product_name_raw": {
+                            "type": ["string", "null"],
+                            "description": "製品名（型番・仕様を含む原文表記）。不明な場合はnull",
+                        },
+                        "product_number_raw": {
+                            "type": ["string", "null"],
+                            "description": "品番。不明な場合はnull",
+                        },
+                        "quantity": {
+                            "type": ["integer", "null"],
+                            "description": "数量（整数）。不明な場合はnull",
+                        },
+                        "delivery_date": {
+                            "type": ["string", "null"],
+                            "description": "納期 (ISO 8601: YYYY-MM-DD)。不明な場合はnull",
+                        },
+                        "certainty": {
+                            "type": "string",
+                            "enum": ["confirmed", "forecast", "forecast_tentative"],
+                            "description": (
+                                "明細の確度。"
+                                "confirmed=確定納期・確定発注書番号(PO番号)が明記されている確定分、"
+                                "forecast=「内示」「見込み」等、確定していないが具体的な数量・納期が"
+                                "提示されている分、"
+                                "forecast_tentative=「内々示」「予定」等、さらに不確実性が高い先の見込み分。"
+                                "表・見出し・注記の文言（確定/内示/内々示、PO番号の有無等）を根拠に判定すること。"
+                            ),
+                        },
+                    },
+                    "required": [
+                        "product_name_raw",
+                        "product_number_raw",
+                        "quantity",
+                        "delivery_date",
+                        "certainty",
+                    ],
+                },
+            },
+        },
+        "required": ["line_items"],
+    },
+}
+
+
+def extract_order_lines(pdf_text: str) -> list[dict[str, Any]]:
+    model = os.environ.get("PDF_EXTRACTION_MODEL", "claude-sonnet-5")
+    response = _client.messages.create(
+        model=model,
+        max_tokens=4096,
+        tools=[_EXTRACT_TOOL],
+        tool_choice={"type": "tool", "name": "extract_order_lines"},
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "以下は受注PDFから抽出したテキストです。"
+                    "明細行ごとに品番・品名・数量・納期・確度を抽出してください。\n\n"
+                    f"{pdf_text}"
+                ),
+            }
+        ],
+    )
+    for block in response.content:
+        if block.type == "tool_use" and block.name == "extract_order_lines":
+            return cast(list[dict[str, Any]], block.input.get("line_items", []))
+    return []

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -102,9 +102,16 @@ def _process_line_item(
     product_number_raw = line.get("product_number_raw")
     product_name_raw = line.get("product_name_raw")
 
+    # 1. products.code の完全一致
+    # 2. products.name に対する品番文字列でのpg_trgm検索
+    #    （code列が未整備で、name列に品番文字列が入っているテナントに対応するため）
+    # 3. products.name に対する品名文字列でのpg_trgm検索
     product_id: int | None = None
     if product_number_raw:
         product_id = match_product_by_code(db, tenant_id, product_number_raw)
+    if product_id is None and product_number_raw:
+        match = match_products(db, tenant_id, product_number_raw)
+        product_id = match["product_id"]
     if product_id is None and product_name_raw:
         match = match_products(db, tenant_id, product_name_raw)
         product_id = match["product_id"]

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -1,0 +1,189 @@
+from typing import Any, cast
+
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.services.attachment_service import download_attachment
+from app.services.pdf_order_extraction_service import extract_order_lines
+from app.services.pdf_text_service import extract_text
+from app.services.product_matching_service import match_product_by_code, match_products
+from app.utils.logger import get_logger
+from supabase import Client
+
+logger = get_logger(__name__)
+
+_CERTAINTY_TO_STATUS = {
+    "confirmed": "confirmed",
+    "forecast": "forecast",
+    "forecast_tentative": "forecast_tentative",
+}
+
+
+def parse_pending_order_pdfs(db: Client) -> dict[str, int]:
+    """
+    order_attachments のステージング行 (order_id IS NULL, parse_status='pending') を
+    ポーリングし、PDFをパースして複数の orders 行を生成する。
+    """
+    table = SupabaseTableName.ORDER_ATTACHMENTS.value
+    result = (
+        db.table(table)
+        .select("*")
+        .is_("order_id", "null")
+        .eq("parse_status", "pending")
+        .execute()
+    )
+    staging_rows = cast(list[dict[str, Any]], result.data or [])
+
+    processed = 0
+    orders_created = 0
+    errors = 0
+
+    for row in staging_rows:
+        try:
+            orders_created += _parse_one(db, row)
+            processed += 1
+        except Exception as exc:
+            errors += 1
+            logger.error(
+                f"pdf_order_parsing: staging row {row['id']} failed: {exc}",
+                exc_info=True,
+            )
+
+    logger.info(
+        f"pdf_order_parsing complete: processed={processed} "
+        f"orders_created={orders_created} errors={errors}"
+    )
+    return {
+        "processed": processed,
+        "orders_created": orders_created,
+        "errors": errors,
+    }
+
+
+def _parse_one(db: Client, row: dict[str, Any]) -> int:
+    """1件のステージング行を処理し、生成した order 数を返す。"""
+    table = SupabaseTableName.ORDER_ATTACHMENTS.value
+    attachment_id = row["id"]
+
+    content = download_attachment(db, row["storage_path"])
+    text_result = extract_text(content)
+
+    if text_result.failure_reason is not None:
+        db.table(table).update({"parse_status": text_result.failure_reason}).eq(
+            "id", attachment_id
+        ).execute()
+        logger.info(
+            f"pdf_order_parsing: attachment {attachment_id} "
+            f"marked {text_result.failure_reason}"
+        )
+        return 0
+
+    line_items = extract_order_lines(cast(str, text_result.text))
+    logger.info(
+        f"pdf_order_parsing: attachment {attachment_id} "
+        f"extracted {len(line_items)} line items"
+    )
+
+    created_count = sum(1 for line in line_items if _process_line_item(db, row, line))
+
+    db.table(table).update({"parse_status": "success"}).eq(
+        "id", attachment_id
+    ).execute()
+    return created_count
+
+
+def _process_line_item(
+    db: Client, staging_row: dict[str, Any], line: dict[str, Any]
+) -> bool:
+    """
+    抽出された1明細から order を生成する。
+    生成できた場合 True、品番照合失敗・重複スキップの場合 False を返す。
+    """
+    tenant_id = staging_row["tenant_id"]
+    attachment_id = staging_row["id"]
+    product_number_raw = line.get("product_number_raw")
+    product_name_raw = line.get("product_name_raw")
+
+    product_id: int | None = None
+    if product_number_raw:
+        product_id = match_product_by_code(db, tenant_id, product_number_raw)
+    if product_id is None and product_name_raw:
+        match = match_products(db, tenant_id, product_name_raw)
+        product_id = match["product_id"]
+
+    if product_id is None:
+        _log_parse_event(
+            db,
+            tenant_id,
+            attachment_id,
+            "no_product_match",
+            {
+                "product_number_raw": product_number_raw,
+                "product_name_raw": product_name_raw,
+            },
+        )
+        return False
+
+    certainty = cast(str | None, line.get("certainty"))
+    status = _CERTAINTY_TO_STATUS.get(certainty or "", "forecast_tentative")
+
+    rpc_result = db.rpc(
+        "create_order_skip_duplicate",
+        {
+            "p_tenant_id": tenant_id,
+            "p_customer_id": staging_row.get("customer_id"),
+            "p_product_id": product_id,
+            "p_quantity": line.get("quantity"),
+            "p_deadline_date": line.get("delivery_date"),
+            "p_status": status,
+            "p_source_type": "email",
+            "p_source_raw": staging_row.get("source_raw"),
+            "p_extracted_product_name": product_name_raw,
+        },
+    ).execute()
+    rpc_rows = cast(list[dict[str, Any]], rpc_result.data or [])
+
+    if not rpc_rows or not rpc_rows[0].get("inserted"):
+        _log_parse_event(
+            db,
+            tenant_id,
+            attachment_id,
+            "duplicate_skipped",
+            {"product_id": product_id, "deadline_date": line.get("delivery_date")},
+        )
+        return False
+
+    order_id = rpc_rows[0]["id"]
+    db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+        {
+            "order_id": order_id,
+            "tenant_id": tenant_id,
+            "storage_path": staging_row["storage_path"],
+            "original_filename": staging_row.get("original_filename", ""),
+            "content_type": staging_row.get("content_type"),
+            "size_bytes": staging_row.get("size_bytes"),
+            "parse_status": "success",
+        }
+    ).execute()
+    logger.info(
+        f"pdf_order_parsing: order {order_id} created from attachment {attachment_id}"
+    )
+    return True
+
+
+def _log_parse_event(
+    db: Client,
+    tenant_id: str,
+    attachment_id: str,
+    reason: str,
+    detail: dict[str, Any],
+) -> None:
+    db.table(SupabaseTableName.ORDER_PARSE_LOG.value).insert(
+        {
+            "tenant_id": tenant_id,
+            "order_attachment_id": attachment_id,
+            "reason": reason,
+            "detail": detail,
+        }
+    ).execute()
+    logger.info(
+        f"pdf_order_parsing: logged {reason} for attachment {attachment_id}: {detail}"
+    )

--- a/backend/app/services/pdf_text_service.py
+++ b/backend/app/services/pdf_text_service.py
@@ -1,0 +1,37 @@
+import io
+from dataclasses import dataclass
+
+import pdfplumber
+from pdfminer.pdfdocument import PDFEncryptionError, PDFPasswordIncorrect
+
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class PdfTextResult:
+    text: str | None
+    # 'failed_encrypted' | 'failed_image' | None (成功時)
+    failure_reason: str | None
+
+
+def extract_text(content: bytes) -> PdfTextResult:
+    """
+    PDFバイナリからテキストを抽出する。
+    - パスワード保護 (PPAP等) で開けない場合は failure_reason='failed_encrypted'
+    - 開けるがテキストが1文字も取れない場合（画像PDF等）は failure_reason='failed_image'
+    """
+    try:
+        with pdfplumber.open(io.BytesIO(content)) as pdf:
+            pages_text = [page.extract_text() or "" for page in pdf.pages]
+    except (PDFPasswordIncorrect, PDFEncryptionError) as exc:
+        logger.info(f"pdf_text_service: encrypted PDF detected: {exc}")
+        return PdfTextResult(text=None, failure_reason="failed_encrypted")
+
+    text = "\n".join(pages_text).strip()
+    if not text:
+        logger.info("pdf_text_service: no extractable text (likely image PDF)")
+        return PdfTextResult(text=None, failure_reason="failed_image")
+
+    return PdfTextResult(text=text, failure_reason=None)

--- a/backend/app/services/product_matching_service.py
+++ b/backend/app/services/product_matching_service.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any, cast
 
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.utils.logger import get_logger
 from supabase import Client
 
@@ -8,6 +9,25 @@ logger = get_logger(__name__)
 
 _THRESHOLD = float(os.environ.get("PRODUCT_MATCH_THRESHOLD", "0.3"))
 _TOP_N = int(os.environ.get("PRODUCT_MATCH_TOP_N", "5"))
+
+
+def match_product_by_code(db: Client, tenant_id: str, code: str) -> int | None:
+    """
+    品番 (products.code) の完全一致で製品を検索する。
+    一致する製品が唯一存在すればその product_id を返し、それ以外は None を返す。
+    """
+    result = (
+        db.table(SupabaseTableName.PRODUCTS.value)
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("code", code)
+        .limit(2)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    if len(rows) == 1:
+        return int(rows[0]["id"])
+    return None
 
 
 def match_products(db: Client, tenant_id: str, product_name: str) -> dict[str, Any]:

--- a/backend/app/services/product_matching_service.py
+++ b/backend/app/services/product_matching_service.py
@@ -9,6 +9,17 @@ logger = get_logger(__name__)
 
 _THRESHOLD = float(os.environ.get("PRODUCT_MATCH_THRESHOLD", "0.3"))
 _TOP_N = int(os.environ.get("PRODUCT_MATCH_TOP_N", "5"))
+# 自動確定に必要な最上位候補の類似度スコア下限。
+# 品番のような構造化文字列は1文字違いでも別製品を指すため、
+# 単に候補が1件というだけでは自動確定の根拠として弱い。
+_AUTO_CONFIRM_THRESHOLD = float(
+    os.environ.get("PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD", "0.75")
+)
+# 最上位候補と次点候補のスコア差の下限。
+# 僅差の候補が複数ある場合は自動確定せず、候補一覧として提示する。
+_AUTO_CONFIRM_MARGIN = float(
+    os.environ.get("PRODUCT_MATCH_AUTO_CONFIRM_MARGIN", "0.15")
+)
 
 
 def match_product_by_code(db: Client, tenant_id: str, code: str) -> int | None:
@@ -34,9 +45,15 @@ def match_products(db: Client, tenant_id: str, product_name: str) -> dict[str, A
     """
     pg_trgm で製品名を類似度検索する。
 
+    自動確定 (product_id を返す) するのは、最上位候補のスコアが
+    _AUTO_CONFIRM_THRESHOLD 以上、かつ次点候補とのスコア差が
+    _AUTO_CONFIRM_MARGIN 以上ある場合のみ。単に候補が1件だけという
+    条件では、品番の1文字違いの別製品（デコイ）が唯一の候補として
+    ヒットするだけで誤って自動確定してしまうため採用しない。
+
     Returns:
         {
-            "product_id": int | None,    # 単一確定時のみセット
+            "product_id": int | None,    # 自動確定時のみセット
             "candidates": list[dict],    # UI 表示用上位 N 件
         }
     """
@@ -57,7 +74,14 @@ def match_products(db: Client, tenant_id: str, product_name: str) -> dict[str, A
         for r in rows[:_TOP_N]
     ]
 
-    if len(rows) == 1:
-        return {"product_id": rows[0]["id"], "candidates": candidates}
+    product_id: int | None = None
+    if rows:
+        top_score = float(rows[0]["score"])
+        second_score = float(rows[1]["score"]) if len(rows) > 1 else 0.0
+        if (
+            top_score >= _AUTO_CONFIRM_THRESHOLD
+            and (top_score - second_score) >= _AUTO_CONFIRM_MARGIN
+        ):
+            product_id = rows[0]["id"]
 
-    return {"product_id": None, "candidates": candidates}
+    return {"product_id": product_id, "candidates": candidates}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -75,3 +75,4 @@ pydantic-settings
 google-api-python-client==2.170.0
 google-auth==2.40.3
 anthropic>=0.40.0
+pdfplumber==0.11.10

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -1,0 +1,146 @@
+# 受注PDF自動パース＋複数order生成（内示ステータス対応）
+
+[order-attachments.md](order-attachments.md) の PDF ステージング基盤（Issue #248）を前提に、
+ステージングされた PDF を実際にパースし、1ファイルに含まれる複数品番・複数納期の明細を、
+確度別ステータス（確定/内示/内々示）付きの複数 `orders` 行として自動生成する（Issue #249）。
+
+---
+
+## 背景と目的
+
+受注PDFは「7月確定 / 8月内示 / 9月内々示」のように確度の異なる複数明細を含み、毎月更新される。
+Issue #248 により PDF添付メールは `order_attachments` に `order_id=NULL` のステージング行として
+保存されるようになったが、そこから実際の注文レコードを生成する処理は未実装だった。
+本Issueでこのパース処理を実装し、1PDFから複数の実注文レコードを正しく起票できるようにする。
+
+---
+
+## 処理フロー
+
+新規cronエンドポイント `GET /api/cron/parse-order-pdfs`（既存 `gmail-poll` と同じBearer認証
+パターン、`backend/app/routers/cron/_auth.py` の `validate_cron_secret()` を共通利用）が
+`pdf_order_parsing_service.parse_pending_order_pdfs()` を呼び出す。
+
+```
+1. order_attachments WHERE parse_status='pending' AND order_id IS NULL をポーリング
+2. Storage から PDF をダウンロードし、pdfplumber でテキスト抽出 (pdf_text_service.py)
+   - パスワード保護 (PPAP等) で開けない → parse_status='failed_encrypted'、orderは生成しない
+   - テキストが1文字も取れない (画像PDF等) → parse_status='failed_image'、orderは生成しない
+3. 抽出成功時、Claude tool-use (pdf_order_extraction_service.py) で明細行の配列を取得
+   { product_name_raw, product_number_raw, quantity, delivery_date, certainty }
+4. 明細ごとに (pdf_order_parsing_service._process_line_item):
+   a. 品番 (product_number_raw) の完全一致 (match_product_by_code) → 見つからなければ
+      品名のpg_trgm類似度検索 (match_products) にフォールバック
+   b. どちらも失敗した場合: order を生成せず order_parse_log に reason='no_product_match' で記録
+   c. certainty → orders.status へ1:1マッピング (confirmed/forecast/forecast_tentative)
+   d. customer_id はステージング行のものをそのまま使用（再照合しない）
+   e. SQL RPC create_order_skip_duplicate で orders に INSERT
+      (tenant_id, customer_id, product_id, deadline_date) の重複時は ON CONFLICT DO NOTHING
+      でスキップし、order_parse_log に reason='duplicate_skipped' で記録
+   f. 生成できた場合、対応する order_attachments 行を追加INSERT
+      (order_id 設定済み、storage_path はステージング行と同一、parse_status='success')
+      → 既存の `/orders/{order_id}/attachments` エンドポイント・UIがそのまま流用できる
+5. 処理後、ステージング行自体の parse_status を更新する
+   (テキスト抽出・Claude抽出が完走すれば、生成された order 数によらず 'success' とする。
+   0件生成となるケース＝全明細が重複/照合失敗＝も、パース処理自体は正常に完了しているため。
+   個々の失敗理由は order_parse_log 側で追跡する)
+```
+
+### なぜ postgrest-py の `on_conflict` を使わないか
+
+supabase-py（postgrest-py）の `.insert(..., on_conflict=...)` は UPSERT（マージ）用であり、
+「重複時に何もしない」動作は表現できない。そのため `create_order_skip_duplicate` という
+SQL RPC 関数（`INSERT ... ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING RETURNING id`）
+を新設し、`inserted: boolean` で成否を返している。
+
+---
+
+## DB スキーマ変更
+
+`supabase/migrations/20260702000000_add_order_status_forecast.sql`:
+
+- `orders.status` の CHECK制約を DROP + 再作成し、`forecast` / `forecast_tentative` を追加
+  （text CHECK制約のため `ALTER TYPE ADD VALUE` は使えない）
+- 新規 UNIQUE 制約 `orders_dedupe_key`: `(tenant_id, customer_id, product_id, deadline_date)`
+  - 既知の制約: `product_id` または `customer_id` が `NULL` の行は NULL の非等価性により
+    デデュープキーとして機能しない。パース処理側は `product_id` が確定した場合のみ
+    このUNIQUE制約に依拠したINSERTを行うことで運用上回避している
+- 新規テーブル `order_parse_log`: `id, tenant_id, order_attachment_id (FK), reason, detail (jsonb), created_at`
+  - `reason`: `duplicate_skipped` / `no_product_match`
+- 新規 RPC 関数 `create_order_skip_duplicate`
+
+### `orders.status` の全定義
+
+| 値                    | 意味                     |
+|------------------------|--------------------------|
+| `draft`                | 下書き                   |
+| `confirmed`            | 確定/スケジュール済      |
+| `completed`            | 完了                     |
+| `canceled`             | キャンセル               |
+| `forecast`             | 内示（Issue #249 で追加）|
+| `forecast_tentative`   | 内々示（Issue #249 で追加）|
+
+---
+
+## 新規ファイル
+
+### Backend
+
+- `supabase/migrations/20260702000000_add_order_status_forecast.sql`
+- `backend/app/services/pdf_text_service.py`
+  - `extract_text(content: bytes) -> PdfTextResult`
+- `backend/app/services/pdf_order_extraction_service.py`
+  - `extract_order_lines(pdf_text: str) -> list[dict]`（Claude tool-use、`PDF_EXTRACTION_MODEL`）
+- `backend/app/services/pdf_order_parsing_service.py`
+  - `parse_pending_order_pdfs(db) -> dict[str, int]`
+- `backend/app/routers/cron/_auth.py`
+  - `validate_cron_secret(request)`（`gmail_poll.py` と共通化）
+- `backend/app/routers/cron/parse_order_pdfs.py`
+  - `GET /api/cron/parse-order-pdfs`
+
+### 既存ファイルへの追加
+
+- `backend/app/services/product_matching_service.py`: `match_product_by_code()` を追加
+- `backend/app/services/attachment_service.py`: `download_attachment()` を追加
+- `backend/app/repositories/supa_infra/common/table_name.py`: `ORDER_PARSE_LOG` を追加
+- `backend/requirements.txt`: `pdfplumber==0.11.10`
+
+---
+
+## 環境変数
+
+```
+# Claude API
+PDF_EXTRACTION_MODEL=claude-sonnet-5  # デフォルト。EMAIL_EXTRACTION_MODEL とは別軸で管理
+```
+
+---
+
+## 受け入れ条件
+
+- [x] サンプルPDFから複数orderが正しく生成される（単体テストでモック検証。実PDFでの精度検証は運用後に実施）
+- [x] `certainty` に応じて `orders.status` が `confirmed`/`forecast`/`forecast_tentative` に正しくセットされる
+- [x] 品番・品名の照合失敗時はorderを生成せず、`order_parse_log` に記録される
+- [x] 暗号化PDF・画像PDF（テキスト抽出不可）でもクラッシュせず `parse_status` が適切に更新される
+- [x] 重複明細（UNIQUE制約抵触）はスキップされ `order_parse_log` に記録される
+- [x] 生成された各orderから、対応する添付PDFが注文詳細画面からダウンロードできる
+      （既存の `/orders/{order_id}/attachments` エンドポイントを変更なしで再利用）
+- [x] マイグレーション（CHECK制約変更、UNIQUE制約、`order_parse_log`）が適用済み
+
+---
+
+## スコープ外
+
+- 既存orderへのupsert・更新処理（将来Issue）
+- PPAP（パスワード付きPDF）の自動復号
+- 複数添付ファイルへの対応（1メール1添付の前提を維持）
+- 重複スキップ・照合失敗の通知UI（将来Issue、`order_parse_log` を参照する前提）
+- ステージング行が長時間 `pending` のまま停滞した場合のリトライ・タイムアウト処理
+- `forecast`/`forecast_tentative` のUIフィルタータブ追加（別途検討）
+
+---
+
+## 関連
+
+- [order-attachments.md](order-attachments.md): PDFステージング保存基盤（Issue #248、前提）
+- 後続: 既存order upsert処理、処理ログ通知基盤（`order_parse_log` を利用）

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -31,6 +31,12 @@ Issue #248 により PDF添付メールは `order_attachments` に `order_id=NUL
 4. 明細ごとに (pdf_order_parsing_service._process_line_item):
    a. 品番 (product_number_raw) の完全一致 (match_product_by_code) → 見つからなければ
       品名のpg_trgm類似度検索 (match_products) にフォールバック
+      - `match_products` の自動確定条件は「候補が1件だけ」ではなく、
+        「最上位候補のスコアが `PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD` 以上、かつ
+        次点候補とのスコア差が `PRODUCT_MATCH_AUTO_CONFIRM_MARGIN` 以上」。
+        品番は1文字違いで別製品を指すことがあり（例: `25760-63C-...` と
+        実在する `22760-63C-...` は pg_trgm 上高い類似度になる）、
+        「候補1件のみ」は自動確定の根拠として弱いため
    b. どちらも失敗した場合: order を生成せず order_parse_log に reason='no_product_match' で記録
    c. certainty → orders.status へ1:1マッピング (confirmed/forecast/forecast_tentative)
    d. customer_id はステージング行のものをそのまま使用（再照合しない）
@@ -112,6 +118,10 @@ SQL RPC 関数（`INSERT ... ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTH
 ```
 # Claude API
 PDF_EXTRACTION_MODEL=claude-sonnet-5  # デフォルト。EMAIL_EXTRACTION_MODEL とは別軸で管理
+
+# 製品マッチング (pg_trgm) の自動確定しきい値
+PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD=0.75  # 最上位候補スコアの下限
+PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の下限
 ```
 
 ---

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -29,15 +29,18 @@ Issue #248 により PDF添付メールは `order_attachments` に `order_id=NUL
 3. 抽出成功時、Claude tool-use (pdf_order_extraction_service.py) で明細行の配列を取得
    { product_name_raw, product_number_raw, quantity, delivery_date, certainty }
 4. 明細ごとに (pdf_order_parsing_service._process_line_item):
-   a. 品番 (product_number_raw) の完全一致 (match_product_by_code) → 見つからなければ
-      品名のpg_trgm類似度検索 (match_products) にフォールバック
+   a. 製品照合は3段階のフォールバックで行う:
+      1. `products.code` の完全一致 (match_product_by_code)
+      2. `products.name` に対する品番文字列 (product_number_raw) でのpg_trgm検索
+         （`code` 列が未整備で、`name` 列に品番文字列が入っているテナントに対応）
+      3. `products.name` に対する品名文字列 (product_name_raw) でのpg_trgm検索
       - `match_products` の自動確定条件は「候補が1件だけ」ではなく、
         「最上位候補のスコアが `PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD` 以上、かつ
         次点候補とのスコア差が `PRODUCT_MATCH_AUTO_CONFIRM_MARGIN` 以上」。
         品番は1文字違いで別製品を指すことがあり（例: `25760-63C-...` と
         実在する `22760-63C-...` は pg_trgm 上高い類似度になる）、
         「候補1件のみ」は自動確定の根拠として弱いため
-   b. どちらも失敗した場合: order を生成せず order_parse_log に reason='no_product_match' で記録
+   b. すべて失敗した場合: order を生成せず order_parse_log に reason='no_product_match' で記録
    c. certainty → orders.status へ1:1マッピング (confirmed/forecast/forecast_tentative)
    d. customer_id はステージング行のものをそのまま使用（再照合しない）
    e. SQL RPC create_order_skip_duplicate で orders に INSERT
@@ -128,7 +131,9 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 
 ## 受け入れ条件
 
-- [x] サンプルPDFから複数orderが正しく生成される（単体テストでモック検証。実PDFでの精度検証は運用後に実施）
+- [x] サンプルPDFから複数orderが正しく生成される（単体テストでモック検証に加え、
+      `backend/__tests__/e2e/test_pdf_order_parsing_flow.py` で実PDF・実Claude API・
+      実Supabaseを用いたe2e検証を実施）
 - [x] `certainty` に応じて `orders.status` が `confirmed`/`forecast`/`forecast_tentative` に正しくセットされる
 - [x] 品番・品名の照合失敗時はorderを生成せず、`order_parse_log` に記録される
 - [x] 暗号化PDF・画像PDF（テキスト抽出不可）でもクラッシュせず `parse_status` が適切に更新される
@@ -147,6 +152,40 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 - 重複スキップ・照合失敗の通知UI（将来Issue、`order_parse_log` を参照する前提）
 - ステージング行が長時間 `pending` のまま停滞した場合のリトライ・タイムアウト処理
 - `forecast`/`forecast_tentative` のUIフィルタータブ追加（別途検討）
+
+---
+
+## E2Eテスト
+
+`backend/__tests__/e2e/test_pdf_order_parsing_flow.py`（実行: `pytest __tests__/e2e/ -v --run-e2e`）。
+
+order-attachments バケットに事前アップロード済みの実PDF（飯野製作所フォーマット、複数品番・
+複数納期・確度混在の注文一覧表）を対象に、`pdf_order_parsing_staging_row` フィクスチャ
+（`conftest.py`）でステージング行をDBに直接INSERTしてから `parse_pending_order_pdfs()` を
+実行し、実際の Supabase Storage・Claude API を使って以下を検証する:
+
+- 配線・データフロー: ステージング行 → テキスト抽出 → Claude抽出 → 製品照合 → order生成 →
+  order_attachments紐付け、という一連の処理が完走し `parse_status` が `success` になること
+- 抽出精度: 実在する製品については正しい数量・妥当な納期でorderが生成され、実在しない製品
+  （1文字違いの類似製品が製品マスタに存在するケース）は誤って別製品にマッチせず
+  `no_product_match` としてスキップされること
+
+テスト対象のPDF実体はfixtureとして使い回すため削除しない。生成された `orders` /
+ステージング行 / `order_parse_log` はテストごとに `run_id` で識別してteardownで削除する。
+
+### このテストで発見・修正した実装上の問題
+
+1. **`match_products` の自動確定条件**: 「pg_trgm候補が1件だけなら自動確定」というロジックは、
+   品番の1文字違いの別製品（デコイ）が唯一の候補としてヒットした場合に誤って自動確定して
+   しまう。「最上位候補のスコアが一定以上、かつ次点候補との差が一定以上」の条件に変更した
+   （`PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD` / `PRODUCT_MATCH_AUTO_CONFIRM_MARGIN`）。
+2. **品番でのproducts.name検索フォールバックの欠落**: `products.code` が未整備で、`name` 列に
+   品番文字列がそのまま登録されているテナントでは、旧ロジック（`product_name_raw` のみで
+   フォールバック検索）では品番と品名が別々に抽出されるPDFの明細をほぼマッチできなかった。
+   `product_number_raw` でも `products.name` をpg_trgm検索するフォールバックを追加した。
+3. **`customer_matching_service.resolve_or_create_customer` の既存バグ**: 存在しない
+   `customers.status` カラムへのINSERTを試みており、新規送信者からのメール受信時（本番の
+   メール起票フロー含む）に顧客自動作成が失敗していた。存在しないカラムへの参照を削除した。
 
 ---
 

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -68,6 +68,8 @@ export function getStatusLabel(status: Order["status"]): string {
     confirmed: "確定",
     completed: "完了",
     canceled: "キャンセル",
+    forecast: "内示",
+    forecast_tentative: "内々示",
   }
   return statusLabels[status] || status
 }
@@ -77,10 +79,12 @@ export function getStatusLabel(status: Order["status"]): string {
  */
 export function getStatusBadgeClass(status: Order["status"]): string {
   const classes: Record<Order["status"], string> = {
-    draft:     "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
-    confirmed: "bg-green-100 text-green-800 hover:bg-green-100",
-    completed: "bg-blue-100 text-blue-800 hover:bg-blue-100",
-    canceled:  "bg-gray-100 text-gray-500 hover:bg-gray-100",
+    draft:               "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
+    confirmed:           "bg-green-100 text-green-800 hover:bg-green-100",
+    completed:           "bg-blue-100 text-blue-800 hover:bg-blue-100",
+    canceled:            "bg-gray-100 text-gray-500 hover:bg-gray-100",
+    forecast:            "bg-orange-100 text-orange-800 hover:bg-orange-100",
+    forecast_tentative:  "bg-purple-100 text-purple-800 hover:bg-purple-100",
   }
   return classes[status] ?? ""
 }

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -9,7 +9,7 @@ export interface Order {
   quantity: number
   desired_deadline?: string // ISO 8601形式
   confirmed_deadline?: string // ISO 8601形式
-  status: 'draft' | 'confirmed' | 'completed' | 'canceled'
+  status: 'draft' | 'confirmed' | 'completed' | 'canceled' | 'forecast' | 'forecast_tentative'
   is_scheduled: boolean
   has_unconfirmed_routings?: boolean
   source_type: 'manual' | 'email'

--- a/supabase/migrations/20260702000000_add_order_status_forecast.sql
+++ b/supabase/migrations/20260702000000_add_order_status_forecast.sql
@@ -1,0 +1,86 @@
+-- 受注PDF自動パース＋複数order生成 (Issue #249)
+-- orders.status に forecast / forecast_tentative を追加し、
+-- PDFパースで生成した order の重複排除用 UNIQUE 制約、
+-- 重複スキップ・照合失敗を記録する order_parse_log テーブルを追加する。
+
+-- ==========================================
+-- orders.status: forecast / forecast_tentative を追加
+-- ==========================================
+-- text CHECK制約のため ALTER TYPE ADD VALUE は使えず、DROP + 再作成する。
+ALTER TABLE orders DROP CONSTRAINT orders_status_check;
+ALTER TABLE orders ADD CONSTRAINT orders_status_check
+  CHECK (status IN ('draft', 'confirmed', 'completed', 'canceled', 'forecast', 'forecast_tentative'));
+
+COMMENT ON COLUMN orders.status IS
+  '注文ステータス: draft(下書き), confirmed(確定/スケジュール済), completed(完了), canceled(キャンセル), '
+  'forecast(内示), forecast_tentative(内々示)';
+
+-- ==========================================
+-- orders: PDFパース由来の重複排除用 UNIQUE 制約
+-- ==========================================
+-- 既存行と (tenant_id, customer_id, product_id, deadline_date) が一致する場合は重複とみなす。
+-- 既知の制約: product_id または customer_id が NULL の行は NULL の非等価性により
+-- デデュープキーとして機能しない（PDFパース処理側では product_id が確定した場合のみ
+-- このUNIQUE制約に依拠したINSERTを行うことで運用上回避する）。
+ALTER TABLE orders ADD CONSTRAINT orders_dedupe_key
+  UNIQUE (tenant_id, customer_id, product_id, deadline_date);
+
+-- ==========================================
+-- order_parse_log: 重複スキップ・照合失敗ログ
+-- ==========================================
+CREATE TABLE order_parse_log (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id           uuid NOT NULL REFERENCES tenants(id),
+  order_attachment_id uuid REFERENCES order_attachments(id) ON DELETE CASCADE,
+  reason              text NOT NULL,
+  detail              jsonb,
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE order_parse_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant isolation" ON order_parse_log
+  FOR ALL
+  USING ((auth.jwt() ->> 'tenant_id')::uuid = tenant_id);
+
+-- ==========================================
+-- create_order_skip_duplicate: 重複時 INSERT をスキップする RPC
+-- ==========================================
+-- supabase-py (postgrest-py) の insert(..., on_conflict=...) は UPSERT 用であり
+-- 「重複時スキップ」を表現できないため、SQL側で ON CONFLICT DO NOTHING を実装する。
+CREATE OR REPLACE FUNCTION create_order_skip_duplicate(
+  p_tenant_id             uuid,
+  p_customer_id           bigint,
+  p_product_id            bigint,
+  p_quantity              int,
+  p_deadline_date         date,
+  p_status                text,
+  p_source_type           text,
+  p_source_raw            text,
+  p_extracted_product_name text
+)
+RETURNS TABLE (id bigint, inserted boolean)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_id bigint;
+BEGIN
+  INSERT INTO orders (
+    tenant_id, customer_id, product_id, quantity, deadline_date,
+    status, source_type, source_raw, extracted_product_name
+  )
+  VALUES (
+    p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
+    p_status, p_source_type, p_source_raw, p_extracted_product_name
+  )
+  ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
+  RETURNING orders.id INTO v_id;
+
+  IF v_id IS NULL THEN
+    RETURN QUERY SELECT NULL::bigint, false;
+  ELSE
+    RETURN QUERY SELECT v_id, true;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- #248 のPDFステージング基盤（`order_attachments` の `order_id=NULL` 行）を前提に、PDFをパースして複数の `orders` 行を自動生成する新規cronエンドポイント `GET /api/cron/parse-order-pdfs` を追加
- `pdfplumber` でテキスト抽出 → 暗号化/画像PDFは `parse_status` を更新するのみ（orderは生成しない）
- Claude tool-use（`PDF_EXTRACTION_MODEL`、デフォルト `claude-sonnet-5`）で複数明細（品番/品名/数量/納期/確度）を抽出
- 明細ごとに製品照合（`products.code`完全一致 → 品番文字列でのpg_trgm検索 → 品名文字列でのpg_trgm検索の3段階フォールバック）し、`certainty` を `orders.status`（`confirmed`/`forecast`/`forecast_tentative`）へマッピング
- 重複明細は新規SQL RPC `create_order_skip_duplicate`（`ON CONFLICT DO NOTHING`、postgrest-pyの`on_conflict`はUPSERT用でスキップ表現不可のため）でスキップし、品番照合失敗と合わせて `order_parse_log` に記録
- 生成した各orderに対応する `order_attachments` 行（`order_id`設定済み、`storage_path`はステージング行と同一）を追加し、既存の `/orders/{order_id}/attachments` はそのまま流用
- フロントエンドの `Order.status` 型・ステータスバッジに `forecast`/`forecast_tentative` を追加（フィルタータブ追加は別途検討としてスコープ外のまま）

### 実PDF・実Claude APIによるe2eテストで発見・修正したバグ
Supabase Storageに事前アップロード済みの実PDF（飯野製作所フォーマット、複数品番・複数納期・確度混在）を対象にe2eテスト（`backend/__tests__/e2e/test_pdf_order_parsing_flow.py`）を作成する過程で、以下の実装上の問題を発見し合わせて修正した:
1. **`match_products` の自動確定条件**: 「pg_trgm候補が1件だけなら自動確定」は、品番の1文字違いの別製品（デコイ）が唯一の候補としてヒットすると誤って自動確定してしまう。「最上位候補のスコアが一定以上、かつ次点候補との差が一定以上」の条件に変更（`PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD` / `PRODUCT_MATCH_AUTO_CONFIRM_MARGIN`）
2. **品番でのproducts.name検索フォールバックの欠落**: `products.code` が未整備で `name` 列に品番文字列が直接登録されているテナントでは、旧ロジックだと品番・品名が別々に抽出されるPDFの明細をほぼマッチできなかった。`product_number_raw` でも `products.name` をpg_trgm検索するフォールバックを追加
3. **`customer_matching_service.resolve_or_create_customer` の既存バグ**: 存在しない `customers.status` カラムへのINSERTを試みており、新規送信者からのメール受信時（本番のメール起票フロー含む）に顧客自動作成が失敗していた。存在しないカラムへの参照を削除

Closes #249

## Test plan
- [x] `pytest __tests__/unit/services/test_pdf_text_service.py` — テキストPDF/空白PDF/暗号化PDF/不正PDFの抽出結果を検証
- [x] `pytest __tests__/unit/services/test_product_matching_service.py` — 品番完全一致・pg_trgm自動確定しきい値のロジックを検証（高信頼度単独候補/低信頼度デコイ単独候補/僅差2候補/候補なしの各ケース）
- [x] `pytest __tests__/unit/services/test_pdf_order_parsing_service.py` — 暗号化PDF検出、例外時のエラーカウント、品番→品番文字列名検索フォールバック、品番照合失敗、重複スキップ、order+order_attachments生成の一連のロジック
- [x] `pytest __tests__/api/routers/cron/test_parse_order_pdfs.py` — Bearer認証・正常系・エラー系
- [x] `pytest __tests__/e2e/test_pdf_order_parsing_flow.py --run-e2e` — 実Supabase Storage・実Claude APIを用いて、事前アップロード済みの実PDFから正しく複数orderが生成され、存在しない製品は誤マッチせず`no_product_match`としてスキップされることを確認（2回実行して冪等性・クリーンアップも確認済み）
- [x] 既存の `pytest __tests__/unit/ __tests__/api/` で回帰確認（既存の無関係な失敗テストのみ、新規failureなし）
- [x] `ruff check .` / `mypy .`
- [x] `supabase migration up` をローカルSupabaseに適用し、マイグレーションが問題なく通ることを確認
- [x] フロントエンド `npx tsc --noEmit` で型エラーなしを確認
- [x] `docs/features/pdf-order-parsing.md` を新規追加・更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)