### PR TITLE
fix: PDFが注文と無関係な内容の場合にメール本文抽出へフォールバック

### DIFF
--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -15,6 +15,7 @@ class TestParsePendingOrderPdfs:
             "id": "att-1",
             "tenant_id": "tenant-1",
             "customer_id": 7,
+            "gmail_message_id": "msg-1",
             "source_raw": "本文 run_id=abc123",
             "storage_path": "tenant-1/inbox/msg-1/order.pdf",
             "original_filename": "order.pdf",
@@ -158,9 +159,21 @@ class TestParsePendingOrderPdfs:
 
         assert result == {"processed": 1, "orders_created": 0, "errors": 0}
 
-        insert_calls = mock_db.table().insert.call_args_list
-        assert not any(c.args[0].get("status") == "draft" for c in insert_calls)
-        assert any(c.args[0]["notif_type"] == "non_order_email" for c in insert_calls)
+        insert_calls = [
+            c.args[0] for c in mock_db.table().insert.call_args_list if c.args
+        ]
+        assert not any(c.get("status") == "draft" for c in insert_calls)
+
+        log_insert = next(
+            c for c in insert_calls if c.get("reason") == "non_order_email"
+        )
+        assert log_insert["order_attachment_id"] == "att-1"
+
+        notif_insert = next(
+            c for c in insert_calls if c.get("notif_type") == "non_order_email"
+        )
+        assert notif_insert["source_table"] == "gmail_message"
+        assert notif_insert["source_id"] == "msg-1"
 
     def test_exception_during_processing_counts_as_error(self):
         mock_db = MagicMock()

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -67,6 +67,101 @@ class TestParsePendingOrderPdfs:
         insert_calls = mock_db.table().insert.call_args_list
         assert any(c.args[0]["notif_type"] == "failed_encrypted" for c in insert_calls)
 
+    def test_pdf_with_no_order_lines_falls_back_to_body_extraction(self):
+        """PDFの内容が注文と無関係で明細が0件の場合、メール本文から抽出した
+        情報を使ってorderが作成されること（Issue #278）。"""
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row()]
+        )
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 42}])
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment",
+                return_value=b"%PDF-fake",
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text",
+                return_value=PdfTextResult(
+                    text="無関係な文書です", failure_reason=None
+                ),
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_order_lines",
+                return_value=[],
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_email_fields",
+                return_value={
+                    "product_name": "製品A",
+                    "quantity": 5,
+                    "deadline_date": "2026-08-01",
+                    "order_number": "PO-1",
+                },
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_products",
+                return_value={"product_id": 100, "candidates": []},
+            ),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 1, "orders_created": 1, "errors": 0}
+
+        insert_calls = [c for c in mock_db.table().insert.call_args_list if c.args]
+        order_insert = next(c.args[0] for c in insert_calls if "status" in c.args[0])
+        assert order_insert["product_id"] == 100
+        assert order_insert["quantity"] == 5
+        assert order_insert["customer_id"] == 7
+        assert order_insert["source_type"] == "email"
+
+        attachment_insert = next(
+            c.args[0] for c in insert_calls if c.args[0].get("order_id") == 42
+        )
+        assert attachment_insert["storage_path"] == "tenant-1/inbox/msg-1/order.pdf"
+
+    def test_pdf_and_body_both_yield_no_order_notifies_non_order_email(self):
+        """PDFに明細がなく、メール本文からも注文情報が抽出できない場合、
+        orderは作成せず non_order_email として通知のみ記録すること。"""
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row()]
+        )
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment",
+                return_value=b"%PDF-fake",
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text",
+                return_value=PdfTextResult(
+                    text="無関係な文書です", failure_reason=None
+                ),
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_order_lines",
+                return_value=[],
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_email_fields",
+                return_value={
+                    "product_name": "<UNKNOWN>",
+                    "quantity": None,
+                    "deadline_date": None,
+                    "order_number": None,
+                },
+            ),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 1, "orders_created": 0, "errors": 0}
+
+        insert_calls = mock_db.table().insert.call_args_list
+        assert not any(c.args[0].get("status") == "draft" for c in insert_calls)
+        assert any(c.args[0]["notif_type"] == "non_order_email" for c in insert_calls)
+
     def test_exception_during_processing_counts_as_error(self):
         mock_db = MagicMock()
         mock_db.table().select().is_().eq().execute.return_value = MagicMock(

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -131,13 +131,18 @@ def _fallback_to_body_extraction(db: Client, row: dict[str, Any]) -> int:
         fields.get(k) is None
         for k in ("product_name", "quantity", "deadline_date", "order_number")
     ):
