### PR TITLE
docs(#259): 2段階Cronのスケジューリング設計を記載

### DIFF
--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -202,6 +202,26 @@ interface OrderCreate {
 
 プレフィックスは環境変数で変更可能（デフォルト: `pp-pending`, `pp-processing`, `pp-done`, `pp-error`）。
 
+### 2段階Cronのスケジューリング設計 (#259)
+
+メール起票パイプラインは実際には2つの独立したcronエンドポイントで構成されている。
+
+| エンドポイント | 役割 |
+|---|---|
+| `GET /api/cron/gmail-poll` | メール取得・フィールド抽出・非PDF添付の即時起票／PDF添付は `order_attachments` へのステージング保存のみ |
+| `GET /api/cron/parse-order-pdfs` | ステージング済みPDF（`order_attachments.parse_status='pending'`）をテキスト抽出・製品照合し、`orders` を実際にINSERT |
+
+**設計方針（案1）: 2段目を高頻度で独立実行し、実行順序のズレを許容する。**
+
+- `gmail_service.py` は「Storageへのアップロード完了 → `order_attachments` へのINSERT」の順で処理し、INSERTは単一の `.execute()` で完結する。そのため `order_attachments` に行が見える時点でPDFは必ずアップロード完了済みであり、「半端な状態」の行は存在しない
+- `parse_pending_order_pdfs()` は `order_id IS NULL AND parse_status='pending'` の行のみを都度SELECTして処理するため、`gmail-poll` の実行途中で `parse-order-pdfs` が走っても、その時点までにINSERT済みの行だけが正しく処理され、未INSERTの分は `parse_status='pending'` のまま残り次回のポーリングで拾われる
+- つまり2段目の実行タイミングが1段目より早くても、起きるのは**データ破損ではなく「今回処理されず次サイクルに持ち越されるだけ」の遅延**。この遅延を実用上無視できる範囲に収めるため、2段目はできるだけ高頻度（5〜15分間隔目安）にスケジュールする
+
+**現状のギャップ（既知の課題、#259で対応中）**
+
+- `frontend/vercel.json` には `gmail-poll` のみ登録されており、`parse-order-pdfs` はどのスケジューラにも登録されていない。そのため現状PDF添付メールは「ステージングまでは自動化されているが、受注確定までは自動実行されない」状態になっている
+- Vercel Cronは無料（Hobby）プランでは実行回数制限（1日2回まで）があり、上記の高頻度実行（5〜15分間隔）を満たせない。Cloud Run + Cloud Scheduler等、Vercel Cron以外のスケジューラへの移行を検討中
+
 ### 環境変数
 
 | 変数名 | デフォルト | 説明 |

--- a/docs/infra/env-setup-gmail-cron.md
+++ b/docs/infra/env-setup-gmail-cron.md
@@ -185,6 +185,18 @@ Vercel ダッシュボード → プロジェクト選択 → **Settings → Env
 
 Vercel ダッシュボード → プロジェクト → **Cron Jobs** タブから手動実行できる（Pro プラン以上）。
 
+### 既知のギャップ: parse-order-pdfs が未登録 (#259)
+
+現在 `frontend/vercel.json` には `gmail-poll` のみ登録されており、PDF添付メールの受注確定を行う
+`GET /api/cron/parse-order-pdfs` はどのスケジューラにも登録されていない。そのためPDF添付メールは
+Storageへのステージング保存までしか自動化されておらず、受注として起票するには手動で
+`parse-order-pdfs` を実行する必要がある（詳細な設計判断は [email-order-intake.md](../features/email-order-intake.md) の
+「2段階Cronのスケジューリング設計」を参照）。
+
+`parse-order-pdfs` は取りこぼしを避けるため5〜15分間隔程度の高頻度実行が望ましいが、
+Vercel Cronは無料（Hobby）プランでは実行回数制限（1日2回まで）があり要件を満たせない。
+そのため Cloud Run + Cloud Scheduler 等、Vercel Cron以外のスケジューラへの移行を検討中。
+
 ---
 
 ## ローカル開発での設定
@@ -237,3 +249,4 @@ curl -s http://localhost:8000/api/cron/gmail-poll \
 - #170: Secret Manager リソース管理（[secret-manager-terraform.md](secret-manager-terraform.md)）
 - #171: Gmail OAuth2 認証情報セットアップ（[gmail-oauth-setup.md](gmail-oauth-setup.md)）
 - #165 / #166 / #167: Gmail メール → 注文下書き自動作成パイプライン実装
+- #259: 2段階Cronの実行頻度に関する仕様整理・スケジューラ移行検討


### PR DESCRIPTION
## Summary
- 本番検証で `parse-order-pdfs` が `vercel.json` に未登録で自動実行されていないことが発覚
- Gmail起票パイプラインが `gmail-poll`（取得・ステージング）と `parse-order-pdfs`（受注確定）の2段階cronで構成されていること、両者の実行順序が前後しても `order_attachments` へのINSERTがアトミックなため「データ破損ではなく遅延」に留まる設計であることを `docs/features/email-order-intake.md` に明文化
- Vercel無料（Hobby）プランのcron実行回数制限（1日2回まで）が2段目の高頻度実行の制約になっており、Cloud Run等のスケジューラ移行を検討中であることを `docs/infra/env-setup-gmail-cron.md` に追記
- 本PRはドキュメント整備のみ。実際のスケジューラ移行・`parse-order-pdfs`登録は別Issueで対応予定

## Test plan
- [x] ドキュメントのみの変更のため、lint/testへの影響なし

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)