### PR TITLE
顧客が特定できないメール/PDF起票で下書き顧客を自動作成する

### DIFF
--- a/backend/__tests__/api/routers/master/test_customers_router.py
+++ b/backend/__tests__/api/routers/master/test_customers_router.py
@@ -111,6 +111,7 @@ class TestCustomerRouter:
             "id": customer_id,
             "name": "Updated Name",
             "alias": "A社",
+            "status": "active",
         }
 
         mock_repo.update.return_value = updated_data
@@ -120,11 +121,12 @@ class TestCustomerRouter:
         assert response.status_code == 200
         assert response.json() == updated_data
 
-        # exclude_unset=True が効いているか確認
+        # exclude_unset=True が効いていること、かつ status は常に 'active' に
+        # 上書きされること（下書き顧客の「確定」は専用ボタンではなく保存で行う仕様）
         mock_repo.update.assert_called_once()
         called_id, called_data = mock_repo.update.call_args[0]
         assert called_id == customer_id
-        assert called_data == payload
+        assert called_data == {"name": "Updated Name", "status": "active"}
 
     def test_delete_customer_success(self, mock_repo):
         """DELETE /{id}: 削除成功時のテスト"""

--- a/backend/__tests__/e2e/conftest.py
+++ b/backend/__tests__/e2e/conftest.py
@@ -200,7 +200,7 @@ def pdf_order_parsing_staging_row(
     # 実際のPDF送信元（飯野製作所）を模したE2Eテスト専用顧客。
     # resolve_or_create_customer は既存顧客があれば再利用するため、
     # 複数回のテスト実行で顧客レコードが増殖することはない。
-    customer_id = resolve_or_create_customer(
+    customer_id, _ = resolve_or_create_customer(
         admin_db, e2e_tenant_id, "e2e-pdf-parsing-test@example.com"
     )
 

--- a/backend/__tests__/unit/services/test_customer_matching_service.py
+++ b/backend/__tests__/unit/services/test_customer_matching_service.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock
+
+import pytest
+from app.services.customer_matching_service import (
+    extract_sender_email,
+    resolve_or_create_customer,
+)
+
+
+@pytest.mark.unit
+class TestExtractSenderEmail:
+    def test_extracts_email_from_english_forwarded_header(self):
+        body = "---------- Forwarded message ----------\nFrom: Taro Yamada <taro@example.com>\n"
+        assert extract_sender_email(body) == "taro@example.com"
+
+    def test_extracts_email_from_japanese_forwarded_header(self):
+        body = "差出人: taro@example.com\n宛先: ...\n"
+        assert extract_sender_email(body) == "taro@example.com"
+
+    def test_returns_none_when_no_forwarded_header(self):
+        assert extract_sender_email("こんにちは、注文をお願いします。") is None
+
+
+@pytest.mark.unit
+class TestResolveOrCreateCustomer:
+    def test_existing_customer_found_by_email_is_not_modified(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[{"id": 1}]
+        )
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", "known@example.com"
+        )
+
+        assert customer_id == 1
+        assert created_draft is False
+        # 既存顧客が見つかった場合は insert が呼ばれない（statusは変更しない）
+        mock_db.table().insert.assert_not_called()
+
+    def test_new_customer_with_email_is_created_as_draft(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[]
+        )
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 2}])
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", "new@example.com"
+        )
+
+        assert customer_id == 2
+        assert created_draft is True
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["status"] == "draft"
+        assert inserted_row["email"] == "new@example.com"
+        assert inserted_row["name"] == "new@example.com"
+
+    def test_no_email_always_creates_draft_with_placeholder_name(self):
+        mock_db = MagicMock()
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 3}])
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", None, "1751511600000"
+        )
+
+        assert customer_id == 3
+        assert created_draft is True
+        # 顧客検索は行われない（email が無いので紐付けようがない）
+        mock_db.table().select.assert_not_called()
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["status"] == "draft"
+        assert "email" not in inserted_row
+        assert inserted_row["name"].startswith("不明な顧客 (")
+
+    def test_no_email_and_no_received_at_falls_back_to_now(self):
+        mock_db = MagicMock()
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 4}])
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", None
+        )
+
+        assert customer_id == 4
+        assert created_draft is True
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["name"].startswith("不明な顧客 (")
+
+    def test_invalid_received_at_falls_back_to_now(self):
+        mock_db = MagicMock()
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 5}])
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", None, "not-a-timestamp"
+        )
+
+        assert customer_id == 5
+        assert created_draft is True
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["name"].startswith("不明な顧客 (")

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -96,7 +96,8 @@ class TestProcessMessagePdfStaging:
     def _mock_gmail_service(self):
         mock_service = MagicMock()
         mock_service.users().messages().get().execute.return_value = {
-            "payload": {"parts": []}
+            "payload": {"parts": []},
+            "internalDate": "1751500000000",
         }
         return mock_service
 
