### PR TITLE
feat(#254): メール/PDF自動処理の通知UI（重複・照合失敗・対象外メール検知）

### DIFF
--- a/backend/__tests__/integration/conftest.py
+++ b/backend/__tests__/integration/conftest.py
@@ -47,6 +47,14 @@ def auth_token(auth_session):
 
 
 @pytest.fixture(scope="session")
+def tenant_id():
+    """ログインユーザーの所属テナントID（.env の TEST_TENANT_ID）。"""
+    if not TEST_TENANT_ID:
+        pytest.skip("TEST_TENANT_ID not set")
+    return TEST_TENANT_ID
+
+
+@pytest.fixture(scope="session")
 def auth_user_id(auth_session):
     """ログインユーザーの auth.users.id。テスト用テナントへのメンバー登録に使う。"""
     return auth_session.user.id

--- a/backend/__tests__/integration/conftest.py
+++ b/backend/__tests__/integration/conftest.py
@@ -18,8 +18,10 @@ TEST_TENANT_ID = os.environ.get("TEST_TENANT_ID", "")
 
 @pytest.fixture(scope="session")
 def real_supabase_client():
-    url = os.environ["SUPABASE_URL"]
-    key = os.environ["SUPABASE_ANON_KEY"]
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_ANON_KEY")
+    if not url or not key:
+        pytest.skip("SUPABASE_URL / SUPABASE_ANON_KEY not set")
     return create_client(url, key)
 
 
@@ -31,6 +33,8 @@ def auth_session(real_supabase_client):
     ため、以降 real_supabase_client.table(...) 経由のクエリはこのユーザーの
     JWTでRLSを通る（notifications への直接INSERT/UPDATE拒否の検証等で利用）。
     """
+    if not TEST_USER_EMAIL or not TEST_USER_PASS:
+        pytest.skip("TEST_USER_EMAIL / TEST_USER_PASS not set")
     return real_supabase_client.auth.sign_in_with_password(
         {"email": TEST_USER_EMAIL, "password": TEST_USER_PASS}
     )

--- a/backend/__tests__/integration/conftest.py
+++ b/backend/__tests__/integration/conftest.py
@@ -8,25 +8,44 @@ from supabase import Client, create_client
 load_dotenv()
 
 # テスト用のユーザー情報 (事前にDBに入れておくか、Setupで作成する)
-TEST_USER_EMAIL = "user_a@example.com"
-TEST_USER_PASS = "password123"
-TEST_TENANT_ID = "uuid-of-tenant-a"
+# .env の TEST_USER_EMAIL / TEST_USER_PASS / TEST_TENANT_ID (backend/scripts/ の
+# シードスクリプト群と共通) と一致させる。ここをハードコードすると .env と値が
+# 乖離してログインに失敗する（実際に発生し、本コメントを追加する契機になった）。
+TEST_USER_EMAIL = os.environ.get("TEST_USER_EMAIL", "")
+TEST_USER_PASS = os.environ.get("TEST_USER_PASS", "")
+TEST_TENANT_ID = os.environ.get("TEST_TENANT_ID", "")
 
 
 @pytest.fixture(scope="session")
 def real_supabase_client():
     url = os.environ["SUPABASE_URL"]
-    key = os.environ["SUPABASE_KEY"]
+    key = os.environ["SUPABASE_ANON_KEY"]
     return create_client(url, key)
 
 
 @pytest.fixture(scope="session")
-def auth_token(real_supabase_client):
-    """本物のSupabaseでログインし、JWTトークンを返す"""
-    res = real_supabase_client.auth.sign_in_with_password(
+def auth_session(real_supabase_client):
+    """本物のSupabaseでログインし、セッション（JWT + ユーザー情報）を返す。
+
+    ログイン後、real_supabase_client 自体もこのユーザーのセッションを保持する
+    ため、以降 real_supabase_client.table(...) 経由のクエリはこのユーザーの
+    JWTでRLSを通る（notifications への直接INSERT/UPDATE拒否の検証等で利用）。
+    """
+    return real_supabase_client.auth.sign_in_with_password(
         {"email": TEST_USER_EMAIL, "password": TEST_USER_PASS}
     )
-    return res.session.access_token
+
+
+@pytest.fixture(scope="session")
+def auth_token(auth_session):
+    """本物のSupabaseでログインし、JWTトークンを返す"""
+    return auth_session.session.access_token
+
+
+@pytest.fixture(scope="session")
+def auth_user_id(auth_session):
+    """ログインユーザーの auth.users.id。テスト用テナントへのメンバー登録に使う。"""
+    return auth_session.user.id
 
 
 @pytest.fixture(scope="session")

--- a/backend/__tests__/integration/test_notifications_rls.py
+++ b/backend/__tests__/integration/test_notifications_rls.py
@@ -158,6 +158,43 @@ class TestNotificationsRls:
         source_ids = [n["source_id"] for n in res.json()]
         assert "msg-other-hidden" not in source_ids
 
+    def test_notification_of_other_membership_is_not_mixed_in(
+        self, auth_token, admin_db, auth_user_id, notif_tenants
+    ):
+        """
+        ユーザーが own/other 両テナントに所属する場合の回帰テスト。
+        is_tenant_member(tenant_id) は所属する全テナントの行を許可するため、
+        x-tenant-id で明示的に絞り込まないと other テナントの通知が
+        own テナント選択時の一覧に混ざってしまう。
+        """
+        admin_db.table("organization_members").insert(
+            {"user_id": auth_user_id, "tenant_id": notif_tenants["other_id"]}
+        ).execute()
+        try:
+            admin_db.table("notifications").insert(
+                {
+                    "tenant_id": notif_tenants["other_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "msg-other-membership-hidden",
+                }
+            ).execute()
+
+            res = client.get(
+                "/notifications",
+                headers={
+                    "Authorization": f"Bearer {auth_token}",
+                    "x-tenant-id": notif_tenants["own_id"],
+                },
+            )
+            assert res.status_code == 200
+            source_ids = [n["source_id"] for n in res.json()]
+            assert "msg-other-membership-hidden" not in source_ids
+        finally:
+            admin_db.table("organization_members").delete().eq(
+                "user_id", auth_user_id
+            ).eq("tenant_id", notif_tenants["other_id"]).execute()
+
     def test_direct_insert_via_user_jwt_is_rejected(
         self, real_supabase_client, notif_tenants
     ):

--- a/backend/__tests__/integration/test_notifications_rls.py
+++ b/backend/__tests__/integration/test_notifications_rls.py
@@ -1,0 +1,386 @@
+"""
+Integration テスト: notifications の RLS / IDOR 修正 (Issue #256, 元Issue #254)
+
+以下は実際の Postgres (RLS込み) でしか検証できないため integration tier に置く。
+- notifications テーブルの RLS ポリシー (SELECTのみ許可、書き込みはデフォルト拒否)
+- GET /notifications の `_resolve_link_url` における他テナント参照のIDOR修正
+  (commit 868a45f, admin_client クエリへの tenant_id 条件漏れ)
+- PATCH /notifications/read の admin_client 経由更新が自テナント行のみを対象にすること
+
+実行:
+  supabase start
+  cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-integration
+"""
+
+from typing import Any, cast
+
+import pytest
+from app.main import app
+from app.routers.transaction.notifications import _resolve_link_url
+from fastapi.testclient import TestClient
+from postgrest.exceptions import APIError
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def notif_tenants(admin_db, auth_user_id):
+    """
+    ログインユーザーが所属する own テナントと、所属しない other テナントを作成する。
+    IDOR検証用に、各テナントに order/order_attachments/order_parse_log も用意する。
+    """
+    own = (
+        admin_db.table("tenants")
+        .insert({"name": "integration test notif tenant (own)"})
+        .execute()
+    )
+    own_id = cast(list[dict[str, Any]], own.data)[0]["id"]
+
+    other = (
+        admin_db.table("tenants")
+        .insert({"name": "integration test notif tenant (other)"})
+        .execute()
+    )
+    other_id = cast(list[dict[str, Any]], other.data)[0]["id"]
+
+    admin_db.table("organization_members").insert(
+        {"user_id": auth_user_id, "tenant_id": own_id}
+    ).execute()
+
+    def _make_attachment(tenant_id: str) -> str:
+        order = (
+            admin_db.table("orders")
+            .insert({"tenant_id": tenant_id, "quantity": 1})
+            .execute()
+        )
+        order_id = cast(list[dict[str, Any]], order.data)[0]["id"]
+        storage_path = f"{tenant_id}/orders/{order_id}/test.pdf"
+        attachment = (
+            admin_db.table("order_attachments")
+            .insert(
+                {
+                    "order_id": order_id,
+                    "tenant_id": tenant_id,
+                    "storage_path": storage_path,
+                    "original_filename": "test.pdf",
+                }
+            )
+            .execute()
+        )
+        return cast(list[dict[str, Any]], attachment.data)[0]["id"]
+
+    own_attachment_id = _make_attachment(own_id)
+    other_attachment_id = _make_attachment(other_id)
+
+    other_log = (
+        admin_db.table("order_parse_log")
+        .insert(
+            {
+                "tenant_id": other_id,
+                "order_attachment_id": other_attachment_id,
+                "reason": "no_product_match",
+                "detail": {},
+            }
+        )
+        .execute()
+    )
+    other_log_id = cast(list[dict[str, Any]], other_log.data)[0]["id"]
+
+    yield {
+        "own_id": own_id,
+        "other_id": other_id,
+        "own_attachment_id": own_attachment_id,
+        "other_attachment_id": other_attachment_id,
+        "other_log_id": other_log_id,
+    }
+
+    admin_db.table("notifications").delete().eq("tenant_id", own_id).execute()
+    admin_db.table("notifications").delete().eq("tenant_id", other_id).execute()
+    admin_db.table("order_parse_log").delete().eq("tenant_id", own_id).execute()
+    admin_db.table("order_parse_log").delete().eq("tenant_id", other_id).execute()
+    admin_db.table("order_attachments").delete().eq("tenant_id", own_id).execute()
+    admin_db.table("order_attachments").delete().eq("tenant_id", other_id).execute()
+    admin_db.table("orders").delete().eq("tenant_id", own_id).execute()
+    admin_db.table("orders").delete().eq("tenant_id", other_id).execute()
+    admin_db.table("organization_members").delete().eq("user_id", auth_user_id).eq(
+        "tenant_id", own_id
+    ).execute()
+    admin_db.table("tenants").delete().eq("id", own_id).execute()
+    admin_db.table("tenants").delete().eq("id", other_id).execute()
+
+
+@pytest.mark.integration
+class TestNotificationsRls:
+    def test_own_tenant_notification_is_visible(
+        self, auth_token, admin_db, notif_tenants
+    ):
+        admin_db.table("notifications").insert(
+            {
+                "tenant_id": notif_tenants["own_id"],
+                "notif_type": "non_order_email",
+                "source_table": "gmail_message",
+                "source_id": "msg-own-visible",
+            }
+        ).execute()
+
+        res = client.get(
+            "/notifications",
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "x-tenant-id": notif_tenants["own_id"],
+            },
+        )
+        assert res.status_code == 200
+        source_ids = [n["source_id"] for n in res.json()]
+        assert "msg-own-visible" in source_ids
+
+    def test_other_tenant_notification_is_not_visible(
+        self, auth_token, admin_db, notif_tenants
+    ):
+        """所属していないテナントの通知はRLS (SELECT: is_tenant_member)により見えない"""
+        admin_db.table("notifications").insert(
+            {
+                "tenant_id": notif_tenants["other_id"],
+                "notif_type": "non_order_email",
+                "source_table": "gmail_message",
+                "source_id": "msg-other-hidden",
+            }
+        ).execute()
+
+        res = client.get(
+            "/notifications",
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "x-tenant-id": notif_tenants["own_id"],
+            },
+        )
+        assert res.status_code == 200
+        source_ids = [n["source_id"] for n in res.json()]
+        assert "msg-other-hidden" not in source_ids
+
+    def test_direct_insert_via_user_jwt_is_rejected(
+        self, real_supabase_client, notif_tenants
+    ):
+        """
+        notifications はSELECTポリシーのみでINSERT/UPDATE/DELETEにポリシーが
+        無い（デフォルト拒否）。以前の FOR ALL ポリシーからの回帰確認。
+        """
+        with pytest.raises(APIError):
+            real_supabase_client.table("notifications").insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "spy-insert-attempt",
+                }
+            ).execute()
+
+    def test_direct_update_via_user_jwt_is_rejected(
+        self, real_supabase_client, admin_db, notif_tenants
+    ):
+        created = (
+            admin_db.table("notifications")
+            .insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "spy-update-attempt",
+                }
+            )
+            .execute()
+        )
+        notif_id = cast(list[dict[str, Any]], created.data)[0]["id"]
+
+        result = (
+            real_supabase_client.table("notifications")
+            .update({"read_at": "2026-01-01T00:00:00Z"})
+            .eq("id", notif_id)
+            .execute()
+        )
+        assert result.data == []
+
+        row = (
+            admin_db.table("notifications")
+            .select("read_at")
+            .eq("id", notif_id)
+            .single()
+            .execute()
+            .data
+        )
+        assert row["read_at"] is None
+
+
+@pytest.mark.integration
+class TestResolveLinkUrlIdorFix:
+    """
+    GET /notifications の `_resolve_link_url` (commit 868a45f) の回帰テスト。
+    admin_client(Service Role Key, RLSバイパス) を使うため、notifications 行
+    自身の tenant_id を必ず条件に含めないと、source_id 経由で他テナントの
+    order_parse_log / order_attachments を参照できてしまう。
+    """
+
+    def test_order_attachments_source_in_other_tenant_resolves_to_none(
+        self, admin_db, notif_tenants
+    ):
+        link_url = _resolve_link_url(
+            admin_db,
+            notif_tenants["own_id"],
+            "no_product_match",
+            "order_attachments",
+            notif_tenants["other_attachment_id"],
+        )
+        assert link_url is None
+
+    def test_order_parse_log_source_in_other_tenant_resolves_to_none(
+        self, admin_db, notif_tenants
+    ):
+        link_url = _resolve_link_url(
+            admin_db,
+            notif_tenants["own_id"],
+            "no_product_match",
+            "order_parse_log",
+            notif_tenants["other_log_id"],
+        )
+        assert link_url is None
+
+    def test_order_attachments_source_in_own_tenant_resolves(
+        self, admin_db, notif_tenants, monkeypatch
+    ):
+        """
+        自テナントの場合は正しく storage_path が見つかり、署名付きURL生成まで
+        到達すること。実際の署名付きURL生成（Storage側の可用性）はこのIDOR修正
+        とは無関係なので create_signed_url はスタブ化し、DBクエリ側の挙動
+        （tenant_id条件つきの照合が正しくヒットすること）だけを検証する。
+        """
+        monkeypatch.setattr(
+            "app.routers.transaction.notifications.create_signed_url",
+            lambda _client,
+            storage_path,
+            **_kwargs: f"https://signed.example/{storage_path}",
+        )
+        link_url = _resolve_link_url(
+            admin_db,
+            notif_tenants["own_id"],
+            "no_product_match",
+            "order_attachments",
+            notif_tenants["own_attachment_id"],
+        )
+        assert link_url is not None
+        assert link_url.startswith("https://signed.example/")
+
+    def test_non_order_email_builds_gmail_link_without_query(self, admin_db):
+        """non_order_email はDBを引かずsource_idからGmailリンクを直接組み立てる"""
+        link_url = _resolve_link_url(
+            admin_db,
+            "irrelevant-tenant-id",
+            "non_order_email",
+            "gmail_message",
+            "msg-123",
+        )
+        assert link_url == "https://mail.google.com/mail/u/0/#all/msg-123"
+
+
+@pytest.mark.integration
+class TestMarkNotificationsReadScope:
+    def test_marks_only_own_tenant_unread_notifications(
+        self, auth_token, admin_db, notif_tenants
+    ):
+        own_notif = (
+            admin_db.table("notifications")
+            .insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "msg-own-unread",
+                }
+            )
+            .execute()
+        )
+        own_notif_id = cast(list[dict[str, Any]], own_notif.data)[0]["id"]
+
+        other_notif = (
+            admin_db.table("notifications")
+            .insert(
+                {
+                    "tenant_id": notif_tenants["other_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "msg-other-unread",
+                }
+            )
+            .execute()
+        )
+        other_notif_id = cast(list[dict[str, Any]], other_notif.data)[0]["id"]
+
+        res = client.patch(
+            "/notifications/read",
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "x-tenant-id": notif_tenants["own_id"],
+            },
+        )
+        assert res.status_code == 200
+
+        own_row = (
+            admin_db.table("notifications")
+            .select("read_at")
+            .eq("id", own_notif_id)
+            .single()
+            .execute()
+            .data
+        )
+        other_row = (
+            admin_db.table("notifications")
+            .select("read_at")
+            .eq("id", other_notif_id)
+            .single()
+            .execute()
+            .data
+        )
+        assert own_row["read_at"] is not None
+        assert other_row["read_at"] is None
+
+    def test_second_call_does_not_change_already_read_notification(
+        self, auth_token, admin_db, notif_tenants
+    ):
+        notif = (
+            admin_db.table("notifications")
+            .insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "non_order_email",
+                    "source_table": "gmail_message",
+                    "source_id": "msg-own-idempotent",
+                }
+            )
+            .execute()
+        )
+        notif_id = cast(list[dict[str, Any]], notif.data)[0]["id"]
+        headers = {
+            "Authorization": f"Bearer {auth_token}",
+            "x-tenant-id": notif_tenants["own_id"],
+        }
+
+        client.patch("/notifications/read", headers=headers)
+        first_read_at = (
+            admin_db.table("notifications")
+            .select("read_at")
+            .eq("id", notif_id)
+            .single()
+            .execute()
+            .data["read_at"]
+        )
+        assert first_read_at is not None
+
+        client.patch("/notifications/read", headers=headers)
+        second_read_at = (
+            admin_db.table("notifications")
+            .select("read_at")
+            .eq("id", notif_id)
+            .single()
+            .execute()
+            .data["read_at"]
+        )
+        assert second_read_at == first_read_at

--- a/backend/__tests__/integration/test_rls_scenarios.py
+++ b/backend/__tests__/integration/test_rls_scenarios.py
@@ -8,30 +8,38 @@ from fastapi.testclient import TestClient
 # 本物のAPIサーバーとして動作させる（Dependency Overrideしない）
 client = TestClient(app)
 
+# RLS違反時、repo層は例外をキャッチせず素通しするため、TestClientのデフォルト設定
+# (raise_server_exceptions=True) だと HTTPレスポンスではなく例外として伝播してしまう。
+# RLS拒否を「レスポンスのステータスコード」として検証するテストではこちらを使う。
+client_no_raise = TestClient(app, raise_server_exceptions=False)
+
 
 @pytest.mark.integration
-def test_create_and_read_own_data(auth_token):
+def test_create_and_read_own_data(auth_token, tenant_id, admin_db):
     """自分のテナントのデータを作成・参照できる"""
 
-    tenant_id = "uuid-of-tenant-a"  # ログインユーザーの所属テナント
-
-    # 1. データ作成 (Bearer Token付き)
+    # 1. データ作成 (Bearer Token + テナントIDヘッダ付き)
+    unique_code = f"MTP-{uuid.uuid4().hex[:8]}"
     payload = {
         "name": "My Tenant Product",
-        "code": "MTP-001",
-        "tenant_id": tenant_id,
+        "code": unique_code,
         "type": "standard",
     }
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = {"Authorization": f"Bearer {auth_token}", "x-tenant-id": tenant_id}
 
-    create_res = client.post("/api/products/", json=payload, headers=headers)
-    assert create_res.status_code == 200
-    created_id = create_res.json()["id"]
+    created_id = None
+    try:
+        create_res = client.post("/products", json=payload, headers=headers)
+        assert create_res.status_code == 200
+        created_id = create_res.json()["id"]
 
-    # 2. データ参照
-    get_res = client.get(f"/api/products/{created_id}", headers=headers)
-    assert get_res.status_code == 200
-    assert get_res.json()["name"] == "My Tenant Product"
+        # 2. データ参照
+        get_res = client.get(f"/products/{created_id}", headers=headers)
+        assert get_res.status_code == 200
+        assert get_res.json()["name"] == "My Tenant Product"
+    finally:
+        if created_id is not None:
+            admin_db.table("products").delete().eq("id", created_id).execute()
 
 
 @pytest.mark.integration
@@ -41,20 +49,21 @@ def test_cannot_access_other_tenant_data(auth_token):
     # 前提: DBに「別のテナント(Tenant B)」のデータがあるとする
     # あるいは、ここで管理者権限などで無理やりTenant Bのデータを作る
 
-    headers = {"Authorization": f"Bearer {auth_token}"}
-
     # Tenant B のIDを指定して作成しようとしても...
     other_tenant_id = str(uuid.uuid4())  # 適当な別テナント
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "x-tenant-id": other_tenant_id,
+    }
     payload = {
         "name": "Spy Product",
-        "code": "SPY-001",
-        "tenant_id": other_tenant_id,
+        "code": f"SPY-{uuid.uuid4().hex[:8]}",
         "type": "standard",
     }
 
     # RLSポリシー (Check) により、作成自体が拒否されるはず (403 or 500)
     # または作成できても、その後のSelectで見えない
-    res = client.post("/api/products/", json=payload, headers=headers)
+    res = client_no_raise.post("/products", json=payload, headers=headers)
 
     # RLSの設定次第ですが、Supabaseは権限がないInsertに対してエラーを返します
     assert res.status_code != 200

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -184,13 +184,17 @@ class TestProcessMessagePdfStaging:
             patch(
                 "app.services.gmail_service.extract_email_fields",
                 return_value={
-                    "product_name": "<UNKNOWN>",
+                    "product_name": "製品A",
                     "quantity": "<UNKNOWN>",
                     "deadline_date": "<UNKNOWN>",
                     "order_number": "<UNKNOWN>",
                 },
             ),
             patch("app.services.gmail_service.extract_sender_email", return_value=None),
+            patch(
+                "app.services.gmail_service.match_products",
+                return_value={"product_id": None, "candidates": []},
+            ),
             patch(
                 "app.services.gmail_service.upload_attachment",
                 return_value="tenant-1/orders/99/def.txt",
@@ -208,3 +212,50 @@ class TestProcessMessagePdfStaging:
             call.args and call.args[0] == "orders"
             for call in mock_db.table.call_args_list
         )
+
+    def test_no_extracted_fields_skips_order_and_creates_notification(self):
+        """本文から注文項目が一切抽出できない場合、orderを作成せず
+        non_order_email として通知のみ記録すること（顧客レコードも作成しない）。"""
+        mock_service = self._mock_gmail_service()
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "app.services.gmail_service._lookup_tenant_id",
+                return_value="tenant-1",
+            ),
+            patch(
+                "app.services.gmail_service._get_attachments",
+                return_value=[],
+            ),
+            patch(
+                "app.services.gmail_service.extract_email_fields",
+                return_value={
+                    "product_name": "<UNKNOWN>",
+                    "quantity": "<UNKNOWN>",
+                    "deadline_date": "<UNKNOWN>",
+                    "order_number": "<UNKNOWN>",
+                },
+            ),
+            patch(
+                "app.services.gmail_service.extract_sender_email",
+                return_value="spam@example.com",
+            ),
+            patch(
+                "app.services.gmail_service.resolve_or_create_customer"
+            ) as mock_resolve_customer,
+            patch("app.services.gmail_service.upload_attachment") as mock_upload,
+        ):
+            _process_message(mock_service, mock_db, "msg-3", "tenantA", {})
+
+        mock_resolve_customer.assert_not_called()
+        mock_upload.assert_not_called()
+        assert not any(
+            call.args and call.args[0] == "orders"
+            for call in mock_db.table.call_args_list
+        )
+
+        notif_insert = mock_db.table("notifications").insert.call_args.args[0]
+        assert notif_insert["notif_type"] == "non_order_email"
+        assert notif_insert["source_table"] == "gmail_message"
+        assert notif_insert["source_id"] == "msg-3"

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -64,6 +64,9 @@ class TestParsePendingOrderPdfs:
             c.args[0] == {"parse_status": "failed_encrypted"} for c in update_calls
         )
 
+        insert_calls = mock_db.table().insert.call_args_list
+        assert any(c.args[0]["notif_type"] == "failed_encrypted" for c in insert_calls)
+
     def test_exception_during_processing_counts_as_error(self):
         mock_db = MagicMock()
         mock_db.table().select().is_().eq().execute.return_value = MagicMock(
@@ -118,9 +121,13 @@ class TestProcessLineItem:
             created = _process_line_item(mock_db, self._staging_row(), line)
 
         assert created is False
-        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        insert_calls = mock_db.table().insert.call_args_list
+        log_insert = insert_calls[0].args[0]
         assert log_insert["reason"] == "no_product_match"
         assert log_insert["order_attachment_id"] == "att-1"
+        notif_insert = insert_calls[1].args[0]
+        assert notif_insert["notif_type"] == "no_product_match"
+        assert notif_insert["source_table"] == "order_parse_log"
 
     def test_falls_back_to_name_search_using_product_number_raw(self):
         """
@@ -184,8 +191,11 @@ class TestProcessLineItem:
             created = _process_line_item(mock_db, self._staging_row(), line)
 
         assert created is False
-        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        insert_calls = mock_db.table().insert.call_args_list
+        log_insert = insert_calls[0].args[0]
         assert log_insert["reason"] == "downgrade_skipped"
+        notif_insert = insert_calls[1].args[0]
+        assert notif_insert["notif_type"] == "downgrade_skipped"
 
     def test_draft_conflict_logs_and_skips(self):
         mock_db = MagicMock()
@@ -207,8 +217,11 @@ class TestProcessLineItem:
             created = _process_line_item(mock_db, self._staging_row(), line)
 
         assert created is False
-        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        insert_calls = mock_db.table().insert.call_args_list
+        log_insert = insert_calls[0].args[0]
         assert log_insert["reason"] == "draft_conflict_skipped"
+        notif_insert = insert_calls[1].args[0]
+        assert notif_insert["notif_type"] == "draft_conflict_skipped"
 
     def test_no_change_skips_without_logging(self):
         mock_db = MagicMock()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,11 @@ from app.routers.master import (
     scheduling_settings_router,
 )
 from app.routers.tenant import member_router
-from app.routers.transaction import orders_router, production_schedules_router
+from app.routers.transaction import (
+    notifications_router,
+    orders_router,
+    production_schedules_router,
+)
 
 # .envファイルの読み込み
 load_dotenv()
@@ -53,6 +57,7 @@ app.include_router(process_routing_router)
 app.include_router(calendar_router)
 app.include_router(customer_router)
 app.include_router(orders_router)
+app.include_router(notifications_router)
 app.include_router(production_schedules_router)
 app.include_router(scheduling_settings_router)
 app.include_router(member_router)

--- a/backend/app/models/transaction/notification_schema.py
+++ b/backend/app/models/transaction/notification_schema.py
@@ -1,0 +1,18 @@
+# models/transaction/notification_schema.py
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class NotificationResponse(BaseModel):
+    """通知のレスポンススキーマ"""
+
+    id: str
+    notif_type: str
+    source_table: str
+    source_id: str | None
+    detail: dict[str, Any] | None
+    read_at: str | None
+    created_at: str
+    link_url: str | None

--- a/backend/app/repositories/supa_infra/common/table_name.py
+++ b/backend/app/repositories/supa_infra/common/table_name.py
@@ -19,3 +19,4 @@ class SupabaseTableName(Enum):
     GMAIL_LABEL_TENANTS = "gmail_label_tenants"
     ORDER_ATTACHMENTS = "order_attachments"
     ORDER_PARSE_LOG = "order_parse_log"
+    NOTIFICATIONS = "notifications"

--- a/backend/app/routers/transaction/__init__.py
+++ b/backend/app/routers/transaction/__init__.py
@@ -1,4 +1,5 @@
 # backend/app/routers/transaction/__init__.py
+from .notifications import notifications_router
 from .orders import orders_router
 from .production_schedules import production_schedules_router
 
@@ -6,6 +7,7 @@ from .production_schedules import production_schedules_router
 
 
 __all__ = [
+    "notifications_router",
     "orders_router",
     "production_schedules_router",
 ]

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -30,9 +30,21 @@ _PARSE_LOG_NOTIF_TYPES = {
 
 
 def _resolve_link_url(
-    admin_client: Client, notif_type: str, source_table: str, source_id: str | None
+    admin_client: Client,
+    tenant_id: str,
+    notif_type: str,
+    source_table: str,
+    source_id: str | None,
 ) -> str | None:
-    """通知の遷移先URLを解決する。取得できない場合は None。"""
+    """
+    通知の遷移先URLを解決する。取得できない場合は None。
+
+    admin_client（Service Role Key、RLSバイパス）を使うため、参照先クエリには
+    必ず notifications 行自身の tenant_id を条件に含める。source_id は notifications
+    行の値をそのまま使っているため、これを怠ると他テナントの order_parse_log /
+    order_attachments 行を参照でき、他テナントの添付ファイルの署名付きURLが
+    生成できてしまう（IDOR）。
+    """
     if source_id is None:
         return None
 
@@ -47,6 +59,7 @@ def _resolve_link_url(
             admin_client.table(SupabaseTableName.ORDER_PARSE_LOG.value)
             .select("order_attachment_id")
             .eq("id", source_id)
+            .eq("tenant_id", tenant_id)
             .limit(1)
             .execute()
         )
@@ -60,6 +73,7 @@ def _resolve_link_url(
         admin_client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
         .select("storage_path")
         .eq("id", attachment_id)
+        .eq("tenant_id", tenant_id)
         .limit(1)
         .execute()
     )
@@ -100,6 +114,7 @@ def get_notifications(
             created_at=str(row["created_at"]),
             link_url=_resolve_link_url(
                 admin_client,
+                row["tenant_id"],
                 row["notif_type"],
                 row["source_table"],
                 row.get("source_id"),
@@ -112,12 +127,19 @@ def get_notifications(
 @notifications_router.patch("/read")
 def mark_notifications_read(
     tenant_id: str = Depends(get_current_tenant_id),
-    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """未読の通知を全件既読化する"""
+    """
+    未読の通知を全件既読化する。
+
+    notifications は認証ユーザーに SELECT のみ許可しており（他テナントの
+    行を経由した情報漏えいを避けるため）、UPDATE は admin_client 経由で行う。
+    x-tenant-id ヘッダー由来の tenant_id で対象を絞り込む
+    （他の admin_client 使用箇所と同じパターン）。
+    """
     logger.info("Marking notifications as read")
     now = datetime.now(UTC).isoformat()
-    client.table(SupabaseTableName.NOTIFICATIONS.value).update({"read_at": now}).eq(
-        "tenant_id", tenant_id
-    ).is_("read_at", "null").execute()
+    admin_client.table(SupabaseTableName.NOTIFICATIONS.value).update(
+        {"read_at": now}
+    ).eq("tenant_id", tenant_id).is_("read_at", "null").execute()
     return {"status": "read"}

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -1,0 +1,123 @@
+# routers/transaction/notifications.py
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends
+
+from app.dependencies import (
+    get_current_tenant_id,
+    get_supabase_admin_client,
+    get_supabase_client,
+)
+from app.models.transaction.notification_schema import NotificationResponse
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.services.attachment_service import create_signed_url
+from app.utils.logger import get_logger
+from supabase import Client
+
+notifications_router = APIRouter(
+    prefix="/notifications", tags=["Transaction (Notifications)"]
+)
+
+logger = get_logger(__name__)
+
+# order_parse_log 経由の通知（PDF照合失敗・格下げ/重複スキップ）
+_PARSE_LOG_NOTIF_TYPES = {
+    "no_product_match",
+    "downgrade_skipped",
+    "draft_conflict_skipped",
+}
+
+
+def _resolve_link_url(
+    admin_client: Client, notif_type: str, source_table: str, source_id: str | None
+) -> str | None:
+    """通知の遷移先URLを解決する。取得できない場合は None。"""
+    if source_id is None:
+        return None
+
+    if notif_type == "non_order_email":
+        return f"https://mail.google.com/mail/u/0/#all/{source_id}"
+
+    attachment_id: str | None = None
+    if source_table == "order_attachments":
+        attachment_id = source_id
+    elif source_table == "order_parse_log" and notif_type in _PARSE_LOG_NOTIF_TYPES:
+        log_result = (
+            admin_client.table(SupabaseTableName.ORDER_PARSE_LOG.value)
+            .select("order_attachment_id")
+            .eq("id", source_id)
+            .limit(1)
+            .execute()
+        )
+        log_rows = cast(list[dict[str, Any]], log_result.data or [])
+        attachment_id = log_rows[0]["order_attachment_id"] if log_rows else None
+
+    if attachment_id is None:
+        return None
+
+    attachment_result = (
+        admin_client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
+        .select("storage_path")
+        .eq("id", attachment_id)
+        .limit(1)
+        .execute()
+    )
+    attachment_rows = cast(list[dict[str, Any]], attachment_result.data or [])
+    storage_path = attachment_rows[0].get("storage_path") if attachment_rows else None
+    if not storage_path:
+        return None
+
+    try:
+        return create_signed_url(admin_client, storage_path)
+    except Exception:
+        logger.warning(f"Failed to generate signed URL for {storage_path}")
+        return None
+
+
+@notifications_router.get("", response_model=list[NotificationResponse])
+def get_notifications(
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """通知を新着順に全件取得（各通知の遷移先URL付き）"""
+    logger.info("Fetching notifications")
+    result = (
+        client.table(SupabaseTableName.NOTIFICATIONS.value)
+        .select("*")
+        .order("created_at", desc=True)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    return [
+        NotificationResponse(
+            id=str(row["id"]),
+            notif_type=row["notif_type"],
+            source_table=row["source_table"],
+            source_id=row.get("source_id"),
+            detail=row.get("detail"),
+            read_at=row.get("read_at"),
+            created_at=str(row["created_at"]),
+            link_url=_resolve_link_url(
+                admin_client,
+                row["notif_type"],
+                row["source_table"],
+                row.get("source_id"),
+            ),
+        )
+        for row in rows
+    ]
+
+
+@notifications_router.patch("/read")
+def mark_notifications_read(
+    tenant_id: str = Depends(get_current_tenant_id),
+    client: Client = Depends(get_supabase_client),
+):
+    """未読の通知を全件既読化する"""
+    logger.info("Marking notifications as read")
+    now = datetime.now(UTC).isoformat()
+    client.table(SupabaseTableName.NOTIFICATIONS.value).update({"read_at": now}).eq(
+        "tenant_id", tenant_id
+    ).is_("read_at", "null").execute()
+    return {"status": "read"}

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -91,14 +91,22 @@ def _resolve_link_url(
 
 @notifications_router.get("", response_model=list[NotificationResponse])
 def get_notifications(
+    tenant_id: str = Depends(get_current_tenant_id),
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """通知を新着順に全件取得（各通知の遷移先URL付き）"""
+    """通知を新着順に全件取得（各通知の遷移先URL付き）
+
+    RLS の is_tenant_member(tenant_id) は所属する全テナントの行を許可するため、
+    複数テナントに所属するユーザーが他テナントの通知を受け取らないよう
+    x-tenant-id ヘッダーの tenant_id で明示的に絞り込む
+    （PATCH /notifications/read と同じ絞り込みに揃える）。
+    """
     logger.info("Fetching notifications")
     result = (
         client.table(SupabaseTableName.NOTIFICATIONS.value)
         .select("*")
+        .eq("tenant_id", tenant_id)
         .order("created_at", desc=True)
         .execute()
     )

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -13,6 +13,7 @@ from app.services.customer_matching_service import (
     resolve_or_create_customer,
 )
 from app.services.email_extraction_service import extract_email_fields
+from app.services.notification_service import create_notification
 from app.services.product_matching_service import match_products
 from app.utils.logger import get_logger
 from supabase import Client
@@ -224,6 +225,27 @@ def _process_message(
         raw_fields = extract_email_fields(body)
         fields = {k: (None if v == "<UNKNOWN>" else v) for k, v in raw_fields.items()}
         logger.info(f"msg {msg_id}: extracted fields={fields}")
+
+        # 5.5 受注メールでない（本文から注文項目が一切抽出できない）場合は
+        #     orderを作成せず通知のみ記録する。顧客レコードも作成しない
+        #     （迷惑メール送信元で顧客テーブルを汚染しないため）。
+        if all(
+            fields.get(k) is None
+            for k in ("product_name", "quantity", "deadline_date", "order_number")
+        ):
+            create_notification(
+                db,
+                tenant_id,
+                "non_order_email",
+                "gmail_message",
+                msg_id,
+                {"body_snippet": body[:200]},
+            )
+            logger.info(
+                f"msg {msg_id}: no order fields extracted, skipping order creation"
+            )
+            _move_label(service, msg_id, done_id, processing_id)
+            return
 
         # 6. 製品マッチング
         product_id: int | None = None

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.utils.logger import get_logger
+from supabase import Client
+
+logger = get_logger(__name__)
+
+
+def create_notification(
+    db: Client,
+    tenant_id: str,
+    notif_type: str,
+    source_table: str,
+    source_id: str | None,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    """
+    自動処理パイプラインのイベントを担当者向け通知として記録する。
+
+    order_parse_log / order_attachments.parse_status は詳細の一次情報として
+    別途残る前提で、notifications は横断的な「担当者に見せる通知」専用の薄い記録。
+    """
+    db.table(SupabaseTableName.NOTIFICATIONS.value).insert(
+        {
+            "tenant_id": tenant_id,
+            "notif_type": notif_type,
+            "source_table": source_table,
+            "source_id": str(source_id) if source_id is not None else None,
+            "detail": detail,
+        }
+    ).execute()
+    logger.info(
+        f"notification: created {notif_type} for tenant {tenant_id} "
+        f"(source={source_table}:{source_id})"
+    )

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.services.attachment_service import download_attachment
+from app.services.notification_service import create_notification
 from app.services.pdf_order_extraction_service import extract_order_lines
 from app.services.pdf_text_service import extract_text
 from app.services.product_matching_service import match_product_by_code, match_products
@@ -79,6 +80,14 @@ def _parse_one(db: Client, row: dict[str, Any]) -> int:
         db.table(table).update({"parse_status": text_result.failure_reason}).eq(
             "id", attachment_id
         ).execute()
+        create_notification(
+            db,
+            row["tenant_id"],
+            text_result.failure_reason,
+            SupabaseTableName.ORDER_ATTACHMENTS.value,
+            attachment_id,
+            {},
+        )
         logger.info(
             f"pdf_order_parsing: attachment {attachment_id} "
             f"marked {text_result.failure_reason}"
@@ -126,15 +135,20 @@ def _process_line_item(
         product_id = match["product_id"]
 
     if product_id is None:
-        _log_parse_event(
+        detail = {
+            "product_number_raw": product_number_raw,
+            "product_name_raw": product_name_raw,
+        }
+        log_id = _log_parse_event(
+            db, tenant_id, attachment_id, "no_product_match", detail
+        )
+        create_notification(
             db,
             tenant_id,
-            attachment_id,
             "no_product_match",
-            {
-                "product_number_raw": product_number_raw,
-                "product_name_raw": product_name_raw,
-            },
+            SupabaseTableName.ORDER_PARSE_LOG.value,
+            log_id,
+            detail,
         )
         return False
 
@@ -166,22 +180,32 @@ def _process_line_item(
         )
 
     if action == "skipped_downgrade":
-        _log_parse_event(
+        detail = {"product_id": product_id, "deadline_date": deadline_date}
+        log_id = _log_parse_event(
+            db, tenant_id, attachment_id, "downgrade_skipped", detail
+        )
+        create_notification(
             db,
             tenant_id,
-            attachment_id,
             "downgrade_skipped",
-            {"product_id": product_id, "deadline_date": deadline_date},
+            SupabaseTableName.ORDER_PARSE_LOG.value,
+            log_id,
+            detail,
         )
         return False
 
     if action == "skipped_draft_conflict":
-        _log_parse_event(
+        detail = {"product_id": product_id, "deadline_date": deadline_date}
+        log_id = _log_parse_event(
+            db, tenant_id, attachment_id, "draft_conflict_skipped", detail
+        )
+        create_notification(
             db,
             tenant_id,
-            attachment_id,
             "draft_conflict_skipped",
-            {"product_id": product_id, "deadline_date": deadline_date},
+            SupabaseTableName.ORDER_PARSE_LOG.value,
+            log_id,
+            detail,
         )
         return False
 
@@ -250,15 +274,22 @@ def _log_parse_event(
     attachment_id: str,
     reason: str,
     detail: dict[str, Any],
-) -> None:
-    db.table(SupabaseTableName.ORDER_PARSE_LOG.value).insert(
-        {
-            "tenant_id": tenant_id,
-            "order_attachment_id": attachment_id,
-            "reason": reason,
-            "detail": detail,
-        }
-    ).execute()
+) -> str | None:
+    """order_parse_log に1行記録し、挿入した行の id を返す。"""
+    result = (
+        db.table(SupabaseTableName.ORDER_PARSE_LOG.value)
+        .insert(
+            {
+                "tenant_id": tenant_id,
+                "order_attachment_id": attachment_id,
+                "reason": reason,
+                "detail": detail,
+            }
+        )
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
     logger.info(
         f"pdf_order_parsing: logged {reason} for attachment {attachment_id}: {detail}"
     )
+    return rows[0]["id"] if rows else None

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,0 +1,148 @@
+# 自動処理パイプラインの通知UI（Issue #254）
+
+[pdf-order-parsing.md](pdf-order-parsing.md)（Issue #249, #252）・
+[email-order-intake.md](email-order-intake.md) の自動処理パイプラインは複数箇所で
+ログのみを記録しており、担当者が気づく手段がなかった。これらのイベントを
+アプリ内通知（通知ベル＋一覧）として可視化する。
+
+---
+
+## 背景と目的
+
+照合失敗・格下げスキップ・重複競合スキップ・読み取り不可（暗号化/画像PDF）・
+対象外メールの6種類のイベントを、担当者がアプリ内でリアルタイムに把握できるようにする。
+
+`order_parse_log` / `order_attachments.parse_status` は詳細の一次情報として残したまま、
+`notifications` は「担当者に見せる通知」専用の薄いテーブルとして横断的に記録する
+（`order_parse_log` の1:1ミラーではない）。
+
+---
+
+## DBスキーマ変更
+
+`supabase/migrations/20260703000000_add_notifications.sql`:
+
+```sql
+CREATE TABLE notifications (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    uuid NOT NULL REFERENCES tenants(id),
+  notif_type   text NOT NULL CHECK (notif_type IN (
+                 'no_product_match', 'downgrade_skipped', 'draft_conflict_skipped',
+                 'failed_encrypted', 'failed_image', 'non_order_email'
+               )),
+  source_table text NOT NULL,   -- 'order_parse_log' | 'order_attachments' | 'gmail_message'
+  source_id    text,            -- 参照元IDの型がuuid/bigint/文字列と混在するためtext
+  detail       jsonb,
+  read_at      timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- 既読管理は `is_read boolean` ではなく `read_at timestamptz` とし、いつ既読になったか
+  追跡可能にする。
+- RLSポリシーは CLAUDE.md の規約に従い `is_tenant_member(tenant_id)` を使用する。
+  Issue起票時点の下書きでは既存 `order_parse_log` の `auth.jwt() ->> 'tenant_id'` ポリシーに
+  倣う想定だったが、このパターンは `organization_members` を経由しないため実際のJWTクレーム
+  と一致せず機能しない（`order_parse_log` は現状どこからも読み取られていないため顕在化して
+  いなかった）。ローカルSupabaseで実際にログインしたユーザーで疎通確認し、`notifications`
+  では `is_tenant_member(tenant_id)` に置き換えて動作を確認済み。
+
+### notif_type と発生箇所の対応
+
+| notif_type | 発生箇所 | source_table | source_id |
+|---|---|---|---|
+| `no_product_match` | `pdf_order_parsing_service._process_line_item` | `order_parse_log` | `order_parse_log.id` |
+| `downgrade_skipped` | 同上 | `order_parse_log` | 同上 |
+| `draft_conflict_skipped` | 同上 | `order_parse_log` | 同上 |
+| `failed_encrypted` | `pdf_order_parsing_service._parse_one` | `order_attachments` | `attachment_id` |
+| `failed_image` | 同上 | `order_attachments` | `attachment_id` |
+| `non_order_email` | `gmail_service._process_message` | `gmail_message` | Gmail `msg_id` |
+
+---
+
+## バックエンド設計
+
+### `notification_service.create_notification()`
+
+`backend/app/services/notification_service.py` に共通ヘルパー
+`create_notification(db, tenant_id, notif_type, source_table, source_id, detail)` を新設し、
+`pdf_order_parsing_service.py` と `gmail_service.py` の両方から呼び出す。
+
+`pdf_order_parsing_service._log_parse_event()` の戻り値を `None` から挿入行の `id` に変更し、
+`no_product_match` / `downgrade_skipped` / `draft_conflict_skipped` の3箇所の呼び出し元で
+`log_id` を `notifications.source_id` として渡す。
+
+### 対象外メール検知（`gmail_service.py`）
+
+本文テキスト抽出ルート（PDF添付なし）で `extract_email_fields` の結果が
+`product_name` / `quantity` / `deadline_date` / `order_number` すべて `None`（`<UNKNOWN>`）の場合、
+挙動を変更し **order作成自体をスキップして通知のみ記録する**。
+
+- 判定ゲートは `fields` 正規化直後、製品マッチングより前に配置（`_process_message`）
+- この場合、顧客レコード（`resolve_or_create_customer`）も作成しない
+  （迷惑メール送信元で顧客テーブルを汚染しないため）
+- `_move_label` で処理済みラベルへ移動して return する
+
+### APIエンドポイント
+
+`backend/app/routers/transaction/notifications.py`:
+
+- `GET /notifications` — 新着順に全件取得。各通知に `link_url`（遷移先）を解決して付与する
+  - `non_order_email`: Gmail permalink（`https://mail.google.com/mail/u/0/#all/{msg_id}`）
+  - `failed_encrypted` / `failed_image`: `order_attachments.storage_path` から署名付きURLを生成
+  - `no_product_match` / `downgrade_skipped` / `draft_conflict_skipped`: `order_parse_log` から
+    `order_attachment_id` を引き、対応する添付の署名付きURLを生成
+  - 参照先が見つからない場合は `link_url: null`
+- `PATCH /notifications/read` — 未読（`read_at IS NULL`）全件を `read_at = now()` で一括既読化
+
+`GET /notifications` はユーザーJWTクライアント（RLSでテナント絞り込み）、`link_url` 解決は
+署名付きURL生成のため admin クライアント（Service Role Key）を使用する
+（既存 `/orders/{order_id}/attachments` と同じパターン）。
+
+---
+
+## フロントエンド設計
+
+- `frontend/src/types/notification.ts`: `Notification` / `NotificationType` 型
+- `frontend/src/hooks/use-notifications.ts`:
+  - `useNotifications()` — `useQuery` + `refetchInterval`（30秒間隔ポーリング。push基盤がないため）
+  - `useMarkNotificationsRead()` — `useMutation`。成功時に `notifications` クエリを invalidate
+- `frontend/src/components/layout/notification-bell.tsx`:
+  - ベルアイコン＋未読件数バッジ（`Popover` で一覧表示、`notif_type` ごとにグルーピング）
+  - 各通知は `link_url` があればクリックで新規タブ遷移、なければテキスト表示のみ
+  - `Popover` の `onOpenChange(true)` タイミングで未読があれば既読化 mutation を発火
+    （mount時の `useEffect` では発火させない。ユーザーが見る前にバッジが消えるのを防ぐため）
+- マウント位置: `frontend/src/components/layout/authenticated-layout.tsx` のheader内
+  （ページタイトルと同じ行、右端）
+
+---
+
+## 受け入れ条件
+
+- [x] `notifications` テーブルが作成されている（マイグレーション済み、ローカルSupabaseで疎通確認済み）
+- [x] `no_product_match` / `downgrade_skipped` / `draft_conflict_skipped` / `failed_encrypted` /
+      `failed_image` が通知として記録される（単体テストで検証）
+- [x] 本文テキストルートで抽出結果が空の場合、order作成をスキップし `non_order_email` として
+      通知記録される（顧客レコードも作成しない）
+- [x] 通知ベル＋未読バッジがUIに表示される（ブラウザで実際にログインし目視確認済み）
+- [x] 通知一覧から各詳細（PDF/添付ファイル/Gmailメール）へ遷移できる（`link_url` 経由）
+- [x] 一覧表示（オープン時）で既読化される
+
+---
+
+## スコープ外（このIssueではやらない）
+
+- PDF添付ルートで「明細抽出結果が空配列」の場合の `non_order_email` 検知
+- メール通知・Slack通知などアプリ外への通知連携
+- `non_order_email` 判定の精度改善（ラベルルーティング自体の見直し等）
+- 通知からの一括操作（一括既読以外のアクション）
+- 通知の長期集計・ダッシュボード
+- `order_parse_log` / `order_attachments` 自体のスキーマ変更
+
+---
+
+## 関連
+
+- [pdf-order-parsing.md](pdf-order-parsing.md): PDF自動パース処理（Issue #249, #252、通知発生元）
+- [email-order-intake.md](email-order-intake.md): メール起票の基盤設計
+- Issue #249, #252: `order_parse_log` への記録処理（本Issueの通知発生元）

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -141,8 +141,35 @@ CREATE TABLE notifications (
 
 ---
 
+## テスト（Issue #256）
+
+単体テストのみでカバーできなかった、実際のPostgres（RLS込み）でしか検証できない挙動を
+`backend/__tests__/integration/test_notifications_rls.py` に追加した。
+
+- `notifications` の RLSポリシー（SELECTのみ許可、INSERT/UPDATE/DELETEはデフォルト拒否）
+  — 自テナント/他テナントの可視性、ユーザーJWT経由の直接書き込みが拒否されること
+- `GET /notifications` の `_resolve_link_url` におけるIDOR修正（commit 868a45f）の回帰テスト
+  — `order_attachments` / `order_parse_log` いずれの経路でも、`source_id` が他テナントの行を
+  指していても `link_url` が `None` になること
+- `PATCH /notifications/read` が自テナントの未読分のみを対象にすること、既読済み行への
+  再実行が冪等であること
+
+あわせて、`backend/__tests__/integration/conftest.py` の `TEST_USER_EMAIL` / `TEST_USER_PASS` /
+`TEST_TENANT_ID` が `.env` の実際のシード値と乖離したハードコード値（`user_a@example.com` 等）
+になっており、ログイン自体に失敗する状態だったため `.env` の値を読むよう修正した
+（`real_supabase_client` の `SUPABASE_KEY` → `SUPABASE_ANON_KEY` の誤りも合わせて修正）。
+`test_rls_scenarios.py` は本Issueのスコープ外のため未着手（`/api/products/` という誤った
+パスを使っており引き続き失敗する既知の問題）。
+
+実行:
+```bash
+supabase start
+cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-integration
+```
+
 ## 関連
 
 - [pdf-order-parsing.md](pdf-order-parsing.md): PDF自動パース処理（Issue #249, #252、通知発生元）
 - [email-order-intake.md](email-order-intake.md): メール起票の基盤設計
 - Issue #249, #252: `order_parse_log` への記録処理（本Issueの通知発生元）
+- Issue #256: integrationテスト追加（RLS/IDOR回帰）

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -183,5 +183,7 @@ cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-in
 
 - [pdf-order-parsing.md](pdf-order-parsing.md): PDF自動パース処理（Issue #249, #252、通知発生元）
 - [email-order-intake.md](email-order-intake.md): メール起票の基盤設計
+- [order-attachments.md](order-attachments.md): `order_attachments` テーブル・`parse_status`
+  の定義（`failed_encrypted` / `failed_image` の発生元、対象外メール検知時の挙動変更）
 - Issue #249, #252: `order_parse_log` への記録処理（本Issueの通知発生元）
 - Issue #256: integrationテスト追加（RLS/IDOR回帰）

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -99,6 +99,11 @@ CREATE TABLE notifications (
 署名付きURL生成のため admin クライアント（Service Role Key）を使用する
 （既存 `/orders/{order_id}/attachments` と同じパターン）。
 
+RLSの `is_tenant_member(tenant_id)` は所属する全テナントの行を許可するため、
+複数テナントに所属するユーザーの場合に他テナントの通知が混ざらないよう
+`x-tenant-id` ヘッダーの tenant_id で明示的に絞り込む（`PATCH /notifications/read`
+と同じ絞り込みに揃えている）。
+
 ---
 
 ## フロントエンド設計
@@ -112,6 +117,7 @@ CREATE TABLE notifications (
   - 各通知は `link_url` があればクリックで新規タブ遷移、なければテキスト表示のみ
   - `Popover` の `onOpenChange(true)` タイミングで未読があれば既読化 mutation を発火
     （mount時の `useEffect` では発火させない。ユーザーが見る前にバッジが消えるのを防ぐため）
+  - ベルボタンはアイコンのみのため `aria-label`（未読件数を含む）でスクリーンリーダー向けに補足
 - マウント位置: `frontend/src/components/layout/authenticated-layout.tsx` のheader内
   （ページタイトルと同じ行、右端）
 
@@ -153,11 +159,17 @@ CREATE TABLE notifications (
   指していても `link_url` が `None` になること
 - `PATCH /notifications/read` が自テナントの未読分のみを対象にすること、既読済み行への
   再実行が冪等であること
+- ユーザーが複数テナント（own/other）に所属する場合、`GET /notifications` が
+  `x-tenant-id` で選択したテナント以外の通知を混ぜないこと（Copilotレビュー指摘の回帰テスト。
+  `is_tenant_member(tenant_id)` だけでは所属する全テナントの行を許可してしまうため、
+  ルータ側で明示的に `tenant_id` を絞り込む必要がある）
 
 あわせて、`backend/__tests__/integration/conftest.py` の `TEST_USER_EMAIL` / `TEST_USER_PASS` /
 `TEST_TENANT_ID` が `.env` の実際のシード値と乖離したハードコード値（`user_a@example.com` 等）
 になっており、ログイン自体に失敗する状態だったため `.env` の値を読むよう修正した
 （`real_supabase_client` の `SUPABASE_KEY` → `SUPABASE_ANON_KEY` の誤りも合わせて修正）。
+必須環境変数（`SUPABASE_URL` / `SUPABASE_ANON_KEY` / `TEST_USER_EMAIL` / `TEST_USER_PASS`）が
+未設定の場合は `KeyError` や分かりにくいログイン失敗ではなく `pytest.skip` で明示的にスキップする。
 `test_rls_scenarios.py` は本Issueのスコープ外のため未着手（`/api/products/` という誤った
 パスを使っており引き続き失敗する既知の問題）。
 

--- a/docs/features/order-attachments.md
+++ b/docs/features/order-attachments.md
@@ -8,6 +8,13 @@ Gmail 自動伝票起票フローで受信した注文書 PDF を Supabase Stora
 > 「PDF をステージング保存し、パース処理（後続Issue）完了後に order を作成」に変更された。
 > 添付なし・非PDF添付メールの既存フロー（即時 order 作成）は変更されていない。
 > 詳細は本ドキュメント内の「PDF添付メールのステージング保存（Issue #248）」を参照。
+>
+> [!IMPORTANT]
+> Issue #254 により、非PDF添付メール（本文テキスト抽出ルート）で `product_name` /
+> `quantity` / `deadline_date` / `order_number` が全て抽出できなかった場合、
+> order 作成・添付保存・`order_attachments` INSERT を含む処理全体をスキップし、
+> 通知記録のみ行うよう変更された。詳細は本ドキュメント内の「対象外メール検知
+> （Issue #254）」および [notifications.md](notifications.md) を参照。
 
 ---
 
@@ -84,6 +91,11 @@ create policy "tenant isolation" on order_attachments
 | `failed_image`           | 画像 PDF で抽出不可             |
 | `failed_no_attachment`   | 添付なし（本文のみで処理）      |
 
+`failed_encrypted` / `failed_image` は Issue #254 でアプリ内通知（`notifications` テーブル）
+にも記録されるようになった。`order_attachments.parse_status` が一次情報として残る点は変わらず、
+`notifications` は横断的な「担当者への通知」専用の薄いテーブルとして別途書き込まれる
+（詳細は [notifications.md](notifications.md) 参照）。
+
 ---
 
 ## バックエンド処理フロー
@@ -118,6 +130,26 @@ create policy "tenant isolation" on order_attachments
 
 このステージング行から実際の `orders` 行を生成する処理（PDFテキスト抽出・複数明細パース）は
 後続Issueで実装する。
+
+### 対象外メール検知（Issue #254）
+
+添付なし・非PDF添付メールの既存フロー内、Claude による単一フィールド抽出（`extract_email_fields`）
+直後・製品マッチングより前に判定ゲートを追加した（`_process_message`、
+`backend/app/services/gmail_service.py`）。
+
+`product_name` / `quantity` / `deadline_date` / `order_number` が全て `None`
+（`<UNKNOWN>`）の場合、「受注メールでない」と判定し以下のように挙動を変更する:
+
+- `orders` INSERT・添付ファイルの Storage 保存・`order_attachments` INSERT を
+  いずれも行わない（従来は添付なしでも `parse_status='failed_no_attachment'` で
+  `order_attachments` に行が作成されていたが、対象外メールの場合はこの行自体を作らない）
+- 顧客レコード（`resolve_or_create_customer`）も作成しない
+  （迷惑メール送信元で顧客テーブルを汚染しないため）
+- 代わりに `notification_service.create_notification()` で `notif_type='non_order_email'`
+  （`source_table='gmail_message'`, `source_id=msg_id`）の通知を1件記録する
+- 処理済みラベルへ移動して return する（エラー扱いにはしない）
+
+詳細は [notifications.md](notifications.md) を参照。
 
 ### 新規ファイル: `backend/app/services/attachment_service.py`
 
@@ -185,6 +217,10 @@ export interface OrderAttachment {
       （`order_id=NULL`, `parse_status='pending'`）が作成される（Issue #248）
 - [x] PDFが `{tenant_id}/inbox/{gmail_message_id}/{filename}` に保存される（Issue #248）
 - [x] `order_attachments.order_id` が nullable になっている（Issue #248）
+- [x] 非PDF添付メールで注文項目が全く抽出できない場合、`orders` / `order_attachments`
+      いずれも作成されず `non_order_email` 通知のみ記録される（Issue #254）
+- [x] `failed_encrypted` / `failed_image` の発生時、`order_attachments.parse_status`
+      更新に加えてアプリ内通知が記録される（Issue #254）
 
 ---
 
@@ -203,3 +239,5 @@ export interface OrderAttachment {
 - Issue B: PDF パース＋複数 order 生成
 - Issue C: 既存 order upsert（予定）
 - [email-order-intake.md](email-order-intake.md): メール起票基盤の設計
+- [notifications.md](notifications.md): 自動処理パイプラインの通知UI（Issue #254）。
+  `failed_encrypted` / `failed_image` / `non_order_email` の通知記録の詳細はこちらを参照

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -211,7 +211,7 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 
 - PPAP（パスワード付きPDF）の自動復号
 - 複数添付ファイルへの対応（1メール1添付の前提を維持）
-- 重複スキップ・照合失敗の通知UI（将来Issue、`order_parse_log` を参照する前提）
+- 重複スキップ・照合失敗の通知UI（[notifications.md](notifications.md) Issue #254 で対応）
 - ステージング行が長時間 `pending` のまま停滞した場合のリトライ・タイムアウト処理
 - `forecast`/`forecast_tentative` のUIフィルタータブ追加（別途検討）
 - `deadline_date` 変更を「同一注文の引き継ぎ」として明示的にUI上で提示する機能（Issue #252スコープ外）
@@ -274,4 +274,4 @@ order-attachments バケットに事前アップロード済みの実PDF（飯�
 
 - [order-attachments.md](order-attachments.md): PDFステージング保存基盤（Issue #248、前提）
 - Issue #252: 既存orderのupsert処理（内示→確定の昇格・数量更新対応）。本ドキュメントに統合
-- 後続: 処理ログ通知基盤（`order_parse_log` を利用）
+- [notifications.md](notifications.md): 処理ログの通知UI（Issue #254、`order_parse_log` を利用）

--- a/frontend/src/components/layout/authenticated-layout.tsx
+++ b/frontend/src/components/layout/authenticated-layout.tsx
@@ -5,6 +5,7 @@ import * as React from "react"
 import { usePathname } from "next/navigation"
 import { SidebarProvider, SidebarTrigger, SidebarInset } from "@/components/ui/sidebar"
 import { AppSidebar } from "./app-sidebar"
+import { NotificationBell } from "./notification-bell"
 import { Separator } from "@/components/ui/separator"
 
 const pageTitleMap: Record<string, string> = {
@@ -49,8 +50,9 @@ export function AuthenticatedLayout({ children, user }: AuthenticatedLayoutProps
           <SidebarTrigger className="bg-background shadow-md border rounded-r-lg" />
         </div>
 
-        <header className="flex h-15 shrink-0 items-center gap-2 border-b px-4">
+        <header className="flex h-15 shrink-0 items-center justify-between gap-2 border-b px-4">
           <div className="font-semibold">{pageTitle}</div>
+          <NotificationBell />
         </header>
 
         <div className="flex flex-1 flex-col px-4 py-6 space-y-6">

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import * as React from "react"
+import { Bell } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { useMarkNotificationsRead, useNotifications } from "@/hooks/use-notifications"
+import type { Notification, NotificationType } from "@/types/notification"
+
+const NOTIF_TYPE_LABELS: Record<NotificationType, string> = {
+  no_product_match: "照合失敗",
+  downgrade_skipped: "格下げスキップ",
+  draft_conflict_skipped: "重複競合スキップ",
+  failed_encrypted: "読み取り不可（暗号化PDF）",
+  failed_image: "読み取り不可（画像PDF）",
+  non_order_email: "対象外メール",
+}
+
+function groupByType(notifications: Notification[]): [NotificationType, Notification[]][] {
+  const groups = new Map<NotificationType, Notification[]>()
+  for (const notif of notifications) {
+    const list = groups.get(notif.notif_type) ?? []
+    list.push(notif)
+    groups.set(notif.notif_type, list)
+  }
+  return Array.from(groups.entries())
+}
+
+export function NotificationBell() {
+  const [open, setOpen] = React.useState(false)
+  const { data: notifications = [] } = useNotifications()
+  const markRead = useMarkNotificationsRead()
+
+  const unreadCount = notifications.filter((n) => n.read_at === null).length
+  const groups = groupByType(notifications)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen && unreadCount > 0) {
+      markRead.mutate()
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell className="size-5" />
+          {unreadCount > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -right-1 -top-1 h-4 min-w-4 px-1 text-[10px]"
+            >
+              {unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <div className="border-b px-4 py-3 font-semibold">通知</div>
+        <div className="max-h-96 overflow-y-auto">
+          {groups.length === 0 && (
+            <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+              通知はありません
+            </div>
+          )}
+          {groups.map(([notifType, items]) => (
+            <div key={notifType} className="border-b last:border-b-0">
+              <div className="flex items-center justify-between px-4 py-2 text-sm font-medium text-muted-foreground">
+                <span>{NOTIF_TYPE_LABELS[notifType]}</span>
+                <span>{items.length}件</span>
+              </div>
+              <ul>
+                {items.map((notif) => (
+                  <li key={notif.id}>
+                    {notif.link_url ? (
+                      <a
+                        href={notif.link_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block px-4 py-2 text-sm hover:bg-accent"
+                      >
+                        <NotificationRow notif={notif} />
+                      </a>
+                    ) : (
+                      <div className="px-4 py-2 text-sm">
+                        <NotificationRow notif={notif} />
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function NotificationRow({ notif }: { notif: Notification }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="truncate text-muted-foreground">
+        {formatDetail(notif)}
+      </span>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {new Date(notif.created_at).toLocaleString("ja-JP", {
+          month: "numeric",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })}
+      </span>
+    </div>
+  )
+}
+
+function formatDetail(notif: Notification): string {
+  const detail = notif.detail
+  if (!detail) return "詳細なし"
+  const productName = detail.product_name_raw ?? detail.product_number_raw
+  if (typeof productName === "string") return productName
+  const snippet = detail.body_snippet
+  if (typeof snippet === "string") return snippet.slice(0, 40)
+  return "詳細を見る"
+}

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -51,7 +51,12 @@ export function NotificationBell() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative"
+          aria-label={unreadCount > 0 ? `通知（未読${unreadCount}件）` : "通知"}
+        >
           <Bell className="size-5" />
           {unreadCount > 0 && (
             <Badge

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -39,15 +39,17 @@ export function NotificationBell() {
   const unreadCount = notifications.filter((n) => n.read_at === null).length
   const groups = groupByType(notifications)
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    setOpen(nextOpen)
-    if (nextOpen && unreadCount > 0) {
+  // Popoverが開いている間、初回ロード遅延や再フェッチで未読が後から
+  // 増えるケースでも取りこぼさず既読化する（isPendingで多重送信を防ぐ）
+  React.useEffect(() => {
+    if (open && unreadCount > 0 && !markRead.isPending) {
       markRead.mutate()
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, unreadCount])
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="ghost" size="icon" className="relative">
           <Bell className="size-5" />

--- a/frontend/src/hooks/use-notifications.ts
+++ b/frontend/src/hooks/use-notifications.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api-client"
+import type { Notification } from "@/types/notification"
+
+const NOTIFICATIONS_KEY = ["notifications"]
+
+export function useNotifications() {
+  return useQuery<Notification[]>({
+    queryKey: NOTIFICATIONS_KEY,
+    queryFn: () => apiClient<Notification[]>("/notifications"),
+    refetchInterval: 1000 * 30,
+  })
+}
+
+export function useMarkNotificationsRead() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () =>
+      apiClient<{ status: string }>("/notifications/read", { method: "PATCH" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_KEY })
+    },
+  })
+}

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -1,0 +1,18 @@
+export type NotificationType =
+  | "no_product_match"
+  | "downgrade_skipped"
+  | "draft_conflict_skipped"
+  | "failed_encrypted"
+  | "failed_image"
+  | "non_order_email"
+
+export interface Notification {
+  id: string
+  notif_type: NotificationType
+  source_table: string
+  source_id: string | null
+  detail: Record<string, unknown> | null
+  read_at: string | null
+  created_at: string
+  link_url: string | null
+}

--- a/supabase/migrations/20260703000000_add_notifications.sql
+++ b/supabase/migrations/20260703000000_add_notifications.sql
@@ -25,9 +25,16 @@ ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
 -- CLAUDE.md の規約に従い is_tenant_member(tenant_id) を使用する。
 -- (order_parse_log の "auth.jwt() ->> 'tenant_id'" ポリシーは organization_members を
 --  経由しないため実際のJWTクレームと一致せず機能しない。本テーブルでは追随しない)
-CREATE POLICY "tenant isolation" ON notifications
-  FOR ALL
-  USING (is_tenant_member(tenant_id))
-  WITH CHECK (is_tenant_member(tenant_id));
+--
+-- notifications への書き込み（INSERT/UPDATE）は cron エンドポイント
+-- (parse-order-pdfs, gmail-poll) と PATCH /notifications/read から常に
+-- Service Role Key の admin_client 経由（RLSバイパス）で行われ、
+-- ユーザーJWTクライアントから直接書き込む経路は存在しない。
+-- そのため認証ユーザーには SELECT のみ許可し、他テナントのnotifications行を
+-- 経由した情報漏えい（source_id改ざんによる他テナント添付ファイルの署名付きURL取得等）
+-- のリスクを避けるため INSERT/UPDATE/DELETE のポリシーは設けない（デフォルト拒否）。
+CREATE POLICY "tenant isolation (select)" ON notifications
+  FOR SELECT
+  USING (is_tenant_member(tenant_id));
 
 CREATE INDEX idx_notifications_tenant_unread ON notifications (tenant_id, read_at, created_at DESC);

--- a/supabase/migrations/20260703000000_add_notifications.sql
+++ b/supabase/migrations/20260703000000_add_notifications.sql
@@ -1,0 +1,33 @@
+-- 自動処理パイプライン（PDF解析・メール抽出）のログを担当者に可視化する通知機能 (Issue #254)
+-- order_parse_log / order_attachments.parse_status は詳細の一次情報として残したまま、
+-- notifications は「担当者に見せる通知」専用の薄いテーブルとして横断的に記録する。
+
+CREATE TABLE notifications (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    uuid NOT NULL REFERENCES tenants(id),
+  notif_type   text NOT NULL CHECK (notif_type IN (
+                 'no_product_match', 'downgrade_skipped', 'draft_conflict_skipped',
+                 'failed_encrypted', 'failed_image', 'non_order_email'
+               )),
+  source_table text NOT NULL,   -- 'order_parse_log' | 'order_attachments' | 'gmail_message'
+  source_id    text,            -- 参照元IDの型がuuid/bigint/文字列と混在するためtext
+  detail       jsonb,
+  read_at      timestamptz,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON COLUMN notifications.notif_type IS
+  'order_parse_log.reason とは別語彙。notifications はPDF解析ログ・添付失敗・メール抽出結果を'
+  '横断集約する通知専用テーブルであり、order_parse_log の1:1ミラーではないため。';
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+-- CLAUDE.md の規約に従い is_tenant_member(tenant_id) を使用する。
+-- (order_parse_log の "auth.jwt() ->> 'tenant_id'" ポリシーは organization_members を
+--  経由しないため実際のJWTクレームと一致せず機能しない。本テーブルでは追随しない)
+CREATE POLICY "tenant isolation" ON notifications
+  FOR ALL
+  USING (is_tenant_member(tenant_id))
+  WITH CHECK (is_tenant_member(tenant_id));
+
+CREATE INDEX idx_notifications_tenant_unread ON notifications (tenant_id, read_at, created_at DESC);


### PR DESCRIPTION
## Summary

- 自動処理パイプライン（PDF解析: Issue #249/#252、Gmail起票）が記録する各種ログイベントを、担当者がアプリ内でリアルタイムに把握できる通知機能を実装
- `notifications` テーブルを新設し、`no_product_match` / `downgrade_skipped` / `draft_conflict_skipped` / `failed_encrypted` / `failed_image` / `non_order_email` の6種類のイベントを横断的に記録
- メール本文抽出ルートで注文項目が一切抽出できない場合、order作成をスキップし `non_order_email` として通知のみ記録するよう挙動を変更（顧客レコードも作成しない）
- 通知ベル＋未読バッジ＋一覧UI（`notif_type` ごとにグルーピング、クリックで詳細へ遷移）を追加

## 実装メモ

- Issue本文で提案されていた `notifications` のRLSポリシー（`auth.jwt() ->> 'tenant_id'`）は、既存 `order_parse_log` の実装を踏襲したものだが、`organization_members` を経由せず実際のJWTクレームと一致しないため機能しない。CLAUDE.mdの規約に従い `is_tenant_member(tenant_id)` に変更し、ローカルSupabase + 実ログインで疎通確認済み
- `GET /notifications` は各通知に遷移先 `link_url` を解決して返す（`order_parse_log`/`order_attachments` の署名付きURL、または Gmail permalink）

## Test plan

- [x] Backend unit tests: `pytest __tests__/unit/services/test_pdf_order_parsing_service.py __tests__/unit/services/test_gmail_service.py` — 全件pass
- [x] `ruff check` / `mypy` — 変更ファイルすべてpass
- [x] ローカルSupabaseにマイグレーション適用（`supabase db reset`）、実ログインでAPI疎通確認（`GET /notifications`, `PATCH /notifications/read`）
- [x] フロントエンドをブラウザで実際に操作し、通知ベル・未読バッジ・グルーピング一覧・開封時の既読化を目視確認（スクリーンショット取得済み）
- [x] `npm run build` / `tsc --noEmit` / `eslint` — pass
- [x] `docs/features/notifications.md` を新規作成し、`pdf-order-parsing.md` から相互参照を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)