+        detail = {"body_snippet": body[:200]}
+        _log_parse_event(db, tenant_id, attachment_id, "non_order_email", detail)
+        # non_order_email 通知は notifications router 側で source_id を
+        # Gmail メッセージIDとしてそのままリンク生成に使うため、
+        # order_attachments.id ではなく gmail_message_id を渡す必要がある
         create_notification(
             db,
             tenant_id,
             "non_order_email",
-            SupabaseTableName.ORDER_ATTACHMENTS.value,
-            attachment_id,
-            {"body_snippet": body[:200]},
+            "gmail_message",
+            row.get("gmail_message_id"),
+            detail,
         )
         logger.info(
             f"pdf_order_parsing: attachment {attachment_id} "

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.services.attachment_service import download_attachment
+from app.services.email_extraction_service import extract_email_fields
 from app.services.notification_service import create_notification
 from app.services.pdf_order_extraction_service import extract_order_lines
 from app.services.pdf_text_service import extract_text
@@ -96,12 +97,94 @@ def _parse_one(db: Client, row: dict[str, Any]) -> int:
         f"extracted {len(line_items)} line items"
     )
 
-    created_count = sum(1 for line in line_items if _process_line_item(db, row, line))
+    if line_items:
+        created_count = sum(
+            1 for line in line_items if _process_line_item(db, row, line)
+        )
+    else:
+        # PDFの内容が注文と無関係で明細が1件も抽出できなかった場合、
+        # メール本文（source_raw）からの抽出にフォールバックする（Issue #278）
+        created_count = _fallback_to_body_extraction(db, row)
 
     db.table(table).update({"parse_status": "success"}).eq(
         "id", attachment_id
     ).execute()
     return created_count
