### PR TITLE
fix(#257): テナント作成スクリプトでgmail_label_tenantsを自動登録

### DIFF
--- a/backend/scripts/create_tenant.py
+++ b/backend/scripts/create_tenant.py
@@ -5,7 +5,8 @@ Usage:
     python scripts/create_tenant.py \
         --company-name "株式会社〇〇" \
         --owner-email "xxx@example.com" \
-        --owner-name "山田太郎"
+        --owner-name "山田太郎" \
+        --gmail-label "株式会社〇〇"  # Gmail受注起票を使う場合のみ指定
 """
 
 import argparse
@@ -50,7 +51,12 @@ def _get_admin_client():
     return create_client(url, key)
 
 
-def create_tenant(company_name: str, owner_email: str, owner_name: str) -> None:
+def create_tenant(
+    company_name: str,
+    owner_email: str,
+    owner_name: str,
+    gmail_label: str | None = None,
+) -> None:
     admin_client = _get_admin_client()
     password = _generate_password()
 
@@ -115,6 +121,29 @@ def create_tenant(company_name: str, owner_email: str, owner_name: str) -> None:
         print("Supabase Studio で手動確認してください。", file=sys.stderr)
         sys.exit(1)
 
+    # Step 4: gmail_label_tenants へ登録（--gmail-label 指定時のみ）
+    gmail_label_registered = False
+    if gmail_label:
+        try:
+            admin_client.table("gmail_label_tenants").insert(
+                {"label_name": gmail_label, "tenant_id": tenant_id}
+            ).execute()
+            gmail_label_registered = True
+        except Exception as e:
+            print(
+                f"警告: gmail_label_tenants の登録に失敗しました: {e}",
+                file=sys.stderr,
+            )
+            print(
+                "  テナント作成自体は完了しています。手動でSupabase SQL Editorから登録してください:",
+                file=sys.stderr,
+            )
+            print(
+                f"  INSERT INTO gmail_label_tenants (label_name, tenant_id) "
+                f"VALUES ('{gmail_label}', '{tenant_id}');",
+                file=sys.stderr,
+            )
+
     # 結果を stdout のみに表示
     print("=== テナント作成完了 ===")
     print(f"テナント名  : {company_name}")
@@ -124,6 +153,15 @@ def create_tenant(company_name: str, owner_email: str, owner_name: str) -> None:
     print(f"初期パスワード: {password}")
     print("======================")
     print("※ 初期パスワードを安全に顧客へ伝達してください")
+
+    if gmail_label_registered:
+        print()
+        print("=== Gmail連携: 次のステップ (要手動対応) ===")
+        print(f"gmail_label_tenants への登録は完了しました（label_name={gmail_label}）")
+        print("受信用Gmailアカウント側で以下のラベルを作成してください:")
+        for prefix in ("pp-pending", "pp-processing", "pp-done", "pp-error"):
+            print(f"  {prefix}/{gmail_label}")
+        print("==========================================")
 
 
 def _rollback(admin_client, user_id: str, tenant_id: str | None) -> None:
@@ -162,6 +200,14 @@ def main() -> None:
     parser.add_argument("--owner-email", required=True, help="オーナーのメールアドレス")
     parser.add_argument("--owner-name", required=True, help="オーナーの氏名")
     parser.add_argument(
+        "--gmail-label",
+        default=None,
+        help=(
+            "Gmail受注起票を有効にする場合の gmail_label_tenants.label_name "
+            "（Gmail側のラベルサフィックスと完全一致させること。省略時は登録しない）"
+        ),
+    )
+    parser.add_argument(
         "--env-file",
         default=None,
         help="読み込む .env ファイルのパス（省略時は scripts/.env）",
@@ -179,6 +225,7 @@ def main() -> None:
         company_name=args.company_name,
         owner_email=args.owner_email,
         owner_name=args.owner_name,
+        gmail_label=args.gmail_label,
     )
 
 

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -202,6 +202,18 @@ interface OrderCreate {
 
 プレフィックスは環境変数で変更可能（デフォルト: `pp-pending`, `pp-processing`, `pp-done`, `pp-error`）。
 
+### テナント登録（`gmail_label_tenants`）
+
+Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail_label_tenants` テーブルで管理する。
+この登録が漏れると該当メールは `pp-error/{テナント名}` に落ちて起票されない（`tenant not found for label` エラー）。
+
+新規テナント作成時は `backend/scripts/create_tenant.py --gmail-label <ラベル名>` で自動登録できる。
+このテーブルはアプリ管理者専用の運用データであり、アプリユーザー向けAPIは設けていない。
+既存テナントへの追加・変更はSupabase SQL Editorで直接行う（詳細は `docs/infra/env-setup-gmail-cron.md` Step 5）。
+
+登録後、Gmail アカウント側で `pp-pending/{テナント名}` 等のラベルを実際に作成する作業は別途手動で必要
+（`gmail_label_tenants` への登録とGmail上のラベル作成は自動連携されない）。
+
 ### 環境変数
 
 | 変数名 | デフォルト | 説明 |

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -115,7 +115,19 @@ Gmail の設定 → フィルタ → フィルタを作成 で以下を設定す
 
 ## Step 5: gmail_label_tenants テーブルにエントリを追加する
 
-Supabase ダッシュボード → SQL Editor で以下を実行する。
+新規テナント作成時は `backend/scripts/create_tenant.py` に `--gmail-label` を指定すると自動で登録される。
+
+```bash
+python scripts/create_tenant.py \
+    --company-name "テナントA" \
+    --owner-email "xxx@example.com" \
+    --owner-name "山田太郎" \
+    --gmail-label "テナントA"
+```
+
+既存テナントへの追加登録やラベル名の変更など、上記スクリプトでカバーされないメンテナンスは
+Supabase ダッシュボード → SQL Editor で直接行う（このテーブルはアプリ管理者のみが関心を持つ運用データのため、
+専用の管理APIは設けていない）。
 
 ```sql
 INSERT INTO gmail_label_tenants (label_name, tenant_id)
@@ -127,6 +139,9 @@ VALUES ('テナントA', '<tenant_id_uuid>');
 ```sql
 SELECT id, name FROM tenants;
 ```
+
+登録後、Gmail アカウント側で `pp-pending/テナントA` 等のラベルを実際に作成することを忘れないこと
+（`gmail_label_tenants` への登録と Gmail 上のラベル作成は別々の手作業であり、自動連携されない）。
 
 ---
 


### PR DESCRIPTION
## Summary
- 本番でGmail起票cron実行時に `tenant not found for label: 有限会社カブトギ工業` が発生。原因は `gmail_label_tenants` への登録漏れ
- 従来 `gmail_label_tenants` はテナント作成フロー（`create_tenant.py`）と独立した手動SQL作業になっており、登録忘れが起きやすかった
- `create_tenant.py` に `--gmail-label` オプションを追加し、指定時はテナント作成直後に自動登録するようにした（省略時は従来通り）
- 登録に失敗してもテナント作成自体はロールバックせず、手動SQL文を警告出力する
- `docs/infra/env-setup-gmail-cron.md` と `docs/features/email-order-intake.md` を更新し、新しい運用手順と「Gmail側の実ラベル作成は別途手動」である旨を明記

## Test plan
- [x] `python -m py_compile backend/scripts/create_tenant.py` が通ること
- [x] `ruff check` / `ruff format` (pre-commit hook) がパスすること
- [ ] ステージング等で `create_tenant.py --gmail-label <label>` を実行し、`gmail_label_tenants` に正しく登録されることを確認
- [ ] `--gmail-label` 省略時に従来通りテナント作成のみ行われることを確認

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)