### PR TITLE
工程管理モーダルのUX改善（一括保存・並べ替え・確定フラグ運用の見直し）

### DIFF
--- a/backend/__tests__/api/routers/master/test_process_routings.py
+++ b/backend/__tests__/api/routers/master/test_process_routings.py
@@ -119,3 +119,47 @@ class TestProcessRoutingRouter:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Not found"
+
+    def test_bulk_replace_process_routings(self, headers, mock_repo):
+        """PUT /: 一括保存（追加・更新・削除・並べ替え）のテスト"""
+        product_id = 1
+        payload = [
+            {
+                "id": 1,
+                "sequence_order": 1,
+                "process_name": "既存工程（更新）",
+                "equipment_group_id": 2,
+                "setup_time_seconds": 100,
+                "unit_time_seconds": 5.0,
+            },
+            {
+                "id": None,
+                "sequence_order": 2,
+                "process_name": "新規工程",
+                "equipment_group_id": None,
+                "setup_time_seconds": 0,
+                "unit_time_seconds": 3.0,
+            },
+        ]
+        expected_data = [
+            {"id": 1, "product_id": product_id, "process_name": "既存工程（更新）"},
+            {"id": 2, "product_id": product_id, "process_name": "新規工程"},
+        ]
+        mock_repo.replace_routings_for_product.return_value = expected_data
+
+        response = client.put(
+            f"/process-routings?product_id={product_id}",
+            json=payload,
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == expected_data
+
+        mock_repo.replace_routings_for_product.assert_called_once()
+        called_product_id, called_tenant_id, called_items = (
+            mock_repo.replace_routings_for_product.call_args[0]
+        )
+        assert called_product_id == product_id
+        assert called_tenant_id == headers["x-tenant-id"]
+        assert [item["id"] for item in called_items] == [1, None]

--- a/backend/__tests__/api/routers/master/test_process_routings.py
+++ b/backend/__tests__/api/routers/master/test_process_routings.py
@@ -163,3 +163,28 @@ class TestProcessRoutingRouter:
         assert called_product_id == product_id
         assert called_tenant_id == headers["x-tenant-id"]
         assert [item["id"] for item in called_items] == [1, None]
+
+    def test_bulk_replace_process_routings_unknown_id(self, headers, mock_repo):
+        """PUT /: 存在しない工程IDが渡された場合は404を返す"""
+        product_id = 1
+        payload = [
+            {
+                "id": 999,
+                "sequence_order": 1,
+                "process_name": "不明な工程",
+                "equipment_group_id": None,
+                "setup_time_seconds": 0,
+                "unit_time_seconds": 1.0,
+            },
+        ]
+        mock_repo.replace_routings_for_product.side_effect = ValueError(
+            "工程ID 999 は製品 1 に属していません"
+        )
+
+        response = client.put(
+            f"/process-routings?product_id={product_id}",
+            json=payload,
+            headers=headers,
+        )
+
+        assert response.status_code == 404

--- a/backend/__tests__/unit/repositories/supabase/master/test_product_repo.py
+++ b/backend/__tests__/unit/repositories/supabase/master/test_product_repo.py
@@ -1,5 +1,6 @@
 # __tests__/repositories/supabase/master/test_product_repo.py
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from app.repositories.supa_infra import ProductRepository, SupabaseTableName
@@ -143,3 +144,64 @@ class TestProductRepository:
 
         assert result == expected
         mock_client.table.assert_called_with(SupabaseTableName.PROCESS_ROUTINGS.value)
+
+    def test_replace_routings_for_product(self, product_repo):
+        """一括保存: 更新・新規作成・削除が items との差分に応じて行われる"""
+        items: list[dict[str, Any]] = [
+            {
+                "id": 1,
+                "sequence_order": 1,
+                "process_name": "工程A",
+                "equipment_group_id": None,
+                "setup_time_seconds": 0,
+                "unit_time_seconds": 1.0,
+            },
+            {
+                "id": None,
+                "sequence_order": 2,
+                "process_name": "工程C",
+                "equipment_group_id": None,
+                "setup_time_seconds": 0,
+                "unit_time_seconds": 1.0,
+            },
+        ]
+
+        with (
+            patch.object(
+                product_repo,
+                "get_routings_by_product",
+                side_effect=[
+                    # 1回目: 既存取得（工程1,2が既存）
+                    [
+                        {"id": 1, "sequence_order": 1, "process_name": "旧工程A"},
+                        {"id": 2, "sequence_order": 2, "process_name": "工程B"},
+                    ],
+                    # 2回目: 保存後の再取得結果
+                    [
+                        {"id": 1, "sequence_order": 1, "process_name": "工程A"},
+                        {"id": 3, "sequence_order": 2, "process_name": "工程C"},
+                    ],
+                ],
+            ),
+            patch.object(product_repo, "delete_routing") as mock_delete,
+            patch.object(product_repo, "update_routing") as mock_update,
+            patch.object(product_repo, "create_routing") as mock_create,
+        ):
+            result = product_repo.replace_routings_for_product(1, "tenant-1", items)
+
+            # 工程2はitemsに含まれないため削除
+            mock_delete.assert_called_once_with(2)
+            # 工程1はitemsに含まれるため更新（idはpayloadから除去される）
+            mock_update.assert_called_once_with(
+                1, {k: v for k, v in items[0].items() if k != "id"}
+            )
+            # id=Noneの工程は新規作成、product_id/tenant_idが付与される
+            mock_create.assert_called_once_with(
+                {k: v for k, v in items[1].items() if k != "id"}
+                | {"product_id": 1, "tenant_id": "tenant-1"}
+            )
+
+        assert result == [
+            {"id": 1, "sequence_order": 1, "process_name": "工程A"},
+            {"id": 3, "sequence_order": 2, "process_name": "工程C"},
+        ]

--- a/backend/__tests__/unit/repositories/supabase/master/test_product_repo.py
+++ b/backend/__tests__/unit/repositories/supabase/master/test_product_repo.py
@@ -205,3 +205,33 @@ class TestProductRepository:
             {"id": 1, "sequence_order": 1, "process_name": "工程A"},
             {"id": 3, "sequence_order": 2, "process_name": "工程C"},
         ]
