### PR TITLE
fix(#267): メール/PDF受注起票のstatusを常にdraftにし顧客側確度と分離

### DIFF
--- a/.vscode/pp-words.txt
+++ b/.vscode/pp-words.txt
@@ -6,3 +6,5 @@ creds
 googleapiclient
 gantt
 autouse
+trgm
+pdfs

--- a/backend/__tests__/e2e/test_pdf_order_parsing_flow.py
+++ b/backend/__tests__/e2e/test_pdf_order_parsing_flow.py
@@ -103,7 +103,14 @@ class TestPdfOrderParsingFlow:
         )
         for order in orders_for_existing_product:
             assert order["quantity"] == 15000
-            assert order["status"] in ("confirmed", "forecast", "forecast_tentative")
+            # メール/PDF転送起票の注文は、顧客側の確度(customer_certainty)に
+            # 関わらず常に status='draft' で作成される (Issue #267)
+            assert order["status"] == "draft"
+            assert order["customer_certainty"] in (
+                "confirmed",
+                "forecast",
+                "forecast_tentative",
+            )
             assert order["customer_id"] == pdf_order_parsing_staging_row["customer_id"]
 
         deadline_dates = {

--- a/backend/__tests__/integration/test_order_upsert_by_dedupe_key.py
+++ b/backend/__tests__/integration/test_order_upsert_by_dedupe_key.py
@@ -1,10 +1,15 @@
 """
-Integration テスト: 既存orderのupsert処理 (Issue #252)
+Integration テスト: 既存orderのupsert処理 (Issue #252, Issue #267で customer_certainty 分離)
 
-`upsert_order_by_dedupe_key` RPC のステータス優先順位判定・数量更新・
-draft/canceledの上書き除外は Claude API・Gmail APIの出力に依存しない
-決定的なSQLロジックのため、e2e (実PDF・実Claude API) ではなく
-integration tier (実Supabaseのみ) で検証する。
+`upsert_order_by_dedupe_key` RPC は、顧客側の確度 (`customer_certainty`:
+confirmed/forecast/forecast_tentative) と ProductPlanner側のワークフロー
+ステータス (`status`: draft/confirmed/completed/canceled) を分離して扱う。
+INSERT時は常に status='draft' で作成し、既存行が confirmed/completed/canceled、
+または手動下書き (status='draft' AND source_type='manual') の場合は自動更新
+から保護する。それ以外 (メール/PDF起票の確認待ちdraft) は customer_certainty
+の優先順位で upsert 判定を行う。
+このロジックはClaude API・Gmail APIの出力に依存しない決定的なSQLロジックのため、
+e2e (実PDF・実Claude API) ではなく integration tier (実Supabaseのみ) で検証する。
 詳細な方針は __tests__/e2e/CLAUDE.md, __tests__/integration/CLAUDE.md を参照。
 
 実行:
@@ -28,7 +33,7 @@ def _upsert(
     product_id: int,
     quantity: int,
     deadline_date: str,
-    status: str,
+    certainty: str,
 ) -> dict[str, Any]:
     result = admin_db.rpc(
         "upsert_order_by_dedupe_key",
@@ -38,7 +43,7 @@ def _upsert(
             "p_product_id": product_id,
             "p_quantity": quantity,
             "p_deadline_date": deadline_date,
-            "p_status": status,
+            "p_customer_certainty": certainty,
             "p_source_type": "email",
             "p_source_raw": "integration-test upsert_order_by_dedupe_key",
             "p_extracted_product_name": "integration test product",
@@ -90,7 +95,9 @@ def dedupe_fixture(admin_db):
 
 @pytest.mark.integration
 class TestUpsertOrderByDedupeKey:
-    def test_inserts_new_order_when_no_existing_match(self, admin_db, dedupe_fixture):
+    def test_inserts_new_order_as_draft_with_customer_certainty(
+        self, admin_db, dedupe_fixture
+    ):
         result = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
@@ -98,23 +105,27 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         assert result["action"] == "inserted"
 
         order = (
             admin_db.table("orders")
-            .select("status, quantity")
+            .select("status, customer_certainty, quantity")
             .eq("id", result["order_id"])
             .single()
             .execute()
             .data
         )
-        assert order["status"] == "forecast"
+        # INSERT時は顧客側の確度に関わらず常に status='draft' で作成される
+        assert order["status"] == "draft"
+        assert order["customer_certainty"] == "forecast"
         assert order["quantity"] == 10
 
-    def test_forecast_is_upgraded_to_confirmed(self, admin_db, dedupe_fixture):
+    def test_certainty_forecast_is_upgraded_to_confirmed_without_changing_status(
+        self, admin_db, dedupe_fixture
+    ):
         first = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
@@ -122,7 +133,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         second = _upsert(
@@ -132,7 +143,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="confirmed",
+            certainty="confirmed",
         )
 
         assert second["action"] == "updated"
@@ -140,13 +151,16 @@ class TestUpsertOrderByDedupeKey:
 
         order = (
             admin_db.table("orders")
-            .select("status")
+            .select("status, customer_certainty")
             .eq("id", first["order_id"])
             .single()
             .execute()
             .data
         )
-        assert order["status"] == "confirmed"
+        # customer_certainty は昇格するが、status はユーザーの確定操作なしに
+        # 変化してはならない
+        assert order["status"] == "draft"
+        assert order["customer_certainty"] == "confirmed"
 
     def test_quantity_only_change_updates_existing_order(
         self, admin_db, dedupe_fixture
@@ -158,7 +172,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         second = _upsert(
@@ -168,7 +182,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=25,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         assert second["action"] == "updated"
@@ -181,12 +195,12 @@ class TestUpsertOrderByDedupeKey:
             .execute()
             .data
         )
-        assert order["status"] == "forecast"
+        assert order["status"] == "draft"
         assert order["quantity"] == 25
 
-    def test_confirmed_existing_rejects_forecast_downgrade(
-        self, admin_db, dedupe_fixture
-    ):
+    def test_confirmed_existing_rejects_any_update(self, admin_db, dedupe_fixture):
+        """ユーザーが /orders/{id}/confirm で確定させた注文 (status='confirmed') は
+        PDF自動処理から完全に保護され、certainty='confirmed' の再取込でも上書きされない。"""
         first = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
@@ -194,8 +208,12 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="confirmed",
+            certainty="confirmed",
         )
+        # confirm_order 相当の操作をシミュレート
+        admin_db.table("orders").update(
+            {"status": "confirmed", "confirmed_at": datetime.now(UTC).isoformat()}
+        ).eq("id", first["order_id"]).execute()
 
         second = _upsert(
             admin_db,
@@ -204,7 +222,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=999,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="confirmed",
         )
 
         assert second["action"] == "skipped_downgrade"
@@ -231,10 +249,12 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="completed",
+            certainty="confirmed",
         )
+        admin_db.table("orders").update({"status": "completed"}).eq(
+            "id", first["order_id"]
+        ).execute()
 
-        # completed 同士でも数量差分だけでは上書きしない
         second = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
@@ -242,7 +262,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=999,
             deadline_date=_FUTURE_DEADLINE,
-            status="completed",
+            certainty="confirmed",
         )
 
         assert second["action"] == "skipped_downgrade"
@@ -266,7 +286,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
         admin_db.table("orders").update({"status": "canceled"}).eq(
             "id", first["order_id"]
@@ -279,7 +299,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=999,
             deadline_date=_FUTURE_DEADLINE,
-            status="confirmed",
+            certainty="confirmed",
         )
 
         assert second["action"] == "skipped_downgrade"
@@ -295,21 +315,26 @@ class TestUpsertOrderByDedupeKey:
         assert order["status"] == "canceled"
         assert order["quantity"] == 10
 
-    def test_draft_existing_always_conflicts(self, admin_db, dedupe_fixture):
-        first = _upsert(
-            admin_db,
-            dedupe_fixture["tenant_id"],
-            dedupe_fixture["customer_id"],
-            dedupe_fixture["product_id"],
-            quantity=10,
-            deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+    def test_manual_draft_existing_always_conflicts(self, admin_db, dedupe_fixture):
+        """手動起票 (source_type='manual') の下書きは、メール/PDF自動処理からの
+        上書きを一切許さない。"""
+        manual_order = (
+            admin_db.table("orders")
+            .insert(
+                {
+                    "tenant_id": dedupe_fixture["tenant_id"],
+                    "customer_id": dedupe_fixture["customer_id"],
+                    "product_id": dedupe_fixture["product_id"],
+                    "quantity": 10,
+                    "deadline_date": _FUTURE_DEADLINE,
+                    "status": "draft",
+                    "source_type": "manual",
+                }
+            )
+            .execute()
         )
-        admin_db.table("orders").update({"status": "draft"}).eq(
-            "id", first["order_id"]
-        ).execute()
+        manual_order_id = cast(list[dict[str, Any]], manual_order.data)[0]["id"]
 
-        # draft は昇格方向 (forecast -> confirmed) の更新でも常にコンフリクト扱い
         second = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
@@ -317,21 +342,23 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=999,
             deadline_date=_FUTURE_DEADLINE,
-            status="confirmed",
+            certainty="confirmed",
         )
 
         assert second["action"] == "skipped_draft_conflict"
+        assert second["order_id"] == manual_order_id
 
         order = (
             admin_db.table("orders")
-            .select("status, quantity")
-            .eq("id", first["order_id"])
+            .select("status, quantity, customer_certainty")
+            .eq("id", manual_order_id)
             .single()
             .execute()
             .data
         )
         assert order["status"] == "draft"
         assert order["quantity"] == 10
+        assert order["customer_certainty"] is None
 
     def test_exact_duplicate_is_skipped_without_change(self, admin_db, dedupe_fixture):
         first = _upsert(
@@ -341,7 +368,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         second = _upsert(
@@ -351,7 +378,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         assert second["action"] == "skipped_no_change"
@@ -368,7 +395,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
         second = _upsert(
             admin_db,
@@ -377,7 +404,7 @@ class TestUpsertOrderByDedupeKey:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE_2,
-            status="forecast",
+            certainty="forecast",
         )
 
         assert second["action"] == "inserted"
@@ -388,7 +415,7 @@ class TestUpsertOrderByDedupeKey:
 class TestMarkSupersededOrders:
     """
     _mark_superseded_orders はPDFパースサービス内のPython関数だが、実DBに対する
-    UPDATEクエリチェーンの組み合わせ (.eq/.neq/.gt/.in_/.is_) が意図通りかは
+    UPDATEクエリチェーン (.eq/.neq/.gt/.in_/.is_) が意図通りかは
     実DBでの検証が必要なため integration tier に置く。
     """
 
@@ -404,7 +431,7 @@ class TestMarkSupersededOrders:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
 
         _mark_superseded_orders(
@@ -426,17 +453,22 @@ class TestMarkSupersededOrders:
         assert order["superseded_at"] is not None
 
     def test_confirmed_order_is_not_superseded(self, admin_db, dedupe_fixture):
+        """status='confirmed'（ユーザー確定済み）の注文は、customer_certainty の値に
+        関わらずsupersedeされない。"""
         from app.services.pdf_order_parsing_service import _mark_superseded_orders
 
-        confirmed = _upsert(
+        order_row = _upsert(
             admin_db,
             dedupe_fixture["tenant_id"],
             dedupe_fixture["customer_id"],
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="confirmed",
+            certainty="forecast",
         )
+        admin_db.table("orders").update(
+            {"status": "confirmed", "confirmed_at": datetime.now(UTC).isoformat()}
+        ).eq("id", order_row["order_id"]).execute()
 
         _mark_superseded_orders(
             admin_db,
@@ -449,7 +481,7 @@ class TestMarkSupersededOrders:
         order = (
             admin_db.table("orders")
             .select("superseded_at")
-            .eq("id", confirmed["order_id"])
+            .eq("id", order_row["order_id"])
             .single()
             .execute()
             .data
@@ -471,7 +503,7 @@ class TestMarkSupersededOrders:
             dedupe_fixture["product_id"],
             quantity=10,
             deadline_date=_FUTURE_DEADLINE,
-            status="forecast",
+            certainty="forecast",
         )
         _mark_superseded_orders(
             admin_db,

--- a/backend/__tests__/integration/test_order_upsert_by_dedupe_key.py
+++ b/backend/__tests__/integration/test_order_upsert_by_dedupe_key.py
@@ -360,6 +360,52 @@ class TestUpsertOrderByDedupeKey:
         assert order["quantity"] == 10
         assert order["customer_certainty"] is None
 
+    def test_email_draft_without_certainty_is_upgraded(self, admin_db, dedupe_fixture):
+        """本文のみのメール起票 (gmail_service.py 経由) は customer_certainty=NULL の
+        draft注文として作成される。これに対する後続のPDF取込は、NULLを最も低い
+        優先度として扱い、正しく確度・数量を更新できる。"""
+        email_order = (
+            admin_db.table("orders")
+            .insert(
+                {
+                    "tenant_id": dedupe_fixture["tenant_id"],
+                    "customer_id": dedupe_fixture["customer_id"],
+                    "product_id": dedupe_fixture["product_id"],
+                    "quantity": 10,
+                    "deadline_date": _FUTURE_DEADLINE,
+                    "status": "draft",
+                    "source_type": "email",
+                }
+            )
+            .execute()
+        )
+        email_order_id = cast(list[dict[str, Any]], email_order.data)[0]["id"]
+
+        second = _upsert(
+            admin_db,
+            dedupe_fixture["tenant_id"],
+            dedupe_fixture["customer_id"],
+            dedupe_fixture["product_id"],
+            quantity=999,
+            deadline_date=_FUTURE_DEADLINE,
+            certainty="forecast_tentative",
+        )
+
+        assert second["action"] == "updated"
+        assert second["order_id"] == email_order_id
+
+        order = (
+            admin_db.table("orders")
+            .select("status, quantity, customer_certainty")
+            .eq("id", email_order_id)
+            .single()
+            .execute()
+            .data
+        )
+        assert order["status"] == "draft"
+        assert order["quantity"] == 999
+        assert order["customer_certainty"] == "forecast_tentative"
+
     def test_exact_duplicate_is_skipped_without_change(self, admin_db, dedupe_fixture):
         first = _upsert(
             admin_db,

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -270,7 +270,7 @@ class TestProcessLineItem:
         assert rpc_call_args.args[0] == "upsert_order_by_dedupe_key"
         rpc_params = rpc_call_args.args[1]
         assert rpc_params["p_product_id"] == 100
-        assert rpc_params["p_status"] == "forecast"
+        assert rpc_params["p_customer_certainty"] == "forecast"
         assert rpc_params["p_customer_id"] == 7
 
         attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -278,6 +278,32 @@ class TestProcessLineItem:
         assert attachment_insert["parse_status"] == "success"
         assert attachment_insert["storage_path"] == "tenant-1/inbox/msg-1/order.pdf"
 
+    def test_unknown_certainty_falls_back_to_forecast_tentative(self):
+        """Claude抽出結果が想定外の値（揺れ・スキーマ変更等）を返した場合でも、
+        orders.customer_certainty のCHECK制約に違反しないよう
+        forecast_tentative にフォールバックしてRPCへ渡すこと。"""
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 555, "action": "inserted"}]
+        )
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "予定",  # 許容値(confirmed/forecast/forecast_tentative)以外
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is True
+        rpc_params = mock_db.rpc.call_args_list[-1].args[1]
+        assert rpc_params["p_customer_certainty"] == "forecast_tentative"
+
     def test_inserted_order_marks_superseded_orders(self):
         """新規orderが挿入された場合、同一(tenant,customer,product)で
         別deadline_dateの旧forecastレコードにsuperseded_atがセットされること。"""

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -12,6 +12,8 @@ from supabase import Client
 
 logger = get_logger(__name__)
 
+_VALID_CUSTOMER_CERTAINTIES = {"confirmed", "forecast", "forecast_tentative"}
+
 _KNOWN_UPSERT_ACTIONS = {
     "inserted",
     "updated",
@@ -146,7 +148,14 @@ def _process_line_item(
         )
         return False
 
-    certainty = cast(str | None, line.get("certainty")) or "forecast_tentative"
+    certainty_raw = cast(str | None, line.get("certainty"))
+    # Claude抽出結果の揺れ・想定外値でも orders.customer_certainty のCHECK制約に
+    # 違反してRPCが失敗しないよう、許容値以外は最も確度が低い値にフォールバックする
+    certainty = (
+        certainty_raw
+        if certainty_raw in _VALID_CUSTOMER_CERTAINTIES
+        else "forecast_tentative"
+    )
     deadline_date = line.get("delivery_date")
 
     rpc_result = db.rpc(

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -12,12 +12,6 @@ from supabase import Client
 
 logger = get_logger(__name__)
 
-_CERTAINTY_TO_STATUS = {
-    "confirmed": "confirmed",
-    "forecast": "forecast",
-    "forecast_tentative": "forecast_tentative",
-}
-
 _KNOWN_UPSERT_ACTIONS = {
     "inserted",
     "updated",
@@ -152,8 +146,7 @@ def _process_line_item(
         )
         return False
 
-    certainty = cast(str | None, line.get("certainty"))
-    status = _CERTAINTY_TO_STATUS.get(certainty or "", "forecast_tentative")
+    certainty = cast(str | None, line.get("certainty")) or "forecast_tentative"
     deadline_date = line.get("delivery_date")
 
     rpc_result = db.rpc(
@@ -164,7 +157,7 @@ def _process_line_item(
             "p_product_id": product_id,
             "p_quantity": line.get("quantity"),
             "p_deadline_date": deadline_date,
-            "p_status": status,
+            "p_customer_certainty": certainty,
             "p_source_type": "email",
             "p_source_raw": staging_row.get("source_raw"),
             "p_extracted_product_name": product_name_raw,
@@ -262,7 +255,8 @@ def _mark_superseded_orders(
         .eq("product_id", product_id)
         .neq("deadline_date", deadline_date)
         .gt("deadline_date", datetime.now(UTC).date().isoformat())
-        .in_("status", ["forecast", "forecast_tentative"])
+        .eq("status", "draft")
+        .in_("customer_certainty", ["forecast", "forecast_tentative"])
         .is_("superseded_at", "null")
         .execute()
     )

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -261,12 +261,21 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 
 ### 注意事項
 
-- `source_type === 'email'` の注文は `draft` のまま起票される。人間がレビューして確定する運用を推奨
+- `source_type === 'email'` の注文は `status='draft'` のまま起票される。`status` が
+  `confirmed` に遷移するのはユーザーが `POST /orders/{id}/confirm` を実行した時のみで、
+  PDF添付メール経由（`pdf_order_parsing_service.py`）でも certainty の値に関わらず
+  常に `draft` で作成される。人間がレビューして確定する運用を徹底するための設計であり、
+  当初これが徹底されていなかった不具合の是正については
+  [pdf-order-parsing.md](pdf-order-parsing.md)（Issue #267）を参照
 - 注文番号は解析できた場合のみ設定し、不明な場合は NULL のまま起票する
 - `source_raw` にはメール本文全体を保存するため、個人情報の取り扱いに注意すること
 - 製品マッチングで候補が複数ある場合、`product_candidates` に候補リストが保存され、`product_id` は NULL になる
 - 顧客が特定できない場合でも `customer_id` は必ず設定される（下書き顧客の自動作成）。
   詳細は [customer-draft-auto-create.md](customer-draft-auto-create.md) を参照
+- PDF添付メール経由で起票された注文は、PDF文面から抽出した顧客側の確度（確定/内示/内々示）
+  を `orders.customer_certainty` に保持する。これは ProductPlanner側のワークフロー
+  ステータス（`status`）とは独立した参考情報であり、UI上は別バッジとして表示される。
+  詳細は [pdf-order-parsing.md](pdf-order-parsing.md) を参照
 
 ---
 

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -1,10 +1,15 @@
-# 受注PDF自動パース＋複数order生成（内示ステータス対応）
+# 受注PDF自動パース＋複数order生成（顧客側確度対応）
 
 [order-attachments.md](order-attachments.md) の PDF ステージング基盤（Issue #248）を前提に、
 ステージングされた PDF を実際にパースし、1ファイルに含まれる複数品番・複数納期の明細を、
-確度別ステータス（確定/内示/内々示）付きの複数 `orders` 行として自動生成する（Issue #249）。
-さらに、同一dedupeキーの既存orderが見つかった場合はステータス昇格・数量更新を行う
+複数 `orders` 行として自動生成する（Issue #249）。
+さらに、同一dedupeキーの既存orderが見つかった場合は数量更新を行う
 upsert処理に対応する（Issue #252）。
+
+PDF文面から抽出した確度（確定/内示/内々示）は `orders.customer_certainty` に「顧客側の
+参考情報」として保存し、ProductPlanner側のワークフローステータス（`orders.status`）とは
+独立に扱う。`status` は常に `draft` で作成され、`confirmed` への遷移はユーザーの確定操作
+（`POST /orders/{id}/confirm`）でのみ発生する（Issue #267、詳細後述）。
 
 ---
 
@@ -14,6 +19,12 @@ upsert処理に対応する（Issue #252）。
 Issue #248 により PDF添付メールは `order_attachments` に `order_id=NULL` のステージング行として
 保存されるようになったが、そこから実際の注文レコードを生成する処理は未実装だった。
 本Issueでこのパース処理を実装し、1PDFから複数の実注文レコードを正しく起票できるようにする。
+
+なお、当初（Issue #249/#252）は certainty をそのまま `orders.status` にマッピングしており、
+確定納期・PO番号が明記された明細（certainty='confirmed'）はユーザーの確認・確定操作なしに
+`status='confirmed'` として起票されてしまっていた。これは「メール/PDF転送起票は常に
+draftとし、ユーザーの確定操作でのみ確定させたい」という運用意図に反するバグであり、
+Issue #267 で `customer_certainty` カラムを新設して是正した。
 
 ---
 
@@ -43,12 +54,14 @@ Issue #248 により PDF添付メールは `order_attachments` に `order_id=NUL
         実在する `22760-63C-...` は pg_trgm 上高い類似度になる）、
         「候補1件のみ」は自動確定の根拠として弱いため
    b. すべて失敗した場合: order を生成せず order_parse_log に reason='no_product_match' で記録
-   c. certainty → orders.status へ1:1マッピング (confirmed/forecast/forecast_tentative)
+   c. certainty はそのまま orders.customer_certainty に保存する（confirmed/forecast/
+      forecast_tentative）。orders.status には反映しない（Issue #267）
    d. customer_id はステージング行のものをそのまま使用（再照合しない）
-   e. SQL RPC upsert_order_by_dedupe_key で orders に INSERT/UPDATE
+   e. SQL RPC upsert_order_by_dedupe_key で orders に INSERT/UPDATE。INSERT時は
+      customer_certainty の値に関わらず常に status='draft' で作成する。
       (tenant_id, customer_id, product_id, deadline_date) の重複時は既存orderの
-      ステータス昇格・数量更新を試み、`action` (inserted/updated/skipped_downgrade/
-      skipped_no_change/skipped_draft_conflict) に応じて分岐する（Issue #252、詳細後述）
+      customer_certainty昇格・数量更新を試み、`action` (inserted/updated/skipped_downgrade/
+      skipped_no_change/skipped_draft_conflict) に応じて分岐する（Issue #252/#267、詳細後述）
    f. `inserted`/`updated` の場合、対応する order_attachments 行を追加INSERT
       (order_id 設定済み、storage_path はステージング行と同一、parse_status='success')
       → 既存の `/orders/{order_id}/attachments` エンドポイント・UIがそのまま流用できる
@@ -64,27 +77,33 @@ Issue #248 により PDF添付メールは `order_attachments` に `order_id=NUL
 ### なぜ postgrest-py の `on_conflict` を使わないか
 
 supabase-py（postgrest-py）の `.insert(..., on_conflict=...)` は単純なマージ用であり、
-「ステータスは昇格のみ許可・数量は差分があれば更新・draft/completed/canceledは対象外」
-といった条件付きロジックは表現できない。そのため SQL RPC 関数 `upsert_order_by_dedupe_key`
-（`orders%ROWTYPE` を `FOR UPDATE` で取得し、優先順位判定してINSERT/UPDATEを分岐）
-を実装し、`action` で結果を返している。
+「顧客側の確度は昇格のみ許可・数量は差分があれば更新・ユーザーが確定/完了/キャンセルした
+注文や手動下書きは対象外」といった条件付きロジックは表現できない。そのため SQL RPC 関数
+`upsert_order_by_dedupe_key`（`orders%ROWTYPE` を `FOR UPDATE` で取得し、優先順位判定して
+INSERT/UPDATEを分岐）を実装し、`action` で結果を返している。
 
-### 既存orderのupsert処理（Issue #252）
+### 既存orderのupsert処理（Issue #252、Issue #267で customer_certainty 対応）
 
 `upsert_order_by_dedupe_key` は `(tenant_id, customer_id, product_id, deadline_date)` の
 dedupeキーに一致する既存orderが見つかった場合、以下のルールで判定する。
 
-- ステータスの優先順位（数値が大きいほど確定度が高い）:
-  `forecast_tentative(0) < forecast(1) < confirmed(2) < completed(3)`。
-  既存 > 新規（格下げ）の場合は更新しない（`skipped_downgrade`）。
-  優先順位表にない `canceled` の既存orderも同様に上書き対象外（`skipped_downgrade`）
-- `status = 'draft'`（手動下書き）の既存orderは優先順位判定に入れず、常に
-  `skipped_draft_conflict` としてコンフリクト記録のみ行う（PDF自動処理で意図せず
-  上書きされないようにするため）
+- **INSERT時は customer_certainty の値に関わらず常に `status='draft'` で作成する**。
+  `status='confirmed'` へはユーザーの確定操作（`POST /orders/{id}/confirm`）でのみ遷移する
+- 既存orderの `status` が `confirmed`/`completed`/`canceled`（ユーザーが確定・完了させた、
+  またはキャンセルした注文）の場合は常に `skipped_downgrade`。PDF自動処理からは一切
+  変更しない
+- 既存orderの `status='draft'` かつ `source_type='manual'`（手動下書き）の場合は
+  優先順位判定に入れず、常に `skipped_draft_conflict` としてコンフリクト記録のみ行う
+  （PDF自動処理で意図せず上書きされないようにするため）
+- それ以外（`status='draft'` かつ `source_type != 'manual'` = メール/PDF起票の確認待ち
+  draft）の場合のみ、`customer_certainty` の優先順位（数値が大きいほど確度が高い）で
+  判定する: `forecast_tentative(0) < forecast(1) < confirmed(2)`。
+  既存 > 新規（格下げ）の場合は更新しない（`skipped_downgrade`）
 - 優先順位が同じかつ数量も一致する場合は完全重複とみなし `skipped_no_change`
   （この場合のみ `order_parse_log` への記録なし）
-- それ以外（昇格 or 同ステータスでの数量差分）は `status`/`quantity`/`source_*`/
-  `extracted_product_name` を更新し `updated` を返す
+- それ以外（昇格 or 同確度での数量差分）は `customer_certainty`/`quantity`/`source_*`/
+  `extracted_product_name` を更新し `updated` を返す（**`status` は `draft` のまま
+  変更しない**）
 
 `_process_line_item` は `action` に応じて分岐する:
 
@@ -99,9 +118,12 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
 `deadline_date` はdedupeキーの一部のため、内示の納期が翌月にずれるようなケースは
 既存の仕組みでは別レコードとして新規INSERTされる（旧レコードは残り続ける）。これは
 現時点で正式な引き継ぎ機能としては対応しないが、旧 `forecast`/`forecast_tentative`
-レコードが一覧に溜まり続けないよう、`inserted` の都度 `_mark_superseded_orders` で
+レコード（`status='draft'` かつ `customer_certainty IN ('forecast', 'forecast_tentative')`
+のもの）が一覧に溜まり続けないよう、`inserted` の都度 `_mark_superseded_orders` で
 同一 `(tenant_id, customer_id, product_id)` の異なる未来日付レコードに
 `superseded_at = now()` をセットし、注文一覧 (`OrderRepository.get_all`) から除外する。
+ユーザーが確定済み（`status='confirmed'`）の注文はこのフィルタ対象外のため supersede
+されない。
 
 ---
 
@@ -125,16 +147,37 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
 - `create_order_skip_duplicate` を削除し、`upsert_order_by_dedupe_key` を新設
   （唯一の呼び出し元 `pdf_order_parsing_service._process_line_item` を置き換え）
 
-### `orders.status` の全定義
+`supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql`（Issue #267）:
 
-| 値                    | 意味                     |
-|------------------------|--------------------------|
-| `draft`                | 下書き                   |
-| `confirmed`            | 確定/スケジュール済      |
-| `completed`            | 完了                     |
-| `canceled`             | キャンセル               |
-| `forecast`             | 内示（Issue #249 で追加）|
-| `forecast_tentative`   | 内々示（Issue #249 で追加）|
+- `orders.customer_certainty text`（nullable）を追加
+- `orders.status` の CHECK制約を元の4値（`draft`/`confirmed`/`completed`/`canceled`）に戻し、
+  `forecast`/`forecast_tentative` を除外
+- 既存データ移行: `status IN ('forecast', 'forecast_tentative')` だった行は
+  `customer_certainty` に値を退避し `status='draft'` に。`status='confirmed' AND
+  confirmed_at IS NULL`（ユーザーが一度も確定操作をしていないのに本バグで確定済みに
+  されていた行）も `customer_certainty='confirmed'`, `status='draft'` に是正
+- `upsert_order_by_dedupe_key` の `p_status` パラメータを `p_customer_certainty` に置き換え
+
+### `orders.status` の全定義（ProductPlanner側のワークフローステータス）
+
+| 値          | 意味                 |
+|--------------|----------------------|
+| `draft`      | 下書き               |
+| `confirmed`  | 確定/スケジュール済（`/orders/{id}/confirm` でのみ遷移） |
+| `completed`  | 完了                 |
+| `canceled`   | キャンセル           |
+
+### `orders.customer_certainty` の全定義（顧客側の確度、参考情報）
+
+| 値                    | 意味                       |
+|------------------------|----------------------------|
+| `null`                 | 手動起票（確度情報なし）     |
+| `confirmed`            | 確定納期・PO番号明記        |
+| `forecast`             | 内示                        |
+| `forecast_tentative`   | 内々示                      |
+
+`orders.status` とは独立しており、`customer_certainty` の値が `confirmed` であっても
+`status` は自動では `confirmed` にならない（Issue #267）。
 
 ---
 
@@ -169,6 +212,18 @@ Issue #252 での追加:
 - `backend/app/repositories/supa_infra/transaction/order_repo.py`: `get_all()` を
   オーバーライドし `superseded_at IS NULL` でフィルタ
 
+Issue #267 での変更（顧客側の確度とProductPlannerステータスの分離）:
+
+- `supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql`
+- `backend/app/services/pdf_order_parsing_service.py`: `_CERTAINTY_TO_STATUS` を削除し、
+  RPCへ渡すパラメータを `p_status` から `p_customer_certainty` に変更。
+  `_mark_superseded_orders()` の絞り込み条件を `status='draft' AND customer_certainty IN
+  (...)` に変更
+- `frontend/src/types/order.ts` / `frontend/src/lib/order-utils.ts`: `customer_certainty`
+  フィールド・表示用ラベル/バッジ関数を追加
+- `frontend/src/components/orders/order-table-row.tsx` /
+  `frontend/src/app/orders/[id]/page.tsx`: 顧客側の確度バッジを追加表示
+
 ---
 
 ## 環境変数
@@ -189,21 +244,28 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 - [x] サンプルPDFから複数orderが正しく生成される（単体テストでモック検証に加え、
       `backend/__tests__/e2e/test_pdf_order_parsing_flow.py` で実PDF・実Claude API・
       実Supabaseを用いたe2e検証を実施）
-- [x] `certainty` に応じて `orders.status` が `confirmed`/`forecast`/`forecast_tentative` に正しくセットされる
+- [x] `certainty` に応じて `orders.customer_certainty` が `confirmed`/`forecast`/`forecast_tentative`
+      に正しくセットされる。`orders.status` は常に `draft` で作成される（Issue #267）
 - [x] 品番・品名の照合失敗時はorderを生成せず、`order_parse_log` に記録される
 - [x] 暗号化PDF・画像PDF（テキスト抽出不可）でもクラッシュせず `parse_status` が適切に更新される
 - [x] 重複明細（UNIQUE制約抵触）はスキップされ `order_parse_log` に記録される
 - [x] 生成された各orderから、対応する添付PDFが注文詳細画面からダウンロードできる
       （既存の `/orders/{order_id}/attachments` エンドポイントを変更なしで再利用）
 - [x] マイグレーション（CHECK制約変更、UNIQUE制約、`order_parse_log`）が適用済み
-- [x] 同一dedupeキーで `forecast` → `confirmed` の更新が正しく反映される（Issue #252）
+- [x] 同一dedupeキーで `customer_certainty` が `forecast` → `confirmed` に更新されても
+      `status` は `draft` のまま変化しない（Issue #252/#267）
 - [x] 同一dedupeキーで数量のみ変わった場合、数量が更新される（Issue #252）
-- [x] `confirmed` な既存orderへの `forecast` 明細は更新されず `downgrade_skipped` として記録される（Issue #252）
-- [x] `status='draft'` の既存orderへの明細は更新されず `draft_conflict_skipped` として記録される（Issue #252）
+- [x] `status='confirmed'/'completed'/'canceled'` な既存orderへの明細は更新されず
+      `downgrade_skipped` として記録される（Issue #252/#267）
+- [x] `status='draft' AND source_type='manual'`（手動下書き）の既存orderへの明細は
+      更新されず `draft_conflict_skipped` として記録される（Issue #252/#267）
 - [x] 完全に値が一致する重複はログ記録なしでスキップされる（Issue #252）
 - [x] `updated` の場合も `order_attachments` に新しいPDFの添付レコードが追加で紐付けられる（Issue #252）
 - [x] `deadline_date` が変わった内示は新規orderとして生成され、旧レコードに `superseded_at` がセットされる（Issue #252）
 - [x] `superseded_at` が設定されたorderは注文一覧APIのレスポンスに含まれない（Issue #252）
+- [x] PDF文面上で確定納期・PO番号が明記された明細（certainty='confirmed'）でも、
+      ユーザーが `/orders/{id}/confirm` を実行するまで `status` は `confirmed` に
+      ならない（Issue #267）
 
 ---
 
@@ -213,7 +275,7 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 - 複数添付ファイルへの対応（1メール1添付の前提を維持）
 - 重複スキップ・照合失敗の通知UI（[notifications.md](notifications.md) Issue #254 で対応）
 - ステージング行が長時間 `pending` のまま停滞した場合のリトライ・タイムアウト処理
-- `forecast`/`forecast_tentative` のUIフィルタータブ追加（別途検討）
+- `customer_certainty`（`forecast`/`forecast_tentative`）のUIフィルタータブ追加（別途検討）
 - `deadline_date` 変更を「同一注文の引き継ぎ」として明示的にUI上で提示する機能（Issue #252スコープ外）
 - `order_history`（変更履歴・監査ログ）テーブルの新設（Issue #252スコープ外）
 - ステータスの手動格下げ操作、`superseded_at` レコードの物理削除・アーカイブ処理（Issue #252スコープ外）
@@ -225,10 +287,11 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 `backend/__tests__/integration/test_order_upsert_by_dedupe_key.py`
 （実行: `supabase start` の上で `pytest __tests__/integration/test_order_upsert_by_dedupe_key.py -v --run-integration`）。
 
-`upsert_order_by_dedupe_key` のステータス優先順位判定・数量更新・draft/canceledの
-上書き除外、および `_mark_superseded_orders` のクエリチェーンは Claude API・Gmail API
-の出力に依存しない決定的なDB/SQLロジックのため、実PDF・実Claude APIを使うe2e tierでは
-なく、ローカル Supabase のみで完結する integration tier で検証する
+`upsert_order_by_dedupe_key` の `customer_certainty` 優先順位判定・数量更新・
+confirmed/completed/canceled/手動draftの上書き除外、および `_mark_superseded_orders`
+のクエリチェーンは Claude API・Gmail APIの出力に依存しない決定的なDB/SQLロジックのため、
+実PDF・実Claude APIを使うe2e tierではなく、ローカル Supabase のみで完結する
+integration tier で検証する
 （方針の詳細は `backend/__tests__/e2e/CLAUDE.md`, `backend/__tests__/integration/CLAUDE.md` を参照）。
 テストごとに専用の tenant/customer/product を作成し、`upsert_order_by_dedupe_key` RPC を
 直接呼び出して `action`（inserted/updated/skipped_downgrade/skipped_draft_conflict/

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -34,6 +34,8 @@ import {
   getCustomerName,
   getStatusLabel,
   getStatusBadgeClass,
+  getCertaintyLabel,
+  getCertaintyBadgeClass,
 } from "@/lib/order-utils"
 import type { OrderSimulateResponse } from "@/types/order"
 import { ApiError } from "@/lib/api-client"
@@ -174,6 +176,16 @@ export default function OrderDetailPage() {
                   </Badge>
                 </dd>
               </div>
+              {order.customer_certainty && (
+                <div className="flex justify-between items-center">
+                  <dt className="text-muted-foreground">顧客側の確度</dt>
+                  <dd>
+                    <Badge className={getCertaintyBadgeClass(order.customer_certainty)}>
+                      {getCertaintyLabel(order.customer_certainty)}
+                    </Badge>
+                  </dd>
+                </div>
+              )}
             </dl>
           </div>
 

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -24,6 +24,8 @@ import {
   getCustomerName,
   getStatusLabel,
   getStatusBadgeClass,
+  getCertaintyLabel,
+  getCertaintyBadgeClass,
 } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
@@ -142,9 +144,16 @@ export function OrderTableRow({
             : "-"}
         </TableCell>
         <TableCell>
-          <Badge className={getStatusBadgeClass(order.status)}>
-            {getStatusLabel(order.status)}
-          </Badge>
+          <div className="flex flex-col items-start gap-1">
+            <Badge className={getStatusBadgeClass(order.status)}>
+              {getStatusLabel(order.status)}
+            </Badge>
+            {order.customer_certainty && (
+              <Badge className={getCertaintyBadgeClass(order.customer_certainty)}>
+                {getCertaintyLabel(order.customer_certainty)}
+              </Badge>
+            )}
+          </div>
         </TableCell>
         <TableCell className="text-right">
           <div className="flex items-center justify-end gap-2">

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -68,8 +68,6 @@ export function getStatusLabel(status: Order["status"]): string {
     confirmed: "確定",
     completed: "完了",
     canceled: "キャンセル",
-    forecast: "内示",
-    forecast_tentative: "内々示",
   }
   return statusLabels[status] || status
 }
@@ -79,12 +77,37 @@ export function getStatusLabel(status: Order["status"]): string {
  */
 export function getStatusBadgeClass(status: Order["status"]): string {
   const classes: Record<Order["status"], string> = {
-    draft:               "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
-    confirmed:           "bg-green-100 text-green-800 hover:bg-green-100",
-    completed:           "bg-blue-100 text-blue-800 hover:bg-blue-100",
-    canceled:            "bg-gray-100 text-gray-500 hover:bg-gray-100",
+    draft:      "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
+    confirmed:  "bg-green-100 text-green-800 hover:bg-green-100",
+    completed:  "bg-blue-100 text-blue-800 hover:bg-blue-100",
+    canceled:   "bg-gray-100 text-gray-500 hover:bg-gray-100",
+  }
+  return classes[status] ?? ""
+}
+
+/**
+ * 顧客側の確度（PDF/メール文面から抽出した内示・内々示・確定の別）の日本語ラベルを取得。
+ * ProductPlanner側のワークフローステータス(status)とは独立した参考情報。
+ */
+export function getCertaintyLabel(certainty: NonNullable<Order["customer_certainty"]>): string {
+  const certaintyLabels: Record<NonNullable<Order["customer_certainty"]>, string> = {
+    confirmed: "顧客確定",
+    forecast: "内示",
+    forecast_tentative: "内々示",
+  }
+  return certaintyLabels[certainty] || certainty
+}
+
+/**
+ * 顧客側の確度バッジの Tailwind クラスを取得
+ */
+export function getCertaintyBadgeClass(
+  certainty: NonNullable<Order["customer_certainty"]>
+): string {
+  const classes: Record<NonNullable<Order["customer_certainty"]>, string> = {
+    confirmed:           "bg-green-50 text-green-700 hover:bg-green-50",
     forecast:            "bg-orange-100 text-orange-800 hover:bg-orange-100",
     forecast_tentative:  "bg-purple-100 text-purple-800 hover:bg-purple-100",
   }
-  return classes[status] ?? ""
+  return classes[certainty] ?? ""
 }

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -9,7 +9,8 @@ export interface Order {
   quantity: number
   desired_deadline?: string // ISO 8601形式
   confirmed_deadline?: string // ISO 8601形式
-  status: 'draft' | 'confirmed' | 'completed' | 'canceled' | 'forecast' | 'forecast_tentative'
+  status: 'draft' | 'confirmed' | 'completed' | 'canceled'
+  customer_certainty: 'confirmed' | 'forecast' | 'forecast_tentative' | null
   is_scheduled: boolean
   has_unconfirmed_routings?: boolean
   source_type: 'manual' | 'email'

--- a/supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql
+++ b/supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql
@@ -1,0 +1,169 @@
+-- 顧客側の確度(certainty)とProductPlanner側のワークフローステータス(status)を分離する (Issue #267)
+--
+-- 背景: pdf_order_parsing_service.py が PDF明細の certainty (確定/内示/内々示という
+-- 「顧客側の確度」) をそのまま orders.status (「ProductPlannerのワークフローステータス」。
+-- 本来 draft -> confirmed はユーザーの確定操作 (/orders/{id}/confirm) でのみ遷移すべき)
+-- に1:1でマッピングしていたため、メール/PDF転送起票の注文がユーザーの確認・確定操作
+-- なしに status='confirmed' として作成されてしまっていた。
+--
+-- 本マイグレーションでは、顧客側の確度を保持する専用カラム orders.customer_certainty を
+-- 新設し、orders.status は元の4値 (draft/confirmed/completed/canceled) に戻す。
+
+-- ==========================================
+-- orders.customer_certainty カラム追加
+-- ==========================================
+ALTER TABLE orders ADD COLUMN customer_certainty text
+  CHECK (customer_certainty IN ('confirmed', 'forecast', 'forecast_tentative'));
+
+COMMENT ON COLUMN orders.customer_certainty IS
+  'PDF/メール文面から抽出した顧客側の確度: confirmed(確定納期・PO番号明記), '
+  'forecast(内示), forecast_tentative(内々示)。ProductPlanner側のワークフロー'
+  'ステータス(status)とは独立した値であり、status を自動で変化させない。'
+  '手動起票の注文では NULL。';
+
+-- ==========================================
+-- 既存データの是正
+-- ==========================================
+-- status='forecast'/'forecast_tentative' だった行は、値を customer_certainty に退避し
+-- status は 'draft' に戻す。
+UPDATE orders
+SET customer_certainty = status,
+    status = 'draft'
+WHERE status IN ('forecast', 'forecast_tentative');
+
+-- status='confirmed' かつ confirmed_at IS NULL の行は、ユーザーが一度も
+-- /orders/{id}/confirm を実行していないにも関わらず、本バグにより
+-- certainty='confirmed' から直接 status='confirmed' にされてしまった行なので、
+-- customer_certainty='confirmed' を設定した上で status='draft' に是正する。
+UPDATE orders
+SET customer_certainty = 'confirmed',
+    status = 'draft'
+WHERE status = 'confirmed'
+  AND confirmed_at IS NULL;
+
+-- ==========================================
+-- orders.status: forecast / forecast_tentative を除外し元の4値に戻す
+-- ==========================================
+ALTER TABLE orders DROP CONSTRAINT orders_status_check;
+ALTER TABLE orders ADD CONSTRAINT orders_status_check
+  CHECK (status IN ('draft', 'confirmed', 'completed', 'canceled'));
+
+COMMENT ON COLUMN orders.status IS
+  'ProductPlannerのワークフローステータス: draft(下書き), confirmed(確定/スケジュール済), '
+  'completed(完了), canceled(キャンセル)。confirmed へはユーザーの確定操作'
+  '(/orders/{id}/confirm) でのみ遷移する。顧客側の確度は customer_certainty を参照。';
+
+-- ==========================================
+-- upsert_order_by_dedupe_key: p_status を廃止し p_customer_certainty に置き換え
+-- ==========================================
+-- INSERT時は常に status='draft' で作成する。既存行が confirmed/completed/canceled
+-- (=ユーザーが確定・完了、またはキャンセルした注文) の場合は常に保護する。
+-- 既存行が draft かつ source_type='manual' (手動下書き) の場合も従来通り保護する。
+-- それ以外 (draft かつ source_type != 'manual' = メール/PDF起票の確認待ちdraft) の
+-- 場合のみ、customer_certainty の優先順位で upsert 判定を行う。
+DROP FUNCTION IF EXISTS upsert_order_by_dedupe_key(
+  uuid, bigint, bigint, int, date, text, text, text, text
+);
+
+CREATE OR REPLACE FUNCTION upsert_order_by_dedupe_key(
+  p_tenant_id             uuid,
+  p_customer_id           bigint,
+  p_product_id            bigint,
+  p_quantity              int,
+  p_deadline_date         date,
+  p_customer_certainty    text,
+  p_source_type           text,
+  p_source_raw            text,
+  p_extracted_product_name text
+)
+RETURNS TABLE (order_id bigint, action text)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_existing        orders%ROWTYPE;
+  v_new_id          bigint;
+  v_existing_priority int;
+  v_new_priority      int;
+BEGIN
+  -- 先にINSERTを試み、UNIQUE制約(orders_dedupe_key)の競合でしか
+  -- 「既存あり」を判定しない。SELECTしてから未存在ならINSERTする順序だと、
+  -- 同一dedupeキーへの並行呼び出しが両方SELECTでNOT FOUNDと判定してしまい、
+  -- 片方が23505で例外終了する競合が起こり得るため。
+  INSERT INTO orders (
+    tenant_id, customer_id, product_id, quantity, deadline_date,
+    status, customer_certainty, source_type, source_raw, extracted_product_name
+  )
+  VALUES (
+    p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
+    'draft', p_customer_certainty, p_source_type, p_source_raw, p_extracted_product_name
+  )
+  ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
+  RETURNING orders.id INTO v_new_id;
+
+  IF v_new_id IS NOT NULL THEN
+    RETURN QUERY SELECT v_new_id, 'inserted'::text;
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_existing
+  FROM orders
+  WHERE tenant_id = p_tenant_id
+    AND customer_id = p_customer_id
+    AND product_id = p_product_id
+    AND deadline_date = p_deadline_date
+  FOR UPDATE;
+
+  -- confirmed/completed/canceled (ユーザーが確定・完了させた、またはキャンセルした注文)
+  -- はPDF自動処理から完全に保護し、常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status IN ('confirmed', 'completed', 'canceled') THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  -- status='draft' かつ source_type='manual' (手動下書き) は自動更新の対象外。
+  -- 常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status = 'draft' AND v_existing.source_type = 'manual' THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_draft_conflict'::text;
+    RETURN;
+  END IF;
+
+  -- ここから先は既存行が draft かつ source_type != 'manual'
+  -- (メール/PDF起票の確認待ちdraft) のケース。
+  -- customer_certainty の優先順位（数値が大きいほど確度が高い）で判定する。
+  v_existing_priority := CASE v_existing.customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE NULL
+  END;
+  v_new_priority := CASE p_customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE NULL
+  END;
+
+  IF v_existing_priority IS NULL
+     OR v_new_priority IS NULL
+     OR v_new_priority < v_existing_priority THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  IF v_new_priority = v_existing_priority AND v_existing.quantity = p_quantity THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_no_change'::text;
+    RETURN;
+  END IF;
+
+  UPDATE orders
+  SET customer_certainty     = p_customer_certainty,
+      quantity                = p_quantity,
+      source_type             = p_source_type,
+      source_raw              = p_source_raw,
+      extracted_product_name  = p_extracted_product_name
+  WHERE id = v_existing.id;
+
+  RETURN QUERY SELECT v_existing.id, 'updated'::text;
+END;
+$$;

--- a/supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql
+++ b/supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql
@@ -131,11 +131,14 @@ BEGIN
   -- ここから先は既存行が draft かつ source_type != 'manual'
   -- (メール/PDF起票の確認待ちdraft) のケース。
   -- customer_certainty の優先順位（数値が大きいほど確度が高い）で判定する。
+  -- 既存行の customer_certainty が NULL（本文のみのメール起票等、確度情報を
+  -- 持たないdraft）の場合は最も低い優先度(-1)として扱い、PDF取込による
+  -- 確度付け・更新を妨げないようにする。
   v_existing_priority := CASE v_existing.customer_certainty
     WHEN 'forecast_tentative' THEN 0
     WHEN 'forecast'           THEN 1
     WHEN 'confirmed'          THEN 2
-    ELSE NULL
+    ELSE -1
   END;
   v_new_priority := CASE p_customer_certainty
     WHEN 'forecast_tentative' THEN 0
@@ -144,8 +147,9 @@ BEGIN
     ELSE NULL
   END;
 
-  IF v_existing_priority IS NULL
-     OR v_new_priority IS NULL
+  -- p_customer_certainty がCHECK制約の許容値以外だった場合
+  -- (呼び出し元での正規化漏れ等) は更新せずコンフリクト扱いにする
+  IF v_new_priority IS NULL
      OR v_new_priority < v_existing_priority THEN
     RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
     RETURN;


### PR DESCRIPTION
## Summary
- PDF文面から抽出した顧客側の確度(certainty: confirmed/forecast/forecast_tentative)を、そのまま ProductPlanner側のワークフローステータス(`orders.status`)へ直接マッピングしていた既存ロジック(Issue #249/#252)により、ユーザーが一度も確認・確定操作をしていないのに注文が「確定済み」として起票されてしまっていた不具合を修正
- 新設カラム `orders.customer_certainty` に顧客側の確度を保持し、`orders.status` とは独立させた。`status` はメール/PDF転送起票では常に `draft` で作成され、`confirmed` への遷移は既存の `POST /orders/{id}/confirm`（ユーザーの明示的な確定操作）経由でのみ発生する
- 既存データも移行: 本バグにより誤って `status='confirmed'`（`confirmed_at IS NULL`）になっていた行は `customer_certainty='confirmed'`, `status='draft'` に是正
- `upsert_order_by_dedupe_key` RPCの保護ロジックも更新: `confirmed`/`completed`/`canceled` の既存注文は常に保護。`draft` かつ `source_type='manual'`（手動下書き）も従来通り保護。それ以外（メール/PDF起票の確認待ちdraft）のみ `customer_certainty` の優先順位でupsert判定
- フロントエンドに顧客側確度バッジを追加表示（注文一覧・詳細画面）

## Test plan
- [x] `cd backend && ruff check . && mypy .`（対象ファイルに新規エラーなし）
- [x] `cd backend && pytest __tests__/unit/services/test_pdf_order_parsing_service.py -v`（11 passed）
- [x] `supabase db reset` でマイグレーション適用を確認
- [x] `cd backend && pytest __tests__/integration/ -v --run-integration`（25 passed、`upsert_order_by_dedupe_key` の新ロジックを含む）
- [x] `cd frontend && npx tsc --noEmit` / `npm run lint`（変更ファイルに新規エラーなし）
- [ ] `cd backend && pytest __tests__/e2e/test_pdf_order_parsing_flow.py -v --run-e2e`（実PDF・実Claude API要、レビュー環境での実行を推奨）

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)