@@ -125,7 +126,7 @@ class TestProcessMessagePdfStaging:
             ),
             patch(
                 "app.services.gmail_service.resolve_or_create_customer",
-                return_value=42,
+                return_value=(42, False),
             ) as mock_resolve_customer,
             patch(
                 "app.services.gmail_service.upload_staged_attachment",
@@ -148,7 +149,7 @@ class TestProcessMessagePdfStaging:
             mock_db, "tenant-1", "msg-1", "order.pdf", b"%PDF-1.4", "application/pdf"
         )
         mock_resolve_customer.assert_called_once_with(
-            mock_db, "tenant-1", "customer@example.com"
+            mock_db, "tenant-1", "customer@example.com", "1751500000000"
         )
 
         inserted_row = mock_db.table("order_attachments").insert.call_args.args[0]
@@ -196,6 +197,10 @@ class TestProcessMessagePdfStaging:
                 return_value={"product_id": None, "candidates": []},
             ),
             patch(
+                "app.services.gmail_service.resolve_or_create_customer",
+                return_value=(7, True),
+            ) as mock_resolve_customer,
+            patch(
                 "app.services.gmail_service.upload_attachment",
                 return_value="tenant-1/orders/99/def.txt",
             ) as mock_upload,
@@ -208,6 +213,20 @@ class TestProcessMessagePdfStaging:
         # 既存フロー: 添付が非PDFなら即時orderが作成され、ステージング保存は呼ばれない
         mock_upload_staged.assert_not_called()
         mock_upload.assert_called_once()
+
+        # メールアドレスが取れない場合も customer_id は必ず設定され、下書き作成の通知が記録される
+        mock_resolve_customer.assert_called_once_with(
+            mock_db, "tenant-1", None, "1751500000000"
+        )
+        notif_inserts = [
+            call.args[0]
+            for call in mock_db.table("notifications").insert.call_args_list
+            if call.args and "notif_type" in call.args[0]
+        ]
+        assert len(notif_inserts) == 1
+        assert notif_inserts[0]["notif_type"] == "customer_draft_created"
+        assert notif_inserts[0]["source_id"] == "msg-2"
+        assert notif_inserts[0]["detail"]["customer_id"] == 7
         assert any(
             call.args and call.args[0] == "orders"
             for call in mock_db.table.call_args_list

--- a/backend/app/models/master/customer_schemas.py
+++ b/backend/app/models/master/customer_schemas.py
@@ -26,6 +26,9 @@ class Customer(CustomerBase):
     """読み取り用顧客のスキーマ"""
 
     id: int
+    status: str = Field(
+        default="active", description="顧客ステータス: active(登録済み), draft(下書き)"
+    )
 
 
 class CustomerUpdateSchema(BaseSchema):

--- a/backend/app/routers/master/customers.py
+++ b/backend/app/routers/master/customers.py
@@ -44,9 +44,12 @@ def update_customer(
     customer_data: CustomerUpdateSchema,
     repo: CustomerRepository = Depends(get_customer_repo),
 ):
-    """顧客を更新"""
+    """顧客を更新。専用の「確定」ボタンは設けず、保存するだけで下書きが解除される
+    （status は常に 'active' に上書きする）"""
     logger.info(f"Updating customer {customer_id}")
-    return repo.update(customer_id, customer_data.model_dump(exclude_unset=True))
+    update_data = customer_data.model_dump(exclude_unset=True)
+    update_data["status"] = "active"
+    return repo.update(customer_id, update_data)
 
 
 @customer_router.delete("/{customer_id}")

--- a/backend/app/services/customer_matching_service.py
+++ b/backend/app/services/customer_matching_service.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from typing import Any, cast
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
@@ -20,31 +21,57 @@ def extract_sender_email(body: str) -> str | None:
     return m.group(1) if m else None
 
 
-def resolve_or_create_customer(db: Client, tenant_id: str, email: str) -> int:
+def _placeholder_customer_name(received_at: str | int | None) -> str:
+    """メールの受信日時（Gmail internalDate、epoch millis）から仮の顧客名を組み立てる。"""
+    dt = datetime.now()
+    if received_at is not None:
+        try:
+            dt = datetime.fromtimestamp(int(received_at) / 1000)
+        except (ValueError, TypeError, OSError):
+            pass
+    return f"不明な顧客 ({dt.strftime('%Y-%m-%d %H:%M')})"
+
+
+def resolve_or_create_customer(
+    db: Client,
+    tenant_id: str,
+    email: str | None,
+    received_at: str | int | None = None,
+) -> tuple[int, bool]:
     """
-    メールアドレスで顧客を検索し、存在すれば customer_id を返す。
-    存在しなければ顧客を自動作成して返す。
+    メールアドレスで顧客を検索し、存在すれば customer_id を返す（status は変更しない）。
+    存在しなければ status='draft' の下書き顧客を自動作成して返す。
+    email が None の場合は既存顧客と紐付けようがないため、常に新規の下書き顧客を作成する
+    （name は受信日時ベースのプレースホルダー）。
+
+    Returns: (customer_id, 新規に下書き作成したかどうか)
     """
     table = SupabaseTableName.CUSTOMERS.value
-    result = (
-        db.table(table)
-        .select("id")
-        .eq("tenant_id", tenant_id)
-        .eq("email", email)
-        .limit(1)
-        .execute()
-    )
-    rows = cast(list[dict[str, Any]], result.data or [])
-    if rows:
-        logger.info(f"customer found: id={rows[0]['id']} email={email}")
-        return int(rows[0]["id"])
 
-    created = (
-        db.table(table)
-        .insert({"tenant_id": tenant_id, "email": email, "name": email})
-        .execute()
-    )
+    if email:
+        result = (
+            db.table(table)
+            .select("id")
+            .eq("tenant_id", tenant_id)
+            .eq("email", email)
+            .limit(1)
+            .execute()
+        )
+        rows = cast(list[dict[str, Any]], result.data or [])
+        if rows:
+            logger.info(f"customer found: id={rows[0]['id']} email={email}")
+            return int(rows[0]["id"]), False
+
+    insert_row: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "name": email if email else _placeholder_customer_name(received_at),
+        "status": "draft",
+    }
+    if email:
+        insert_row["email"] = email
+
+    created = db.table(table).insert(insert_row).execute()
     created_rows = cast(list[dict[str, Any]], created.data or [])
     new_id = int(created_rows[0]["id"])