+
+    def test_replace_routings_for_product_unknown_id_raises(self, product_repo):
+        """items に存在しない工程IDが含まれる場合、無断で新規作成せず ValueError を送出する"""
+        items: list[dict[str, Any]] = [
+            {
+                "id": 999,
+                "sequence_order": 1,
+                "process_name": "工程A",
+                "equipment_group_id": None,
+                "setup_time_seconds": 0,
+                "unit_time_seconds": 1.0,
+            },
+        ]
+
+        with (
+            patch.object(
+                product_repo,
+                "get_routings_by_product",
+                return_value=[{"id": 1, "sequence_order": 1, "process_name": "工程A"}],
+            ),
+            patch.object(product_repo, "delete_routing") as mock_delete,
+            patch.object(product_repo, "create_routing") as mock_create,
+        ):
+            with pytest.raises(ValueError, match="999"):
+                product_repo.replace_routings_for_product(1, "tenant-1", items)
+
+            # 不正なidを検知した時点でinsertにフォールバックしていないこと
+            mock_create.assert_not_called()
+            # 既存工程(id=1)はitemsに含まれないため削除対象と判定されている
+            mock_delete.assert_called_once_with(1)

--- a/backend/app/models/master/__init__.py
+++ b/backend/app/models/master/__init__.py
@@ -1,6 +1,11 @@
 # backend/app/models/master/__init__.py
 from .customer_schemas import CustomerCreateSchema, CustomerUpdateSchema
-from .process_routings import RoutingCreate, RoutingResponse, RoutingUpdate
+from .process_routings import (
+    RoutingBulkItem,
+    RoutingCreate,
+    RoutingResponse,
+    RoutingUpdate,
+)
 from .product_schemas import ProductCreateSchema, ProductUpdateSchema
 
 __all__ = [
@@ -9,6 +14,7 @@ __all__ = [
     "RoutingCreate",
     "RoutingUpdate",
     "RoutingResponse",
+    "RoutingBulkItem",
     "CustomerCreateSchema",
     "CustomerUpdateSchema",
 ]

--- a/backend/app/models/master/process_routings.py
+++ b/backend/app/models/master/process_routings.py
@@ -34,6 +34,21 @@ class RoutingUpdate(BaseSchema):
     # setup_method_id: int | None = Field(default=None, description="段取り方法ID")
 
 
+class RoutingBulkItem(BaseSchema):
+    """一括保存における1工程分のスキーマ。新規工程は id=None で送信する"""
+
+    id: int | None = Field(
+        default=None, description="既存工程のID（新規追加の場合はNone）"
+    )
+    sequence_order: int = Field(default=..., description="シーケンス番号")
+    process_name: str = Field(default=..., description="工程名")
+    equipment_group_id: int | None = Field(
+        default=..., description="設備グループID（Noneの場合は設備なし）"
+    )
+    setup_time_seconds: int = Field(default=0, description="セットアップ時間")
+    unit_time_seconds: float = Field(default=0, description="単位時間")
+
+
 class RoutingResponse(RoutingCreate):
     """工程ルーティングのレスポンススキーマ"""
 

--- a/backend/app/repositories/supa_infra/master/product_repo.py
+++ b/backend/app/repositories/supa_infra/master/product_repo.py
@@ -106,7 +106,11 @@ class ProductRepository(BaseRepository[T]):
         for item in items:
             data = dict(item)
             routing_id = data.pop("id", None)
-            if routing_id is not None and routing_id in existing_ids:
+            if routing_id is not None:
+                if routing_id not in existing_ids:
+                    raise ValueError(
+                        f"工程ID {routing_id} は製品 {product_id} に属していません"
+                    )
                 self.update_routing(routing_id, data)
             else:
                 data["product_id"] = product_id

--- a/backend/app/repositories/supa_infra/master/product_repo.py
+++ b/backend/app/repositories/supa_infra/master/product_repo.py
@@ -87,6 +87,34 @@ class ProductRepository(BaseRepository[T]):
         )
         return res.count is not None and res.count > 0
 
+    def replace_routings_for_product(
+        self, product_id: int, tenant_id: str, items: list[dict[str, Any]]
+    ) -> list[T]:
+        """製品の工程セット全体を一括で置き換える（追加・更新・削除・並べ替えの一括保存用）。
+
+        items に id を含むものは既存工程の更新、id が無いものは新規作成として扱う。
+        既存工程のうち items に含まれない id は削除する。
+        is_confirmed / confirmed_by / confirmed_at は変更しない（確定操作は別APIで行う）。
+        """
+        existing = self.get_routings_by_product(product_id)
+        existing_ids = {cast(int, r["id"]) for r in existing}
+        incoming_ids = {item["id"] for item in items if item.get("id") is not None}
+
+        for routing_id in existing_ids - incoming_ids:
+            self.delete_routing(routing_id)
+
+        for item in items:
+            data = dict(item)
+            routing_id = data.pop("id", None)
+            if routing_id is not None and routing_id in existing_ids:
+                self.update_routing(routing_id, data)
+            else:
+                data["product_id"] = product_id
+                data["tenant_id"] = tenant_id
+                self.create_routing(data)
+
+        return self.get_routings_by_product(product_id)
+
     def get_routings_confirmed_status(self, product_id: int) -> bool:
         """製品の全工程が確定済みかどうかを返す。工程が0件の場合は False。"""
         routings = self.get_routings_by_product(product_id)

--- a/backend/app/routers/master/process_routings.py
+++ b/backend/app/routers/master/process_routings.py
@@ -10,7 +10,7 @@ from app.dependencies import (
     get_product_repo,
     get_supabase_client,
 )
-from app.models.master import RoutingCreate, RoutingUpdate
+from app.models.master import RoutingBulkItem, RoutingCreate, RoutingUpdate
 from app.repositories.supa_infra.master.product_repo import ProductRepository
 from app.utils.logger import get_logger
 from supabase import Client  # type: ignore
