### PR TITLE
fix(#269): 工程未設定と未確定でメッセージを区別

### DIFF
--- a/backend/__tests__/unit/repositories/supabase/transaction/test_order_repo.py
+++ b/backend/__tests__/unit/repositories/supabase/transaction/test_order_repo.py
@@ -118,3 +118,22 @@ class TestOrderRepositoryRoutingStatus:
         assert by_id[2]["has_unconfirmed_routings"] is True
         assert by_id[3]["has_no_routings"] is False
         assert by_id[3]["has_unconfirmed_routings"] is False
+
+    def test_get_all_with_routing_status_all_orders_without_product_id(self):
+        """全注文が product_id=None（product_ids が空）でも例外にならず両フラグが True になる"""
+        orders_data = [
+            {"id": 1, "product_id": None},
+            {"id": 2, "product_id": None},
+        ]
+        mock_client = self._make_client(orders_data, [])
+        repo = OrderRepository(mock_client)
+        cast(Any, repo).get_all = MagicMock(return_value=orders_data)
+
+        result = repo.get_all_with_routing_status()
+
+        mock_client.table.return_value.select.return_value.in_.assert_not_called()
+        by_id = {o["id"]: o for o in result}
+        assert by_id[1]["has_no_routings"] is True
+        assert by_id[1]["has_unconfirmed_routings"] is True
+        assert by_id[2]["has_no_routings"] is True
+        assert by_id[2]["has_unconfirmed_routings"] is True

--- a/backend/__tests__/unit/repositories/supabase/transaction/test_order_repo.py
+++ b/backend/__tests__/unit/repositories/supabase/transaction/test_order_repo.py
@@ -1,4 +1,5 @@
 # __tests__/repositories/supabase/transaction/test_order_repo.py
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,3 +32,89 @@ class TestOrderRepositoryGetAll:
         repo = OrderRepository(mock_client)
 
         assert repo.get_all() == []
+
+
+@pytest.mark.unit
+class TestOrderRepositoryRoutingStatus:
+    def _make_client(self, orders_data, routings_data):
+        mock_client = MagicMock()
+        (
+            mock_client.table.return_value.select.return_value.is_.return_value.execute.return_value.data
+        ) = orders_data
+        (
+            mock_client.table.return_value.select.return_value.in_.return_value.execute.return_value.data
+        ) = routings_data
+        (
+            mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data
+        ) = routings_data
+        return mock_client
+
+    def test_get_by_id_no_routings_at_all(self):
+        """工程が1件も登録されていない場合、has_no_routings と has_unconfirmed_routings が両方 True"""
+        mock_client = self._make_client([{"id": 1, "product_id": 10}], [])
+        (
+            mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data
+        ) = []
+        repo = OrderRepository(mock_client)
+        cast(Any, repo).get_by_id = MagicMock(return_value={"id": 1, "product_id": 10})
+
+        result = repo.get_by_id_with_routing_status(1)
+
+        assert result is not None
+        assert result["has_no_routings"] is True
+        assert result["has_unconfirmed_routings"] is True
+
+    def test_get_by_id_routings_exist_but_unconfirmed(self):
+        """工程は登録済みだが未確定の場合、has_no_routings は False、has_unconfirmed_routings は True"""
+        mock_client = self._make_client(
+            [{"id": 1, "product_id": 10}],
+            [{"product_id": 10, "is_confirmed": False}],
+        )
+        repo = OrderRepository(mock_client)
+        cast(Any, repo).get_by_id = MagicMock(return_value={"id": 1, "product_id": 10})
+
+        result = repo.get_by_id_with_routing_status(1)
+
+        assert result is not None
+        assert result["has_no_routings"] is False
+        assert result["has_unconfirmed_routings"] is True
+
+    def test_get_by_id_routings_all_confirmed(self):
+        """全ての工程が確定済みの場合、両フラグとも False"""
+        mock_client = self._make_client(
+            [{"id": 1, "product_id": 10}],
+            [{"product_id": 10, "is_confirmed": True}],
+        )
+        repo = OrderRepository(mock_client)
+        cast(Any, repo).get_by_id = MagicMock(return_value={"id": 1, "product_id": 10})
+
+        result = repo.get_by_id_with_routing_status(1)
+
+        assert result is not None
+        assert result["has_no_routings"] is False
+        assert result["has_unconfirmed_routings"] is False
+
+    def test_get_all_with_routing_status_distinguishes_flags(self):
+        """全件取得でも工程未設定/未確定を区別する"""
+        orders_data = [
+            {"id": 1, "product_id": 10},  # 工程未設定
+            {"id": 2, "product_id": 20},  # 工程あり・未確定
+            {"id": 3, "product_id": 30},  # 工程あり・確定済み
+        ]
+        routings_data = [
+            {"product_id": 20, "is_confirmed": False},
+            {"product_id": 30, "is_confirmed": True},
+        ]
+        mock_client = self._make_client(orders_data, routings_data)
+        repo = OrderRepository(mock_client)
+        cast(Any, repo).get_all = MagicMock(return_value=orders_data)
+
+        result = repo.get_all_with_routing_status()
+
+        by_id = {o["id"]: o for o in result}
+        assert by_id[1]["has_no_routings"] is True
+        assert by_id[1]["has_unconfirmed_routings"] is True
+        assert by_id[2]["has_no_routings"] is False
+        assert by_id[2]["has_unconfirmed_routings"] is True
+        assert by_id[3]["has_no_routings"] is False
+        assert by_id[3]["has_unconfirmed_routings"] is False

--- a/backend/app/repositories/supa_infra/transaction/order_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_repo.py
@@ -24,14 +24,18 @@ class OrderRepository(BaseRepository):
         if not orders:
             return []
 
-        product_ids = list({o["product_id"] for o in orders if o.get("product_id")})
-        res = (
-            self.client.table(SupabaseTableName.PROCESS_ROUTINGS.value)
-            .select("product_id, is_confirmed")
-            .in_("product_id", product_ids)
-            .execute()
+        product_ids = list(
+            {o["product_id"] for o in orders if o.get("product_id") is not None}
         )
-        routings = cast(list[dict[str, Any]], res.data or [])
+        routings: list[dict[str, Any]] = []
+        if product_ids:
+            res = (
+                self.client.table(SupabaseTableName.PROCESS_ROUTINGS.value)
+                .select("product_id, is_confirmed")
+                .in_("product_id", product_ids)
+                .execute()
+            )
+            routings = cast(list[dict[str, Any]], res.data or [])
         products_with_routings = {r["product_id"] for r in routings}
         products_with_unconfirmed = {
             r["product_id"] for r in routings if not r["is_confirmed"]

--- a/backend/app/repositories/supa_infra/transaction/order_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_repo.py
@@ -19,7 +19,7 @@ class OrderRepository(BaseRepository):
         return cast(list[dict[str, Any]], res.data or [])
 
     def get_all_with_routing_status(self) -> list[dict]:
-        """全注文を has_unconfirmed_routings フラグ付きで取得（2クエリ、N+1なし）"""
+        """全注文を has_no_routings / has_unconfirmed_routings フラグ付きで取得（2クエリ、N+1なし）"""
         orders = self.get_all()
         if not orders:
             return []
@@ -40,22 +40,25 @@ class OrderRepository(BaseRepository):
         result = []
         for order in orders:
             pid = order.get("product_id")
-            has_unconfirmed = (
-                pid is None
-                or pid not in products_with_routings
-                or pid in products_with_unconfirmed
+            has_no_routings = pid is None or pid not in products_with_routings
+            has_unconfirmed = has_no_routings or pid in products_with_unconfirmed
+            result.append(
+                {
+                    **order,
+                    "has_no_routings": has_no_routings,
+                    "has_unconfirmed_routings": has_unconfirmed,
+                }
             )
-            result.append({**order, "has_unconfirmed_routings": has_unconfirmed})
         return result
 
     def get_by_id_with_routing_status(self, order_id: int) -> dict | None:
-        """注文を1件取得し has_unconfirmed_routings フラグを付与"""
+        """注文を1件取得し has_no_routings / has_unconfirmed_routings フラグを付与"""
         order = self.get_by_id(order_id)
         if not order:
             return None
         pid = order.get("product_id")
         if pid is None:
-            return {**order, "has_unconfirmed_routings": True}
+            return {**order, "has_no_routings": True, "has_unconfirmed_routings": True}
         res = (
             self.client.table(SupabaseTableName.PROCESS_ROUTINGS.value)
             .select("product_id, is_confirmed")
@@ -63,8 +66,15 @@ class OrderRepository(BaseRepository):
             .execute()
         )
         routings = cast(list[dict[str, Any]], res.data or [])
-        has_unconfirmed = not routings or any(not r["is_confirmed"] for r in routings)
-        return {**order, "has_unconfirmed_routings": has_unconfirmed}
+        has_no_routings = not routings
+        has_unconfirmed = has_no_routings or any(
+            not r["is_confirmed"] for r in routings
+        )
+        return {
+            **order,
+            "has_no_routings": has_no_routings,
+            "has_unconfirmed_routings": has_unconfirmed,
+        }
 
     def mark_as_scheduled(self, order_id: int) -> None:
         """

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -70,7 +70,7 @@ def create_order(
 
 @orders_router.get("")
 def get_orders(repo: OrderRepository = Depends(get_order_repo)):
-    """注文を全件取得（has_unconfirmed_routings フラグ付き）"""
+    """注文を全件取得（has_no_routings / has_unconfirmed_routings フラグ付き）"""
     logger.info("Fetching all orders")
     results = repo.get_all_with_routing_status()
     return [_map_order_response(order) for order in results]
@@ -126,7 +126,7 @@ def get_unconfirmed_routing_queue(
 
 @orders_router.get("/{order_id}")
 def get_order(order_id: int, repo: OrderRepository = Depends(get_order_repo)):
-    """注文を1件取得（has_unconfirmed_routings フラグ付き）"""
+    """注文を1件取得（has_no_routings / has_unconfirmed_routings フラグ付き）"""
     logger.info(f"Fetching order {order_id}")
     result = repo.get_by_id_with_routing_status(order_id)
     if not result:

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -130,3 +130,24 @@ Issue #197 / #199 / #200 で実装。
              → /orders にリダイレクト
              → 専門家キューに自動表示（has_unconfirmed_routings=true）
 ```
+
+---
+
+## 注文詳細画面のメッセージ区別（Issue #269）
+
+注文詳細画面で、製品に工程が「1件も登録されていない」場合と「登録済みだが未確定」の場合を区別せず、どちらも「工程が設定されていません。製品マスタから工程を設定してください。」と表示していたため、実態と異なる誤解を招いていた。
+
+### Backend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/repositories/supa_infra/transaction/order_repo.py` | `get_all_with_routing_status()` / `get_by_id_with_routing_status()` に `has_no_routings: bool` を追加。`has_unconfirmed_routings` は従来通り「工程0件 または 未確定あり」を表す |
+
+`has_no_routings` は製品に工程が1件も登録されていない場合のみ `true`。`has_unconfirmed_routings` はそれに加えて「登録済みだが `is_confirmed=false` の工程が1件でもある」場合も `true` になる。
+
+### Frontend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `types/order.ts` | `Order` に `has_no_routings?: boolean` を追加 |
+| `app/orders/[id]/page.tsx` | `hasNoRouting`（工程0件）と `hasUnconfirmedRouting`（工程はあるが未確定）を分離。前者は「工程が設定されていません」、後者は「未確定の工程があります」とメッセージを出し分け |

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -123,7 +123,10 @@ export default function OrderDetailPage() {
 
   const isDraft = order.status === "draft"
   const canDelete = order.status === "draft" || order.status === "canceled"
-  const hasNoRouting = order.has_unconfirmed_routings === true && !order.is_scheduled
+  const hasNoRouting = order.has_no_routings === true && !order.is_scheduled
+  const hasUnconfirmedRouting =
+    order.has_unconfirmed_routings === true && !hasNoRouting && !order.is_scheduled
+  const blocksSimulation = hasNoRouting || hasUnconfirmedRouting
 
   return (
     <div className="container mx-auto py-6 px-4">
@@ -249,7 +252,7 @@ export default function OrderDetailPage() {
               <div className="flex-1 space-y-1">
                 <Button
                   onClick={handleSimulate}
-                  disabled={simulateMutation.isPending || hasNoRouting}
+                  disabled={simulateMutation.isPending || blocksSimulation}
                   className="w-full"
                 >
                   <Calculator className="mr-2 h-4 w-4" />
@@ -263,6 +266,17 @@ export default function OrderDetailPage() {
                       className="underline text-primary"
                     >
                       製品マスタから工程を設定してください。
+                    </a>
+                  </p>
+                )}
+                {hasUnconfirmedRouting && (
+                  <p className="text-xs text-muted-foreground">
+                    未確定の工程があります。{" "}
+                    <a
+                      href={`/master/products?highlight=${order.product_id}`}
+                      className="underline text-primary"
+                    >
+                      製品マスタから工程を確定してください。
                     </a>
                   </p>
                 )}

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -12,6 +12,7 @@ export interface Order {
   status: 'draft' | 'confirmed' | 'completed' | 'canceled'
   customer_certainty: 'confirmed' | 'forecast' | 'forecast_tentative' | null
   is_scheduled: boolean
+  has_no_routings?: boolean
   has_unconfirmed_routings?: boolean
   source_type: 'manual' | 'email'
   source_raw?: string


### PR DESCRIPTION
## Summary
- 注文詳細画面で、製品の工程が「1件も登録されていない」場合と「登録済みだが未確定」の場合を区別せず一律で「工程が設定されていません」と表示していた問題を修正
- `OrderRepository.get_all_with_routing_status()` / `get_by_id_with_routing_status()` に `has_no_routings` フラグを新設し、`has_unconfirmed_routings`（工程0件 or 未確定あり）と区別できるようにした
- フロントで両フラグに応じて「工程が設定されていません」/「未確定の工程があります」を出し分け

Closes #269

## Test plan
- [x] `pytest backend/__tests__/unit/repositories/supabase/transaction/test_order_repo.py` — 新規追加した工程未設定/未確定の区別テストがパス
- [x] `pytest backend/__tests__/unit backend/__tests__/api` — 既存の失敗は本変更前から存在する無関係な失敗であることを確認済み
- [x] `ruff check` / `mypy` / `tsc --noEmit` / `eslint` — 変更ファイルはクリーン
- [ ] 実画面での確認（工程未設定 / 未確定 それぞれのケースでメッセージ表示を目視確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)