-    logger.info(f"customer auto-created: id={new_id} email={email}")
-    return new_id
+    logger.info(f"draft customer auto-created: id={new_id} email={email}")
+    return new_id, True

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -182,11 +182,18 @@ def _process_message(
             # PDF添付メール: orderは作成せず、order_attachments にステージング保存する
             # （パースして複数orderを生成する処理は後続Issueで実装）
             sender_email = extract_sender_email(body)
-            customer_id = (
-                resolve_or_create_customer(db, tenant_id, sender_email)
-                if sender_email
-                else None
+            customer_id, created_draft = resolve_or_create_customer(
+                db, tenant_id, sender_email, msg.get("internalDate")
             )
+            if created_draft:
+                create_notification(
+                    db,
+                    tenant_id,
+                    "customer_draft_created",
+                    "gmail_message",
+                    msg_id,
+                    {"customer_id": customer_id, "email": sender_email},
+                )
 
             storage_path = upload_staged_attachment(
                 db,
@@ -257,10 +264,19 @@ def _process_message(
             candidates = match["candidates"]
 
         # 7. 顧客マッチング
-        customer_id = None
         sender_email = extract_sender_email(body)
-        if sender_email:
-            customer_id = resolve_or_create_customer(db, tenant_id, sender_email)
+        customer_id, created_draft = resolve_or_create_customer(
+            db, tenant_id, sender_email, msg.get("internalDate")
+        )
+        if created_draft:
+            create_notification(
+                db,
+                tenant_id,
+                "customer_draft_created",
+                "gmail_message",
+                msg_id,
+                {"customer_id": customer_id, "email": sender_email},
+            )
 
         # 8. ドラフト注文を Supabase に登録
         order_row: dict[str, Any] = {

--- a/docs/features/customer-draft-auto-create.md
+++ b/docs/features/customer-draft-auto-create.md
@@ -1,0 +1,128 @@
+# 顧客が特定できないメール/PDF起票での下書き顧客自動作成（Issue #263）
+
+メール/PDF起票で送信者の顧客が特定できない場合に `customer_id` が NULL のまま起票されてしまう
+問題（#262 の根本原因の一つ）を解消する。顧客情報を事前に登録していなくても、下書き状態の
+顧客を自動作成して `customer_id` を必ず設定し、担当者が後から手直しするだけで受注登録が
+完結する体験にする。
+
+---
+
+## 背景と目的
+
+- メールアドレスが本文から抽出できない場合でも、注文起票時に `customer_id` を必ず設定する
+  （NULL のまま残さない）
+- 自動作成された顧客は「下書き」であることを明示し、担当者が後で正しい顧客情報に
+  手直しできるようにする
+- 従来「メールアドレスは分かるが未登録」の顧客も無自覚に自動作成されており
+  （`resolve_or_create_customer`）、正規登録の顧客と区別がつかなかった。これも下書き扱いに揃える
+
+---
+
+## DBスキーマ変更
+
+### `customers.status` 追加 (`20260704000000_add_customer_status.sql`)
+
+```sql
+alter table customers
+add column status text not null default 'active'
+check (status in ('active', 'draft'));
+```
+
+`orders.status` と同じ命名パターン（`text` + CHECK制約 + comment）。既存の全顧客は
+`default 'active'` によりそのまま `active` 扱いになり、既存データへの影響はない。
+
+### `notifications.notif_type` に `customer_draft_created` を追加
+
+(`20260704000001_add_customer_draft_created_notif_type.sql`)
+
+[notifications.md](notifications.md) の CHECK 制約に `customer_draft_created` を追加する
+（既存の6種類の列挙値に追加するだけで、テーブル自体の変更はなし）。
+
+---
+
+## バックエンド設計
+
+### `resolve_or_create_customer` の拡張 (`customer_matching_service.py`)
+
+```python
+def resolve_or_create_customer(
+    db: Client,
+    tenant_id: str,
+    email: str | None,
+    received_at: str | int | None = None,
+) -> tuple[int, bool]:
+    ...
+```
+
+- 戻り値を `int`（customer_id）から `tuple[int, bool]`（customer_id, 新規に下書き作成したか）
+  に変更。呼び出し元が「下書きを作成したかどうか」を意識せず通知を出せるようにするため
+- `email` が既存顧客と一致した場合: 従来通りその `customer_id` を返す（`status` は変更しない）
+- `email` があり新規作成する場合: `status='draft'` で作成する
+- `email` が無い場合: 常に新規の下書き顧客を作成する。`name` は
+  `不明な顧客 (YYYY-MM-DD HH:MM)` 形式のプレースホルダーとし、`received_at`
+  （Gmailメッセージの `internalDate`、epoch millis）から算出する。取得できない・不正な値の場合は
+  処理実行時刻にフォールバックする
+
+### 呼び出し元 `gmail_service.py` の修正
+
+`_process_message` 内の PDF添付分岐・非PDF分岐の両方で、`sender_email` の有無に関わらず
+必ず `resolve_or_create_customer` を呼ぶように変更した（変更前は
+`if sender_email else None` で丸ごとスキップされ `customer_id=None` になっていた）。
+
+いずれの分岐でも `msg.get("internalDate")` を `received_at` として渡し、下書き顧客が
+新規作成された場合は `create_notification` で `customer_draft_created` を記録する
+（`source_table="gmail_message"`, `source_id=msg_id`）。
+
+### 顧客編集フォームでの「確定」(`routers/master/customers.py`)
+
+`PATCH /customers/{id}` (`update_customer`) は、リクエストの更新内容に関わらず `status` を
+強制的に `'active'` に上書きして保存する。専用の「確定」ボタンは設けず、既存の編集フォームで
+保存するだけで下書き解除される仕様とした。
+
+### レスポンススキーマ
+
+`Customer`（読み取り用スキーマ、`models/master/customer_schemas.py`）に
+`status: str = "active"` を追加し、フロントエンドで下書き判定できるようにした。
+`CustomerCreateSchema` / `CustomerUpdateSchema` には追加していない
+（`status` は常にサーバー側ロジックで決まり、クライアントから直接指定する経路がないため）。
+
+---
+
+## フロントエンド設計
+
+- `frontend/src/types/customer.ts`: `Customer.status: "active" | "draft"` を追加
+- `frontend/src/app/master/customers/page.tsx`: 顧客一覧テーブルの顧客名セルに
+  `status === "draft"` の場合 `Badge variant="secondary"` で「下書き」を表示
+- `frontend/src/components/customer-selector.tsx`: 顧客選択コンボボックスの各選択肢にも
+  同様に「下書き」バッジを表示
+
+---
+
+## 受け入れ条件
+
+- [x] メールアドレスが抽出できないメール/PDF起票でも `customer_id` が必ず設定され、
+      対応する顧客が `status='draft'` で作成されること
+- [x] メールアドレスがあるが未登録だった場合も、自動作成された顧客が `status='draft'` になること
+- [x] 下書き顧客作成時に通知（`customer_draft_created`）が記録されること
+- [x] 顧客一覧・セレクターで下書き顧客が視覚的に区別できること
+- [x] 既存の顧客編集フォームで保存すると `status` が `active` になること
+- [x] 既存のテストをパスし、新規ロジックのユニットテストを追加すること
+      (`__tests__/unit/services/test_customer_matching_service.py`)
+- [x] 型・Lint エラーが出ていないこと
+
+---
+
+## スコープ外（このIssueではやらない）
+
+- `_mark_superseded_orders` の NULL customer_id ハンドリング自体のバグ修正（#262 で対応予定）
+- 下書き顧客専用の「確定」ボタンや一括確定UI
+- 顧客詳細ページの新設（現状は一覧ページの編集ダイアログのみ）
+
+---
+
+## 関連
+
+- [email-order-intake.md](email-order-intake.md): メール起票の基盤設計、`customer_matching_service.py` の位置づけ
+- [notifications.md](notifications.md): `notifications` テーブル・`create_notification` の共通設計
+- Issue #262: `customer_id=NULL` によるbigint型エラー（本Issueで新規発生分はほぼ解消見込み）
+- Issue #259, #168: 関連Issue

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -265,6 +265,8 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 - 注文番号は解析できた場合のみ設定し、不明な場合は NULL のまま起票する
 - `source_raw` にはメール本文全体を保存するため、個人情報の取り扱いに注意すること
 - 製品マッチングで候補が複数ある場合、`product_candidates` に候補リストが保存され、`product_id` は NULL になる
+- 顧客が特定できない場合でも `customer_id` は必ず設定される（下書き顧客の自動作成）。
+  詳細は [customer-draft-auto-create.md](customer-draft-auto-create.md) を参照
 
 ---
 

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -57,6 +57,7 @@ CREATE TABLE notifications (
 | `failed_encrypted` | `pdf_order_parsing_service._parse_one` | `order_attachments` | `attachment_id` |
 | `failed_image` | 同上 | `order_attachments` | `attachment_id` |
 | `non_order_email` | `gmail_service._process_message` | `gmail_message` | Gmail `msg_id` |
+| `customer_draft_created` | `resolve_or_create_customer` 呼び出し元（`gmail_service._process_message`）| `gmail_message` | Gmail `msg_id` |
 
 ---
 
@@ -185,5 +186,7 @@ cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-in
 - [email-order-intake.md](email-order-intake.md): メール起票の基盤設計
 - [order-attachments.md](order-attachments.md): `order_attachments` テーブル・`parse_status`
   の定義（`failed_encrypted` / `failed_image` の発生元、対象外メール検知時の挙動変更）
+- [customer-draft-auto-create.md](customer-draft-auto-create.md): `customer_draft_created`
+  の追加（Issue #263）
 - Issue #249, #252: `order_parse_log` への記録処理（本Issueの通知発生元）
 - Issue #256: integrationテスト追加（RLS/IDOR回帰）

--- a/frontend/src/app/master/customers/page.tsx
+++ b/frontend/src/app/master/customers/page.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteCustomer,
 } from "@/hooks/use-customers"
 import type { Customer } from "@/types/customer"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -201,7 +202,14 @@ export default function CustomersPage() {
                 customers.map((customer) => (
                   <TableRow key={customer.id}>
                     <TableCell className="font-medium">{customer.id}</TableCell>
-                    <TableCell>{customer.name}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {customer.name}
+                        {customer.status === "draft" && (
+                          <Badge variant="secondary">下書き</Badge>
+                        )}
+                      </div>
+                    </TableCell>
                     <TableCell>{customer.alias || "-"}</TableCell>
                     <TableCell>{customer.representative_name || "-"}</TableCell>
                     <TableCell>{customer.phone_number || "-"}</TableCell>

--- a/frontend/src/components/customer-selector.tsx
+++ b/frontend/src/components/customer-selector.tsx
@@ -52,7 +52,11 @@ export function CustomerSelector({
             <>
               <SelectItem value={CLEAR_SELECTION_VALUE}>選択を解除</SelectItem>
               {customers.map((customer) => (
-                <SelectItem key={customer.id} value={customer.id.toString()}>
+                <SelectItem
+                  key={customer.id}
+                  value={customer.id.toString()}
+                  textValue={customer.name}
+                >
                   <span className="flex items-center gap-2">
                     {customer.name}
                     {customer.status === "draft" && (

--- a/frontend/src/components/customer-selector.tsx
+++ b/frontend/src/components/customer-selector.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useCustomers } from "@/hooks/use-customers"
+import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
 
 interface CustomerSelectorProps {
@@ -52,7 +53,12 @@ export function CustomerSelector({
               <SelectItem value={CLEAR_SELECTION_VALUE}>選択を解除</SelectItem>
               {customers.map((customer) => (
                 <SelectItem key={customer.id} value={customer.id.toString()}>
-                  {customer.name}
+                  <span className="flex items-center gap-2">
+                    {customer.name}
+                    {customer.status === "draft" && (
+                      <Badge variant="secondary">下書き</Badge>
+                    )}
+                  </span>
                 </SelectItem>
               ))}
             </>

--- a/frontend/src/types/customer.ts
+++ b/frontend/src/types/customer.ts
@@ -8,6 +8,7 @@ export interface Customer {
   representative_name?: string
   phone_number?: string
   email?: string
+  status: "active" | "draft"
   tenant_id: string
   created_at: string
   updated_at: string

--- a/supabase/migrations/20260704000000_add_customer_status.sql
+++ b/supabase/migrations/20260704000000_add_customer_status.sql
@@ -1,0 +1,9 @@
+-- Add status column to customers table (Issue #263)
+-- メール/PDF起票で顧客が特定できない場合に自動作成される「下書き」顧客を
+-- 正規登録の顧客と区別するためのフラグ。既存の全顧客は default 'active' により
+-- そのまま active 扱いになる（マイグレーションによる既存データへの影響なし）。
+alter table customers
+add column status text not null default 'active'
+check (status in ('active', 'draft'));
+
+comment on column customers.status is '顧客ステータス: active(登録済み), draft(自動作成された下書き。手直しして保存すると active になる)';

--- a/supabase/migrations/20260704000001_add_customer_draft_created_notif_type.sql
+++ b/supabase/migrations/20260704000001_add_customer_draft_created_notif_type.sql
@@ -1,0 +1,10 @@
+-- Allow 'customer_draft_created' as a notif_type (Issue #263)
+-- メール/PDF起票で顧客が特定できず下書き顧客を自動作成した際、担当者向けに記録する通知。
+alter table notifications drop constraint notifications_notif_type_check;
+
+alter table notifications
+add constraint notifications_notif_type_check
+check (notif_type in (
+  'no_product_match', 'downgrade_skipped', 'draft_conflict_skipped',
+  'failed_encrypted', 'failed_image', 'non_order_email', 'customer_draft_created'
+));


### PR DESCRIPTION
## Summary
- `customers.status` カラムを追加（`active` / `draft`、既存データは全て `active` のまま）
- `resolve_or_create_customer` を拡張し、送信者メールアドレスの有無に関わらず必ず `customer_id` を返すように変更。新規作成分は `status='draft'` とする
- `gmail_service.py` の PDF添付分岐・非PDF分岐の両方で、`sender_email` が無くても必ず顧客解決を呼ぶよう修正（従来は `customer_id=None` のまま起票されていた）
- 下書き顧客の新規作成時に `customer_draft_created` 通知を記録
- `PATCH /customers/{id}` で保存すると `status` が強制的に `active` になる（専用の「確定」ボタンは設けない仕様）
- フロントエンド（顧客一覧・顧客セレクター）に「下書き」バッジを追加
- `docs/features/customer-draft-auto-create.md` を新規作成し、関連ドキュメント（`email-order-intake.md`, `notifications.md`）から相互リンク

Closes #263

## Test plan
- [x] `backend/__tests__/unit/services/test_customer_matching_service.py`（新規）: `resolve_or_create_customer` の全分岐（既存顧客/新規作成/emailなし/received_atなし・不正値）
- [x] `backend/__tests__/unit/services/test_gmail_service.py`: PDF/非PDF両分岐での呼び出し・通知記録を更新
- [x] `backend/__tests__/api/routers/master/test_customers_router.py`: PATCH で `status` が強制上書きされることを検証
- [x] `ruff check` / `mypy` / `tsc --noEmit` / `eslint` すべてパス
- [ ] ローカル Supabase でマイグレーション適用・実際の顧客作成/編集フローの目視確認（レビュー時に実施推奨）