@@ -41,6 +41,26 @@ def get_process_routings(
     """製品IDに紐づく工程順序を取得"""
     logger.info(f"Fetching process routings for product {product_id}")
     return repo.get_routings_by_product(product_id)
+
+
+@process_routing_router.put("")
+def bulk_replace_process_routings(
+    items: list[RoutingBulkItem],
+    product_id: int = Query(..., description="製品ID"),
+    tenant_id: str = Depends(get_current_tenant_id),
+    repo: ProductRepository = Depends(get_product_repo),
+):
+    """製品の工程セット全体を一括保存する（追加・更新・削除・並べ替えをまとめて反映）。
+
+    確定フラグ (is_confirmed) はここでは変更しない。確定・確定取消は
+    PATCH /process-routings/{routing_id} を利用すること。
+    """
+    logger.info(f"Bulk replacing process routings for product {product_id}")
+    return repo.replace_routings_for_product(
+        product_id,
+        tenant_id,
+        [item.model_dump() for item in items],
+    )
 
 
 @process_routing_router.get("/{routing_id}")

--- a/backend/app/routers/master/process_routings.py
+++ b/backend/app/routers/master/process_routings.py
@@ -56,11 +56,14 @@ def bulk_replace_process_routings(
     PATCH /process-routings/{routing_id} を利用すること。
     """
     logger.info(f"Bulk replacing process routings for product {product_id}")
-    return repo.replace_routings_for_product(
-        product_id,
-        tenant_id,
-        [item.model_dump() for item in items],
-    )
+    try:
+        return repo.replace_routings_for_product(
+            product_id,
+            tenant_id,
+            [item.model_dump() for item in items],
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
 
 
 @process_routing_router.get("/{routing_id}")

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -176,3 +176,36 @@ Issue #197 / #199 / #200 で実装。
 ### E2E テスト（Playwright、新規導入）
 
 `frontend/e2e/product-routing-status.spec.ts` で、製品マスタ上での工程未登録/未確定/確定済みの3状態表示をブラウザ経由で検証。ローカル実行専用（CI 未組み込み）。前提条件・実行方法は `frontend/e2e/README.md` を参照。
+
+---
+
+## 工程管理モーダルのUX改善（Issue #273）
+
+工程管理モーダル（`product-routings-dialog.tsx`）で、追加・編集・削除・並べ替えのたびにサーバーと都度通信していたため、ライン上でのタブレット操作や誤操作時の事故につながっていた。ローカル下書き＋明示保存方式に変更し、並べ替えUIを新設した。
+
+### 設計判断の記録
+
+- **確定フラグ (`is_confirmed`) の粒度**: 工程単位のまま維持することとした。`get_unconfirmed_routing_counts()`（工程単位カウント、Issue #200 専門家キューで使用）や Issue #203（工程単位のロール制限）など、工程単位の情報に依存する既存・計画中の機能があるため、製品単位への統合はスコープ外とする。
+- **確定フラグのトグル操作**: 一括保存の下書きには含めず、従来通り即時にサーバーへ反映する。`confirmed_by` / `confirmed_at` という監査ログの正確性を、操作の一貫性より優先した。未保存（サーバーに存在しない）新規工程は確定操作自体を不可とする。
+- **一括保存の実装方式**: `PUT /process-routings?product_id={id}` バルクAPIを新設。フロントの下書き配列（`id: null` = 新規）をそのまま送信し、サーバー側で既存工程との差分から insert/update/delete を行う。複数の個別リクエストを束ねる方式ではなく単一エンドポイントにしたことで、通信の途中失敗による並び順崩れ・部分反映を避けやすくした。ただし DB トランザクションでは括っていない（Supabase 経由でテーブル単位の逐次実行）。
+- **同時編集の競合検知**: 本格的な楽観ロックは実装せず、last-write-wins（後勝ち）を許容する方針とした。複数ユーザーが同時に同じ製品の工程を編集する頻度は低く、実装・テストコストに見合わないと判断。将来必要になった場合は `updated_at` 比較による楽観ロックを追加する。
+
+### Backend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/models/master/process_routings.py` | `RoutingBulkItem` スキーマを追加（`id: int \| None` で新規/既存を判別、`is_confirmed` 系フィールドは含まない） |
+| `app/repositories/supa_infra/master/product_repo.py` | `replace_routings_for_product()` を追加。items に含まれない既存工程IDを削除、id ありは更新、id なしは新規作成し、最終状態を返す。`is_confirmed` / `confirmed_by` / `confirmed_at` はここでは変更しない |
+| `app/routers/master/process_routings.py` | `PUT /process-routings?product_id={id}` を追加（リクエストボディは `RoutingBulkItem` の配列） |
+
+### Frontend の変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `types/process-routing.ts` | `ProcessRoutingBulkItem` 型を追加 |
+| `hooks/use-process-routings.ts` | `useBulkSaveProcessRoutings()` フックを追加（PUTを呼び、成功時に工程一覧・製品一覧キャッシュを invalidate） |
+| `components/product-routings-dialog.tsx` | ローカル下書き状態 (`DraftRouting[]`) を導入。追加・編集・削除・並べ替えは下書きのみを更新し、「変更を保存」ボタン押下時に一括保存。並べ替えは行ごとの上下矢印ボタンに変更し、`sequence_order` の数値入力欄は廃止（保存時に配列順から再採番）。確定トグルは従来通り即時反映とし、成功時に下書き・基準状態の両方へ反映する。ダイアログを閉じる操作（×・背景クリック・Esc）は、未保存の変更があれば確認ダイアログを挟む |
+
+### E2E テストの変更
+
+`frontend/e2e/product-routing-status.spec.ts` の `addProcess()` は工程を下書きに追加するのみになったため、`saveChanges()` ヘルパーを追加し、工程追加後に明示的に「変更を保存」を押してからサーバー状態を検証するよう更新した（未保存の新規工程は確定操作もできないため）。

--- a/frontend/e2e/product-routing-status.spec.ts
+++ b/frontend/e2e/product-routing-status.spec.ts
@@ -49,7 +49,13 @@ async function addProcess(page: Page, dialog: Locator, processName: string) {
   await dialog.locator('input[placeholder="例: 切削加工"]').fill(processName)
   const select = dialog.locator("select")
   await select.selectOption({ label: "設備なし" })
+  // 追加はローカルの下書きに反映されるのみで、サーバーへは保存されない
   await dialog.getByRole("button", { name: "追加" }).click()
+  await page.waitForTimeout(300)
+}
+
+async function saveChanges(page: Page, dialog: Locator) {
+  await dialog.getByRole("button", { name: "変更を保存" }).click()
   await page.waitForTimeout(500)
 }
 
@@ -90,6 +96,7 @@ test.describe("製品マスタ: 工程の確定状態表示", () => {
     // 工程あり・未確定: 「未確定あり」バッジ
     const unconfirmedDialog = await openRoutingsDialog(page, products.unconfirmed.name)
     await addProcess(page, unconfirmedDialog, "検査工程")
+    await saveChanges(page, unconfirmedDialog)
     await page.keyboard.press("Escape")
     await page.waitForTimeout(300)
 
@@ -99,6 +106,7 @@ test.describe("製品マスタ: 工程の確定状態表示", () => {
     // 工程あり・確定済み: 「確定済み」バッジ
     const confirmedDialog = await openRoutingsDialog(page, products.confirmed.name)
     await addProcess(page, confirmedDialog, "検査工程2")
+    await saveChanges(page, confirmedDialog)
     await confirmedDialog.getByRole("button", { name: "確定する" }).click()
     await page.waitForTimeout(500)
     await page.keyboard.press("Escape")

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Pencil, Trash2, Plus, Loader2, Lock, CheckCircle2 } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { Pencil, Trash2, Plus, Loader2, Lock, CheckCircle2, ArrowUp, ArrowDown } from "lucide-react"
 import { toast } from "sonner"
 import {
   Dialog,
@@ -35,9 +35,8 @@ import {
 } from "@/components/ui/table"
 import {
   useProcessRoutings,
-  useCreateProcessRouting,
   useUpdateProcessRouting,
-  useDeleteProcessRouting,
+  useBulkSaveProcessRoutings,
 } from "@/hooks/use-process-routings"
 import { useEquipmentGroups, formatGroupLabel } from "@/lib/hooks/use-equipment-groups"
 import { useSimulateOrder } from "@/hooks/use-orders"
@@ -51,29 +50,67 @@ interface ProductRoutingsDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+/** モーダル内でのみ扱うローカル下書き工程。id が負値の場合は未保存の新規工程を表す。 */
+interface DraftRouting {
+  id: number
+  process_name: string
+  equipment_group_id: number | null
+  setup_time_seconds: number
+  unit_time_seconds: number
+  is_confirmed: boolean
+  confirmed_by: string | null
+  confirmed_at: string | null
+}
+
+const toDraft = (routing: ProcessRouting): DraftRouting => ({
+  id: routing.id,
+  process_name: routing.process_name,
+  equipment_group_id: routing.equipment_group_id,
+  setup_time_seconds: routing.setup_time_seconds,
+  unit_time_seconds: routing.unit_time_seconds,
+  is_confirmed: routing.is_confirmed,
+  confirmed_by: routing.confirmed_by,
+  confirmed_at: routing.confirmed_at,
+})
+
+// 下書きの差分検知用に比較可能な形へ正規化する（並び順・追加・削除・編集・確定状態の変化を検知する）
+const serializeDrafts = (drafts: DraftRouting[]) => JSON.stringify(drafts)
+
 /**
  * 製品の製造工程ルーティング管理ダイアログ
+ *
+ * 工程の追加・編集・削除・並べ替えはローカルの下書き状態のみを更新し、
+ * 「変更を保存」ボタン押下時にまとめてサーバーへ反映する。
+ * 確定フラグの切り替えのみ、監査ログ（confirmed_by/confirmed_at）の正確性を優先し即時反映する。
  */
 export function ProductRoutingsDialog({
   product,
   open,
   onOpenChange,
 }: ProductRoutingsDialogProps) {
+  // ローカル下書き状態
+  const [draftRoutings, setDraftRoutings] = useState<DraftRouting[]>([])
+  const [baselineRoutings, setBaselineRoutings] = useState<DraftRouting[]>([])
+  const initializedRef = useRef(false)
+  const nextTempIdRef = useRef(-1)
+
   // 編集状態
-  const [editingRouting, setEditingRouting] = useState<ProcessRouting | null>(null)
+  const [editingId, setEditingId] = useState<number | null>(null)
   const [processName, setProcessName] = useState("")
   const [equipmentGroupId, setEquipmentGroupId] = useState<number | null | "">("")
-  const [sequenceOrder, setSequenceOrder] = useState<number | "">(1)
   const [setupTime, setSetupTime] = useState<number | "">(0)
   const [unitTime, setUnitTime] = useState<number | "">(0)
 
   // 削除確認ダイアログの状態
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-  const [routingToDelete, setRoutingToDelete] = useState<ProcessRouting | null>(null)
+  const [routingToDelete, setRoutingToDelete] = useState<DraftRouting | null>(null)
 
   // 確定取消確認ダイアログの状態
   const [unconfirmDialogOpen, setUnconfirmDialogOpen] = useState(false)
-  const [routingToUnconfirm, setRoutingToUnconfirm] = useState<ProcessRouting | null>(null)
+  const [routingToUnconfirm, setRoutingToUnconfirm] = useState<DraftRouting | null>(null)
+
+  // 未保存変更で閉じようとした場合の確認ダイアログ
+  const [closeConfirmOpen, setCloseConfirmOpen] = useState(false)
 
   // 個数からの目安
   const [estimateQuantity, setEstimateQuantity] = useState<number | "">(1000)
@@ -86,10 +123,29 @@ export function ProductRoutingsDialog({
   const isAdmin = currentMember?.role === "admin"
 
   // ミューテーション
-  const createMutation = useCreateProcessRouting()
   const updateMutation = useUpdateProcessRouting()
-  const deleteMutation = useDeleteProcessRouting()
+  const bulkSaveMutation = useBulkSaveProcessRoutings()
   const simulateMutation = useSimulateOrder()
+
+  // ダイアログが開いたタイミングでサーバーの工程一覧を下書きへ1度だけ反映する
+  // （確定トグル等によるクエリ再取得のたびに下書きが上書きされないようにするため）
+  useEffect(() => {
+    if (!open) {
+      initializedRef.current = false
+      return
+    }
+    if (initializedRef.current || !routings) return
+
+    const drafts = routings
+      .slice()
+      .sort((a, b) => a.sequence_order - b.sequence_order)
+      .map(toDraft)
+    setDraftRoutings(drafts)
+    setBaselineRoutings(drafts)
+    initializedRef.current = true
+  }, [open, routings])
+
+  const isDirty = serializeDrafts(draftRoutings) !== serializeDrafts(baselineRoutings)
 
   // 個数・工程が変わったら500ms debounce でシミュレーション実行
   useEffect(() => {
@@ -114,46 +170,30 @@ export function ProductRoutingsDialog({
 
   // フォームをリセット
   const resetForm = () => {
-    setEditingRouting(null)
+    setEditingId(null)
     setProcessName("")
     setEquipmentGroupId("")
-    setSequenceOrder(1)
     setSetupTime(0)
     setUnitTime(0)
   }
 
-  // ダイアログが閉じられたときにフォームをリセット
-  useEffect(() => {
-    if (!open) {
-      resetForm()
-    }
-  }, [open])
-
   // 編集ボタンのハンドラ
-  const handleEdit = (routing: ProcessRouting) => {
-    setEditingRouting(routing)
+  const handleEdit = (routing: DraftRouting) => {
+    setEditingId(routing.id)
     setProcessName(routing.process_name)
     setEquipmentGroupId(routing.equipment_group_id)
-    setSequenceOrder(routing.sequence_order)
     setSetupTime(routing.setup_time_seconds)
     setUnitTime(routing.unit_time_seconds)
   }
 
-  // 保存ハンドラ
-  const handleSave = async () => {
-    if (!product) return
-
-    // バリデーション
+  // 下書きへの追加・更新ハンドラ（サーバー通信は行わない）
+  const handleSave = () => {
     if (!processName.trim()) {
       toast.error("工程名を入力してください")
       return
     }
     if (equipmentGroupId === "") {
       toast.error("設備グループまたは「設備なし」を選択してください")
-      return
-    }
-    if (sequenceOrder === "" || sequenceOrder < 0) {
-      toast.error("順序を入力してください")
       return
     }
     if (setupTime === "" || setupTime < 0) {
@@ -165,82 +205,72 @@ export function ProductRoutingsDialog({
       return
     }
 
-    // この時点で sequenceOrder, setupTime, unitTime は number 型であることが保証される
-    // 重複する順序番号のチェック
-    const duplicateRouting = routings?.find(
-      (r) => r.sequence_order === (sequenceOrder as number) && r.id !== editingRouting?.id
-    )
-    if (duplicateRouting) {
-      toast.error(`順序 ${sequenceOrder} は既に工程「${duplicateRouting.process_name}」で使用されています`)
-      return
-    }
-
-    try {
-      // この時点で equipmentGroupId は "" でないことが保証される（バリデーション済み）
-      if (editingRouting) {
-        // 更新
-        await updateMutation.mutateAsync({
-          id: editingRouting.id,
-          data: {
-            process_name: processName,
-            equipment_group_id: equipmentGroupId,
-            sequence_order: sequenceOrder,
-            setup_time_seconds: setupTime,
-            unit_time_seconds: unitTime,
-          },
-        })
-        toast.success("工程を更新しました")
-      } else {
-        // 作成
-        await createMutation.mutateAsync({
-          product_id: product.id,
-          process_name: processName,
-          equipment_group_id: equipmentGroupId,
-          sequence_order: sequenceOrder,
-          setup_time_seconds: setupTime,
-          unit_time_seconds: unitTime,
-        })
-        toast.success("工程を追加しました")
+    if (editingId !== null) {
+      setDraftRoutings((prev) =>
+        prev.map((r) =>
+          r.id === editingId
+            ? {
+                ...r,
+                process_name: processName,
+                equipment_group_id: equipmentGroupId,
+                setup_time_seconds: setupTime,
+                unit_time_seconds: unitTime,
+              }
+            : r
+        )
+      )
+      toast.success("工程を更新しました（未保存）")
+    } else {
+      const newRouting: DraftRouting = {
+        id: nextTempIdRef.current--,
+        process_name: processName,
+        equipment_group_id: equipmentGroupId,
+        setup_time_seconds: setupTime,
+        unit_time_seconds: unitTime,
+        is_confirmed: false,
+        confirmed_by: null,
+        confirmed_at: null,
       }
-      resetForm()
-    } catch (error) {
-      toast.error(editingRouting ? "工程の更新に失敗しました" : "工程の追加に失敗しました")
-      console.error(error)
+      setDraftRoutings((prev) => [...prev, newRouting])
+      toast.success("工程を追加しました（未保存）")
     }
+    resetForm()
+  }
+
+  // 上下ボタンによる並べ替え
+  const moveRouting = (index: number, direction: -1 | 1) => {
+    const targetIndex = index + direction
+    setDraftRoutings((prev) => {
+      if (targetIndex < 0 || targetIndex >= prev.length) return prev
+      const next = [...prev]
+      ;[next[index], next[targetIndex]] = [next[targetIndex], next[index]]
+      return next
+    })
   }
 
   // 削除ボタンのハンドラ（確認ダイアログを開く）
-  const handleDeleteClick = (routing: ProcessRouting) => {
+  const handleDeleteClick = (routing: DraftRouting) => {
     setRoutingToDelete(routing)
     setDeleteConfirmOpen(true)
   }
 
-  // 削除の実行
-  const handleDeleteConfirm = async () => {
-    if (!product || !routingToDelete) return
+  // 削除の実行（下書きから除去するのみ）
+  const handleDeleteConfirm = () => {
+    if (!routingToDelete) return
 
-    try {
-      await deleteMutation.mutateAsync({
-        id: routingToDelete.id,
-        productId: product.id,
-      })
-      toast.success("工程を削除しました")
-
-      // 削除した工程を編集中だった場合はフォームをリセット
-      if (editingRouting?.id === routingToDelete.id) {
-        resetForm()
-      }
-    } catch (error) {
-      toast.error("工程の削除に失敗しました")
-      console.error(error)
-    } finally {
-      setDeleteConfirmOpen(false)
-      setRoutingToDelete(null)
+    setDraftRoutings((prev) => prev.filter((r) => r.id !== routingToDelete.id))
+    if (editingId === routingToDelete.id) {
+      resetForm()
     }
+    toast.success("工程を削除しました（未保存）")
+    setDeleteConfirmOpen(false)
+    setRoutingToDelete(null)
   }
 
-  // 確定トグルのハンドラ
-  const handleConfirmToggle = async (routing: ProcessRouting) => {
+  // 確定トグルのハンドラ（即時反映）
+  const handleConfirmToggle = async (routing: DraftRouting) => {
+    if (routing.id < 0) return // 未保存の新規工程は確定操作不可
+
     if (routing.is_confirmed) {
       // 確定取消 → 確認ダイアログを表示
       setRoutingToUnconfirm(routing)
@@ -248,10 +278,11 @@ export function ProductRoutingsDialog({
     } else {
       // 確定ON → 即時実行
       try {
-        await updateMutation.mutateAsync({
+        const updated = await updateMutation.mutateAsync({
           id: routing.id,
           data: { is_confirmed: true },
         })
+        applyConfirmedState(updated)
         toast.success(`工程「${routing.process_name}」を確定しました`)
       } catch (error) {
         toast.error("確定操作に失敗しました")
@@ -264,10 +295,11 @@ export function ProductRoutingsDialog({
   const handleUnconfirmConfirm = async () => {
     if (!routingToUnconfirm) return
     try {
-      await updateMutation.mutateAsync({
+      const updated = await updateMutation.mutateAsync({
         id: routingToUnconfirm.id,
         data: { is_confirmed: false },
       })
+      applyConfirmedState(updated)
       toast.success(`工程「${routingToUnconfirm.process_name}」の確定を取り消しました`)
     } catch (error) {
       toast.error("確定取消に失敗しました")
@@ -278,6 +310,66 @@ export function ProductRoutingsDialog({
     }
   }
 
+  // 確定状態の変更を下書き・基準状態の両方に反映する（保存前の他の編集内容は保持する）
+  const applyConfirmedState = (updated: ProcessRouting) => {
+    const patch = (list: DraftRouting[]) =>
+      list.map((r) =>
+        r.id === updated.id
+          ? {
+              ...r,
+              is_confirmed: updated.is_confirmed,
+              confirmed_by: updated.confirmed_by,
+              confirmed_at: updated.confirmed_at,
+            }
+          : r
+      )
+    setDraftRoutings(patch)
+    setBaselineRoutings(patch)
+  }
+
+  // 一括保存の実行
+  const handleBulkSave = async () => {
+    if (!product) return
+    try {
+      const result = await bulkSaveMutation.mutateAsync({
+        productId: product.id,
+        items: draftRoutings.map((r, index) => ({
+          id: r.id > 0 ? r.id : null,
+          process_name: r.process_name,
+          equipment_group_id: r.equipment_group_id,
+          sequence_order: index + 1,
+          setup_time_seconds: r.setup_time_seconds,
+          unit_time_seconds: r.unit_time_seconds,
+        })),
+      })
+      const drafts = result
+        .slice()
+        .sort((a, b) => a.sequence_order - b.sequence_order)
+        .map(toDraft)
+      setDraftRoutings(drafts)
+      setBaselineRoutings(drafts)
+      toast.success("変更を保存しました")
+    } catch (error) {
+      toast.error("変更の保存に失敗しました")
+      console.error(error)
+    }
+  }
+
+  // ダイアログを閉じようとした際のハンドラ（未保存の変更があれば確認を挟む）
+  const handleOpenChange = (next: boolean) => {
+    if (!next && isDirty) {
+      setCloseConfirmOpen(true)
+      return
+    }
+    onOpenChange(next)
+  }
+
+  // 確認ダイアログで「破棄して閉じる」を選択した場合
+  const handleDiscardAndClose = () => {
+    setCloseConfirmOpen(false)
+    onOpenChange(false)
+  }
+
   // 設備グループ名を取得
   const getEquipmentGroupName = (equipmentGroupId: number | null) => {
     if (equipmentGroupId === null) return "設備なし"
@@ -285,113 +377,158 @@ export function ProductRoutingsDialog({
     return group?.name || "不明"
   }
 
-  const isPending = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending
+  const isPending = updateMutation.isPending || bulkSaveMutation.isPending
 
   return (
     <>
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-6xl max-h-[85vh] flex flex-col">
         <DialogHeader className="shrink-0">
           <DialogTitle>工程管理 - {product?.name}</DialogTitle>
           <DialogDescription>
-            製品の製造工程を管理します
+            製品の製造工程を管理します。変更は「変更を保存」を押すまでサーバーに反映されません。
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid grid-cols-[2fr_1fr] gap-6 flex-1 min-h-0">
           {/* 左側: 工程リスト */}
           <div className="flex flex-col min-h-0">
-            <h3 className="text-sm font-semibold mb-3">登録済み工程</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold">
+                登録済み工程
+                {isDirty && (
+                  <span className="ml-2 text-xs font-normal text-amber-600">未保存の変更があります</span>
+                )}
+              </h3>
+              <Button
+                size="sm"
+                onClick={handleBulkSave}
+                disabled={!isDirty || isPending}
+              >
+                {bulkSaveMutation.isPending ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                変更を保存
+              </Button>
+            </div>
             <div className="border rounded-md flex-1 overflow-y-auto">
               {isLoadingRoutings ? (
                 <div className="flex items-center justify-center h-full">
                   <p className="text-sm text-muted-foreground">読み込み中...</p>
                 </div>
-              ) : routings && routings.length > 0 ? (
+              ) : draftRoutings.length > 0 ? (
                 <Table>
                   <TableHeader className="sticky top-0 z-10 bg-background">
                     <TableRow>
-                      <TableHead className="w-[80px]">順序</TableHead>
+                      <TableHead className="w-[70px]">順序</TableHead>
                       <TableHead>工程名</TableHead>
                       <TableHead>設備グループ</TableHead>
                       <TableHead className="w-[120px]">段取り時間(秒)</TableHead>
                       <TableHead className="w-[120px]">単位時間(秒)</TableHead>
                       <TableHead className="w-[80px] text-center">確定</TableHead>
-                      <TableHead className="w-[100px] text-right">操作</TableHead>
+                      <TableHead className="w-[130px] text-right">操作</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {routings
-                      .sort((a, b) => a.sequence_order - b.sequence_order)
-                      .map((routing) => (
-                        <TableRow
-                          key={routing.id}
-                          className={editingRouting?.id === routing.id ? "bg-muted/50" : ""}
-                        >
-                          <TableCell className="font-medium">{routing.sequence_order}</TableCell>
-                          <TableCell>
-                            <div className="flex items-center gap-2">
-                              {routing.process_name}
-                              {routing.is_confirmed && (
-                                <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-500 text-green-600 bg-green-50">
-                                  <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
-                                  確定済み
-                                </Badge>
-                              )}
-                            </div>
-                          </TableCell>
-                          <TableCell>{getEquipmentGroupName(routing.equipment_group_id)}</TableCell>
-                          <TableCell>{routing.setup_time_seconds}</TableCell>
-                          <TableCell>{routing.unit_time_seconds}</TableCell>
-                          <TableCell className="text-center">
-                            {isAdmin ? (
+                    {draftRoutings.map((routing, index) => (
+                      <TableRow
+                        key={routing.id}
+                        className={editingId === routing.id ? "bg-muted/50" : ""}
+                      >
+                        <TableCell className="font-medium">
+                          <div className="flex items-center gap-0.5">
+                            <span className="w-4 text-right">{index + 1}</span>
+                            <div className="flex flex-col">
                               <button
                                 type="button"
-                                onClick={() => handleConfirmToggle(routing)}
-                                disabled={isPending}
-                                aria-label={routing.is_confirmed ? "確定を取り消す" : "確定する"}
-                                className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
-                                  routing.is_confirmed
-                                    ? "bg-green-500 border-green-500"
-                                    : "bg-background border-input hover:border-green-400"
-                                } disabled:opacity-50 disabled:cursor-not-allowed`}
+                                onClick={() => moveRouting(index, -1)}
+                                disabled={index === 0}
+                                aria-label={`${routing.process_name}を上へ移動`}
+                                className="disabled:opacity-25 disabled:cursor-not-allowed hover:text-primary"
                               >
-                                {routing.is_confirmed && (
-                                  <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 12 12">
-                                    <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                                  </svg>
-                                )}
+                                <ArrowUp className="h-3 w-3" />
                               </button>
-                            ) : (
-                              <div className="flex items-center justify-center" aria-label="管理者のみ操作可能">
-                                <Lock className="h-3.5 w-3.5 text-muted-foreground" />
-                              </div>
-                            )}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex justify-end gap-1">
-                              <Button
-                                variant="ghost"
-                                size="icon-sm"
-                                onClick={() => handleEdit(routing)}
-                                disabled={isPending}
-                                aria-label={`${routing.process_name}を編集`}
+                              <button
+                                type="button"
+                                onClick={() => moveRouting(index, 1)}
+                                disabled={index === draftRoutings.length - 1}
+                                aria-label={`${routing.process_name}を下へ移動`}
+                                className="disabled:opacity-25 disabled:cursor-not-allowed hover:text-primary"
                               >
-                                <Pencil className="h-3.5 w-3.5" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon-sm"
-                                onClick={() => handleDeleteClick(routing)}
-                                disabled={isPending}
-                                aria-label={`${routing.process_name}を削除`}
-                              >
-                                <Trash2 className="h-3.5 w-3.5" />
-                              </Button>
+                                <ArrowDown className="h-3 w-3" />
+                              </button>
                             </div>
-                          </TableCell>
-                        </TableRow>
-                      ))}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            {routing.process_name}
+                            {routing.id < 0 && (
+                              <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-amber-500 text-amber-600 bg-amber-50">
+                                未保存
+                              </Badge>
+                            )}
+                            {routing.is_confirmed && (
+                              <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-green-500 text-green-600 bg-green-50">
+                                <CheckCircle2 className="h-2.5 w-2.5 mr-0.5" />
+                                確定済み
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>{getEquipmentGroupName(routing.equipment_group_id)}</TableCell>
+                        <TableCell>{routing.setup_time_seconds}</TableCell>
+                        <TableCell>{routing.unit_time_seconds}</TableCell>
+                        <TableCell className="text-center">
+                          {isAdmin ? (
+                            <button
+                              type="button"
+                              onClick={() => handleConfirmToggle(routing)}
+                              disabled={isPending || routing.id < 0}
+                              aria-label={routing.is_confirmed ? "確定を取り消す" : "確定する"}
+                              title={routing.id < 0 ? "保存後に確定できます" : undefined}
+                              className={`w-5 h-5 rounded border-2 flex items-center justify-center mx-auto transition-colors ${
+                                routing.is_confirmed
+                                  ? "bg-green-500 border-green-500"
+                                  : "bg-background border-input hover:border-green-400"
+                              } disabled:opacity-50 disabled:cursor-not-allowed`}
+                            >
+                              {routing.is_confirmed && (
+                                <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 12 12">
+                                  <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                </svg>
+                              )}
+                            </button>
+                          ) : (
+                            <div className="flex items-center justify-center" aria-label="管理者のみ操作可能">
+                              <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleEdit(routing)}
+                              disabled={isPending}
+                              aria-label={`${routing.process_name}を編集`}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleDeleteClick(routing)}
+                              disabled={isPending}
+                              aria-label={`${routing.process_name}を削除`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
                   </TableBody>
                 </Table>
               ) : (
@@ -457,12 +594,13 @@ export function ProductRoutingsDialog({
                 </div>
                 <p className="text-[10px] text-muted-foreground leading-snug">
                   他の受注がない場合の単体換算値です。実際の納期は設備の混雑状況により長くなる場合があります。
+                  未保存の工程変更は反映されません。
                 </p>
               </CardContent>
             </Card>
 
             <h3 className="text-sm font-semibold">
-              {editingRouting ? "工程編集" : "工程追加"}
+              {editingId !== null ? "工程編集" : "工程追加"}
             </h3>
 
             <div className="space-y-4 flex-1">
@@ -473,7 +611,6 @@ export function ProductRoutingsDialog({
                   value={processName}
                   onChange={(e) => setProcessName(e.target.value)}
                   placeholder="例: 切削加工"
-                  disabled={isPending}
                 />
               </div>
 
@@ -494,7 +631,6 @@ export function ProductRoutingsDialog({
                         setEquipmentGroupId(Number(e.target.value))
                       }
                     }}
-                    disabled={isPending}
                     className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <option value="">選択してください</option>
@@ -510,18 +646,6 @@ export function ProductRoutingsDialog({
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-2">
-                  <Label htmlFor="sequence-order">順序</Label>
-                  <Input
-                    id="sequence-order"
-                    type="number"
-                    min="0"
-                    value={sequenceOrder}
-                    onChange={(e) => setSequenceOrder(e.target.value === "" ? "" : Number(e.target.value))}
-                    disabled={isPending}
-                  />
-                </div>
-
-                <div className="space-y-2">
                   <Label htmlFor="setup-time">段取り時間 (秒)</Label>
                   <Input
                     id="setup-time"
@@ -529,31 +653,31 @@ export function ProductRoutingsDialog({
                     min="0"
                     value={setupTime}
                     onChange={(e) => setSetupTime(e.target.value === "" ? "" : Number(e.target.value))}
-                    disabled={isPending}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="unit-time">単位時間 (秒)</Label>
+                  <Input
+                    id="unit-time"
+                    type="number"
+                    min="0"
+                    value={unitTime}
+                    onChange={(e) => setUnitTime(e.target.value === "" ? "" : Number(e.target.value))}
                   />
                 </div>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="unit-time">単位時間 (秒)</Label>
-                <Input
-                  id="unit-time"
-                  type="number"
-                  min="0"
-                  value={unitTime}
-                  onChange={(e) => setUnitTime(e.target.value === "" ? "" : Number(e.target.value))}
-                  disabled={isPending}
-                />
-              </div>
+              <p className="text-[10px] text-muted-foreground leading-snug">
+                並べ替えは工程一覧の上下ボタンで行います。
+              </p>
             </div>
 
             <div className="flex gap-2 mt-4">
               <Button
                 onClick={handleSave}
-                disabled={isPending}
                 className="flex-1"
               >
-                {editingRouting ? (
+                {editingId !== null ? (
                   <>
                     <Pencil className="mr-2 h-4 w-4" />
                     更新
@@ -565,11 +689,10 @@ export function ProductRoutingsDialog({
                   </>
                 )}
               </Button>
-              {editingRouting && (
+              {editingId !== null && (
                 <Button
                   variant="outline"
                   onClick={resetForm}
-                  disabled={isPending}
                 >
                   キャンセル
                 </Button>
@@ -587,7 +710,7 @@ export function ProductRoutingsDialog({
           <AlertDialogTitle>工程の削除</AlertDialogTitle>
           <AlertDialogDescription>
             本当に工程「{routingToDelete?.process_name}」を削除しますか？
-            この操作は取り消せません。
+            「変更を保存」を押すまでサーバーには反映されません。
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -610,6 +733,23 @@ export function ProductRoutingsDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>キャンセル</AlertDialogCancel>
           <AlertDialogAction onClick={handleUnconfirmConfirm}>確定を取り消す</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+
+    {/* 未保存変更の警告ダイアログ */}
+    <AlertDialog open={closeConfirmOpen} onOpenChange={setCloseConfirmOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>保存されていない変更があります</AlertDialogTitle>
+          <AlertDialogDescription>
+            工程の追加・編集・削除・並べ替えの変更が保存されていません。
+            破棄してモーダルを閉じますか？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDiscardAndClose}>破棄して閉じる</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -132,6 +132,7 @@ export function ProductRoutingsDialog({
   useEffect(() => {
     if (!open) {
       initializedRef.current = false
+      resetForm()
       return
     }
     if (initializedRef.current || !routings) return
@@ -442,7 +443,7 @@ export function ProductRoutingsDialog({
                               <button
                                 type="button"
                                 onClick={() => moveRouting(index, -1)}
-                                disabled={index === 0}
+                                disabled={index === 0 || bulkSaveMutation.isPending}
                                 aria-label={`${routing.process_name}を上へ移動`}
                                 className="disabled:opacity-25 disabled:cursor-not-allowed hover:text-primary"
                               >
@@ -451,7 +452,7 @@ export function ProductRoutingsDialog({
                               <button
                                 type="button"
                                 onClick={() => moveRouting(index, 1)}
-                                disabled={index === draftRoutings.length - 1}
+                                disabled={index === draftRoutings.length - 1 || bulkSaveMutation.isPending}
                                 aria-label={`${routing.process_name}を下へ移動`}
                                 className="disabled:opacity-25 disabled:cursor-not-allowed hover:text-primary"
                               >

--- a/frontend/src/hooks/use-process-routings.ts
+++ b/frontend/src/hooks/use-process-routings.ts
@@ -3,7 +3,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { apiClient } from "@/lib/api-client"
 import { PRODUCTS_QUERY_KEY } from "@/hooks/use-products"
-import type { ProcessRouting, ProcessRoutingCreate, ProcessRoutingUpdate } from "@/types/process-routing"
+import type {
+  ProcessRouting,
+  ProcessRoutingBulkItem,
+  ProcessRoutingCreate,
+  ProcessRoutingUpdate,
+} from "@/types/process-routing"
 
 // クエリキーを生成する関数
 const getProcessRoutingsQueryKey = (productId: number) => ["process-routings", productId]
@@ -60,6 +65,33 @@ export function useUpdateProcessRouting() {
         queryKey: getProcessRoutingsQueryKey(data.product_id)
       })
       // 製品一覧の工程確定状況バッジも再取得
+      queryClient.invalidateQueries({ queryKey: PRODUCTS_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * 製品の工程セット全体を一括保存するフック（追加・更新・削除・並べ替えをまとめて反映）
+ */
+export function useBulkSaveProcessRoutings() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      productId,
+      items,
+    }: {
+      productId: number
+      items: ProcessRoutingBulkItem[]
+    }) =>
+      apiClient<ProcessRouting[]>(`/process-routings?product_id=${productId}`, {
+        method: "PUT",
+        body: JSON.stringify(items),
+      }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: getProcessRoutingsQueryKey(variables.productId),
+      })
       queryClient.invalidateQueries({ queryKey: PRODUCTS_QUERY_KEY })
     },
   })

--- a/frontend/src/types/process-routing.ts
+++ b/frontend/src/types/process-routing.ts
@@ -41,3 +41,16 @@ export interface ProcessRoutingUpdate {
   unit_time_seconds?: number
   is_confirmed?: boolean
 }
+
+/**
+ * 一括保存（PUT /process-routings）における1工程分のデータ型。
+ * id が null の場合は新規追加として扱われる。is_confirmed はここでは扱わない。
+ */
+export interface ProcessRoutingBulkItem {
+  id: number | null
+  process_name: string
+  equipment_group_id: number | null
+  sequence_order: number
+  setup_time_seconds: number
+  unit_time_seconds: number
+}


### PR DESCRIPTION
## Summary
- Issue #273 の要件に基づき、工程管理モーダル（`product-routings-dialog.tsx`）の追加・編集・削除・並べ替えを行単位の都度サーバー通信からローカル下書き＋明示保存（「変更を保存」ボタン）方式に変更
- 並べ替えを `sequence-order` の数値手入力から、行ごとの上下矢印ボタン方式に変更（タブレット・手袋操作を想定）
- 未保存の変更がある状態でモーダルを閉じようとした場合（×・背景クリック・Esc）に確認ダイアログを表示
- 一括保存用に `PUT /process-routings?product_id={id}` バルクAPIを新設（既存工程との差分から insert/update/delete）

## 設計判断（Issueの未確定事項への回答）
- **確定フラグの粒度**: 工程単位のまま維持。`get_unconfirmed_routing_counts()`（専門家キュー）や計画中の Issue #203（工程単位のロール制限）が工程単位の情報に依存するため、製品単位への統合は見送り
- **確定トグルの反映タイミング**: 一括保存には含めず、従来通り即時反映（`confirmed_by`/`confirmed_at` の監査ログ精度を優先）。未保存の新規工程は確定操作不可
- **一括保存の実装方式**: バルクAPI新設（既存エンドポイントの並列呼び出しは、部分失敗時の並び順崩れリスクがあるため不採用）
- **同時編集競合検知**: 本格実装はせず、last-write-wins を許容する方針のみ記録（詳細は `docs/features/process-routing-confirmation.md` 参照）

## Test plan
- [x] Backend: `pytest __tests__/unit/repositories/supabase/master/test_product_repo.py __tests__/api/routers/master/test_process_routings.py`（新規テスト含め全てpass。無関係な既存2件の失敗は本PR起因ではないことを main ブランチでも再現確認済み）
- [x] Backend: `ruff check` / `mypy`（変更ファイルすべてpass）
- [x] Frontend: `npx tsc --noEmit` / `npm run build`（pass）
- [x] `frontend/e2e/product-routing-status.spec.ts` を新フローに合わせて更新（追加後に明示保存するよう `saveChanges()` ヘルパーを追加）。ローカルSupabase/backend/frontend起動環境が無いため実行は未実施 — レビュー時にローカル環境で実行確認をお願いします
- [ ] ブラウザでの実機確認（追加・編集・削除・並べ替え・未保存警告・確定トグル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)