+
+
+def _fallback_to_body_extraction(db: Client, row: dict[str, Any]) -> int:
+    """
+    PDFから明細が1件も抽出できなかった場合に、メール本文（source_raw）から
+    注文情報の抽出を試みるフォールバック。
+
+    抽出できた場合は order を1件作成して1を返す。本文からも注文情報が
+    抽出できなかった場合は non_order_email として通知のみ記録し0を返す。
+    """
+    tenant_id = row["tenant_id"]
+    attachment_id = row["id"]
+    body = cast(str, row.get("source_raw") or "")
+
+    raw_fields = extract_email_fields(body)
+    fields = {k: (None if v == "<UNKNOWN>" else v) for k, v in raw_fields.items()}
+
+    if all(
+        fields.get(k) is None
+        for k in ("product_name", "quantity", "deadline_date", "order_number")
+    ):
+        create_notification(
+            db,
+            tenant_id,
+            "non_order_email",
+            SupabaseTableName.ORDER_ATTACHMENTS.value,
+            attachment_id,
+            {"body_snippet": body[:200]},
+        )
+        logger.info(
+            f"pdf_order_parsing: attachment {attachment_id} "
+            "PDF had no order lines and body extraction also failed"
+        )
+        return 0
+
+    product_id: int | None = None
+    candidates: list[dict[str, Any]] = []
+    product_name = cast(str | None, fields.get("product_name"))
+    if product_name:
+        match = match_products(db, tenant_id, product_name)
+        product_id = match["product_id"]
+        candidates = match["candidates"]
+
+    order_row: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "source_type": "email",
+        "source_raw": body,
+        "status": "draft",
+        "product_id": product_id,
+        "quantity": fields.get("quantity"),
+        "deadline_date": fields.get("deadline_date"),
+        "order_number": fields.get("order_number"),
+        "extracted_product_name": product_name,
+        "product_candidates": candidates if candidates else None,
+        "customer_id": row.get("customer_id"),
+    }
+    insert_result = db.table(SupabaseTableName.ORDERS.value).insert(order_row).execute()
+    order_id = cast(list[dict[str, Any]], insert_result.data)[0]["id"]
+
+    db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+        {
+            "order_id": order_id,
+            "tenant_id": tenant_id,
+            "storage_path": row["storage_path"],
+            "original_filename": row.get("original_filename", ""),
+            "content_type": row.get("content_type"),
+            "size_bytes": row.get("size_bytes"),
+            "parse_status": "success",
+        }
+    ).execute()
+    logger.info(
+        f"pdf_order_parsing: order {order_id} created from body fallback "
+        f"for attachment {attachment_id} (PDF had no order lines)"
+    )
+    return 1
 
 
 def _process_line_item(

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -74,6 +74,27 @@ Issue #267 で `customer_certainty` カラムを新設して是正した。
    個々の失敗理由は order_parse_log 側で追跡する)
 ```
 
+### PDFが注文と無関係な内容だった場合のフォールバック（Issue #278）
+
+添付PDFが署名画像・会社案内・注文と無関係な資料等で、`extract_order_lines` が
+明細を1件も抽出できなかった場合（`line_items == []`）、そのままでは受注下書きが
+一切起票されず、本文に書かれた注文情報が失われていた。
+
+`pdf_order_parsing_service._parse_one` は `line_items` が空のとき、ステージング行の
+`source_raw`（メール本文）に対して `email_extraction_service.extract_email_fields()`
+（[email-order-intake.md](email-order-intake.md) の添付なしメールと同じ抽出ロジック）
+によるフォールバック抽出を行う（`_fallback_to_body_extraction`）。
+
+- 本文から `product_name`/`quantity`/`deadline_date`/`order_number` のいずれかが
+  抽出できた場合: 製品照合の上、`orders` に1件 `status='draft'` で直接INSERTし、
+  ステージング行の添付ファイルを紐付ける `order_attachments` 行を追加する
+- 本文からも何も抽出できなかった場合: order は作成せず、`non_order_email` として
+  `create_notification` のみ行う（添付なしメールの「対象外メール」通知と同じ扱い）
+
+このフォールバックは `upsert_order_by_dedupe_key` によるdedupe処理を経由しない
+直接INSERTのため、既存のPDF明細処理（複数品番・確度別のupsert）とは独立した
+単発の下書き起票として扱われる。
+
 ### なぜ postgrest-py の `on_conflict` を使わないか
 
 supabase-py（postgrest-py）の `.insert(..., on_conflict=...)` は単純なマージ用であり、


### PR DESCRIPTION
## Summary
- 添付PDFが注文と無関係な内容（署名画像・会社案内等）で `extract_order_lines` が明細を1件も抽出できない場合、これまでは受注下書きが一切起票されずサイレントに処理完了していた
- PDFの明細が0件のとき、メール本文（`order_attachments.source_raw`）から `extract_email_fields` で注文情報を抽出するフォールバックを追加し、抽出できれば `orders` を1件作成、抽出できなければ `non_order_email` として通知を記録するようにした

Closes #278

## Test plan
- [x] `pytest __tests__/unit/services/test_pdf_order_parsing_service.py -v` — フォールバック成功/失敗の新規テスト含め全件パス
- [x] `pytest __tests__/unit/ __tests__/api/ -q` — 既存テストへの影響なし
- [x] `ruff check` / `mypy` — pass
- [x] `docs/features/pdf-order-parsing.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)