### PR TITLE
メール起点受注を1ソース:N受注モデルに変更（Issue #280 Phase1+2）

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,23 +2,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "pip install (functions)",
-            "type": "shell",
-            "osx": {
-                "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
-            },
-            "windows": {
-                "command": "${config:azureFunctions.pythonVenv}\\Scripts\\python -m pip install -r requirements.txt"
-            },
-            "linux": {
-                "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
-            },
-            "problemMatcher": [],
-            "options": {
-                "cwd": "${workspaceFolder}/backend"
-            }
-        },
-        {
             "label": "Backend (Uvicorn)",
             "type": "shell",
             // 仮想環境を起動してから uvicorn を実行
@@ -80,6 +63,15 @@
             "label": "Pre-commit run all files",
             "type": "shell",
             "command": "source backend/.venv/bin/activate && pre-commit run --all-files",
+            "problemMatcher": [],
+            "presentation": {
+                "group": "test-runners"
+            }
+        },
+        {
+            "label": "Run Integration Tests",
+            "type": "shell",
+            "command": "source backend/.venv/bin/activate && pytest backend/__tests__/integration --run-integration",
             "problemMatcher": [],
             "presentation": {
                 "group": "test-runners"

--- a/backend/__tests__/e2e/test_gmail_attachment_flow.py
+++ b/backend/__tests__/e2e/test_gmail_attachment_flow.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 from app.services.gmail_service import poll_unread_emails
+from app.services.pdf_order_parsing_service import parse_pending_order_pdfs
 
 
 @pytest.mark.e2e
@@ -103,9 +104,12 @@ class TestGmailAttachmentFlow:
         admin_db,
     ) -> None:
         """
-        添付なしメールを受信したとき:
-        - orders レコードが作成される（処理は継続する）
-        - order_attachments レコードが parse_status='failed_no_attachment' で作成される
+        添付なしメールを受信したとき (Issue #280 で非同期パース経路に統一):
+        - Gmail ポーリング直後は order は作成されず、order_attachments に
+          order_id=NULL のステージング行（storage_path=""）が作成される
+        - parse_pending_order_pdfs (cron) がメール本文から注文情報を抽出し、
+          orders レコードと parse_status='failed_no_attachment' の
+          order_attachments レコードを作成する
         """
         run_id = inject_email_without_attachment["run_id"]
 
@@ -115,6 +119,28 @@ class TestGmailAttachmentFlow:
         assert result["processed"] >= 1
 
         time.sleep(1)
+
+        # --- ステージング行の検証 ---
+        staging_result = (
+            admin_db.table("order_attachments")
+            .select("*")
+            .is_("order_id", "null")
+            .like("source_raw", f"%run_id={run_id}%")
+            .execute()
+        )
+        staging_rows = staging_result.data or []
+        assert len(staging_rows) == 1, (
+            f"Expected 1 staged order_attachment, got {len(staging_rows)}. "
+            f"run_id={run_id}"
+        )
+        assert staging_rows[0]["storage_path"] == ""
+        assert staging_rows[0]["parse_status"] == "pending"
+
+        # --- 非同期パースを実行 ---
+        parse_result = parse_pending_order_pdfs(admin_db)
+        assert parse_result["errors"] == 0, (
+            f"parse_pending_order_pdfs returned errors: {parse_result}"
+        )
 
         # --- orders レコードの検証 ---
         order_result = (

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -172,7 +172,11 @@ class TestGetMessageBody:
 
 @pytest.mark.unit
 class TestProcessMessagePdfStaging:
-    """PDF添付メールのステージング保存分岐 (Issue #248) の単体テスト。"""
+    """メール受信時のステージング保存分岐 (Issue #248, #280) の単体テスト。
+
+    実際の抽出・order生成は parse_pending_order_pdfs（cron）が非同期に行うため、
+    ここでは _process_message が常に order_attachments へステージング行を
+    作成するだけであることを検証する。"""
 
     def _mock_gmail_service(self):
         mock_service = MagicMock()
@@ -213,14 +217,10 @@ class TestProcessMessagePdfStaging:
                 "app.services.gmail_service.upload_staged_attachment",
                 return_value="tenant-1/inbox/msg-1/abc.pdf",
             ) as mock_upload_staged,
-            patch("app.services.gmail_service.extract_email_fields") as mock_extract,
         ):
             _process_message(mock_service, mock_db, "msg-1", "tenantA", {})
 
-        # Claudeによる単一フィールド抽出は呼ばれない（後続Issueに置き換わるため）
-        mock_extract.assert_not_called()
-
-        # orders テーブルへの INSERT は発生しない
+        # orders テーブルへの INSERT は発生しない（パースは後続の非同期処理）
         assert not any(
             call.args and call.args[0] == "orders"
             for call in mock_db.table.call_args_list
@@ -241,12 +241,11 @@ class TestProcessMessagePdfStaging:
         assert inserted_row["storage_path"] == "tenant-1/inbox/msg-1/abc.pdf"
         assert inserted_row["parse_status"] == "pending"
 
-    def test_non_pdf_attachment_keeps_existing_immediate_order_flow(self):
+    def test_non_pdf_attachment_is_staged_via_same_path_as_pdf(self):
+        """非PDF添付メールも、PDF添付メールと同じくステージング保存され、
+        即時のorder作成は行われないこと（Issue #280: 1ソース1回保存への統一）。"""
         mock_service = self._mock_gmail_service()
         mock_db = MagicMock()
-        mock_db.table("orders").insert().execute.return_value = MagicMock(
-            data=[{"id": 99}]
-        )
 
         with (
             patch(
@@ -263,37 +262,21 @@ class TestProcessMessagePdfStaging:
                     }
                 ],
             ),
-            patch(
-                "app.services.gmail_service.extract_email_fields",
-                return_value={
-                    "product_name": "製品A",
-                    "quantity": "<UNKNOWN>",
-                    "deadline_date": "<UNKNOWN>",
-                    "order_number": "<UNKNOWN>",
-                },
-            ),
             patch("app.services.gmail_service.extract_sender_email", return_value=None),
-            patch(
-                "app.services.gmail_service.match_products",
-                return_value={"product_id": None, "candidates": []},
-            ),
             patch(
                 "app.services.gmail_service.resolve_or_create_customer",
                 return_value=(7, True),
             ) as mock_resolve_customer,
             patch(
-                "app.services.gmail_service.upload_attachment",
-                return_value="tenant-1/orders/99/def.txt",
-            ) as mock_upload,
-            patch(
-                "app.services.gmail_service.upload_staged_attachment"
+                "app.services.gmail_service.upload_staged_attachment",
+                return_value="tenant-1/inbox/msg-2/def.txt",
             ) as mock_upload_staged,
         ):
             _process_message(mock_service, mock_db, "msg-2", "tenantA", {})
 
-        # 既存フロー: 添付が非PDFなら即時orderが作成され、ステージング保存は呼ばれない
-        mock_upload_staged.assert_not_called()
-        mock_upload.assert_called_once()
+        mock_upload_staged.assert_called_once_with(
+            mock_db, "tenant-1", "msg-2", "memo.txt", b"hello", "text/plain"
+        )
 
         # メールアドレスが取れない場合も customer_id は必ず設定され、下書き作成の通知が記録される
         mock_resolve_customer.assert_called_once_with(
@@ -308,14 +291,19 @@ class TestProcessMessagePdfStaging:
         assert notif_inserts[0]["notif_type"] == "customer_draft_created"
         assert notif_inserts[0]["source_id"] == "msg-2"
         assert notif_inserts[0]["detail"]["customer_id"] == 7
-        assert any(
+        assert not any(
             call.args and call.args[0] == "orders"
             for call in mock_db.table.call_args_list
         )
 
-    def test_no_extracted_fields_skips_order_and_creates_notification(self):
-        """本文から注文項目が一切抽出できない場合、orderを作成せず
-        non_order_email として通知のみ記録すること（顧客レコードも作成しない）。"""
+        inserted_row = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert inserted_row["order_id"] is None
+        assert inserted_row["storage_path"] == "tenant-1/inbox/msg-2/def.txt"
+        assert inserted_row["parse_status"] == "pending"
+
+    def test_no_attachment_email_is_staged_with_empty_storage_path(self):
+        """添付なしメールも同様にステージング保存され、storage_path は
+        空文字で保存されること（parse_pending_order_pdfs 側で本文抽出に回る）。"""
         mock_service = self._mock_gmail_service()
         mock_db = MagicMock()
 
@@ -329,33 +317,28 @@ class TestProcessMessagePdfStaging:
                 return_value=[],
             ),
             patch(
-                "app.services.gmail_service.extract_email_fields",
-                return_value={
-                    "product_name": "<UNKNOWN>",
-                    "quantity": "<UNKNOWN>",
-                    "deadline_date": "<UNKNOWN>",
-                    "order_number": "<UNKNOWN>",
-                },
-            ),
-            patch(
                 "app.services.gmail_service.extract_sender_email",
                 return_value="spam@example.com",
             ),
             patch(
-                "app.services.gmail_service.resolve_or_create_customer"
-            ) as mock_resolve_customer,
-            patch("app.services.gmail_service.upload_attachment") as mock_upload,
+                "app.services.gmail_service.resolve_or_create_customer",
+                return_value=(3, False),
+            ),
+            patch(
+                "app.services.gmail_service.upload_staged_attachment"
+            ) as mock_upload_staged,
         ):
             _process_message(mock_service, mock_db, "msg-3", "tenantA", {})
 
-        mock_resolve_customer.assert_not_called()
-        mock_upload.assert_not_called()
+        mock_upload_staged.assert_not_called()
         assert not any(
             call.args and call.args[0] == "orders"
             for call in mock_db.table.call_args_list
         )
 
-        notif_insert = mock_db.table("notifications").insert.call_args.args[0]
-        assert notif_insert["notif_type"] == "non_order_email"
-        assert notif_insert["source_table"] == "gmail_message"
-        assert notif_insert["source_id"] == "msg-3"
+        inserted_row = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert inserted_row["order_id"] is None
+        assert inserted_row["storage_path"] == ""
+        assert inserted_row["original_filename"] == ""
+        assert inserted_row["content_type"] is None
+        assert inserted_row["parse_status"] == "pending"

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -70,12 +70,14 @@ class TestParsePendingOrderPdfs:
 
     def test_pdf_with_no_order_lines_falls_back_to_body_extraction(self):
         """PDFの内容が注文と無関係で明細が0件の場合、メール本文から抽出した
-        情報を使ってorderが作成されること（Issue #278）。"""
+        line_itemsを使ってorderが作成されること（Issue #278/#280）。"""
         mock_db = MagicMock()
         mock_db.table().select().is_().eq().execute.return_value = MagicMock(
             data=[self._staging_row()]
         )
-        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 42}])
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 42, "action": "inserted"}]
+        )
 
         with (
             patch(
@@ -93,13 +95,20 @@ class TestParsePendingOrderPdfs:
                 return_value=[],
             ),
             patch(
-                "app.services.pdf_order_parsing_service.extract_email_fields",
-                return_value={
-                    "product_name": "製品A",
-                    "quantity": 5,
-                    "deadline_date": "2026-08-01",
-                    "order_number": "PO-1",
-                },
+                "app.services.pdf_order_parsing_service.extract_email_order_lines",
+                return_value=[
+                    {
+                        "product_name_raw": "製品A",
+                        "product_number_raw": None,
+                        "quantity": 5,
+                        "delivery_date": "2026-08-01",
+                        "certainty": "confirmed",
+                    }
+                ],
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+                return_value=None,
             ),
             patch(
                 "app.services.pdf_order_parsing_service.match_products",
@@ -110,17 +119,67 @@ class TestParsePendingOrderPdfs:
 
         assert result == {"processed": 1, "orders_created": 1, "errors": 0}
 
-        insert_calls = [c for c in mock_db.table().insert.call_args_list if c.args]
-        order_insert = next(c.args[0] for c in insert_calls if "status" in c.args[0])
-        assert order_insert["product_id"] == 100
-        assert order_insert["quantity"] == 5
-        assert order_insert["customer_id"] == 7
-        assert order_insert["source_type"] == "email"
+        rpc_params = mock_db.rpc.call_args_list[-1].args[1]
+        assert rpc_params["p_product_id"] == 100
+        assert rpc_params["p_quantity"] == 5
+        assert rpc_params["p_customer_id"] == 7
+        assert rpc_params["p_source_type"] == "email"
+        assert rpc_params["p_source_attachment_id"] == "att-1"
 
-        attachment_insert = next(
-            c.args[0] for c in insert_calls if c.args[0].get("order_id") == 42
-        )
+        attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert attachment_insert["order_id"] == 42
         assert attachment_insert["storage_path"] == "tenant-1/inbox/msg-1/order.pdf"
+
+    def test_body_fallback_with_multiple_line_items_creates_multiple_orders(self):
+        """1通のメールに部品番号ごとの複数月分の内示数量が含まれる場合
+        （Issue #280の実例）、line_items配列として複数明細を抽出し、
+        それぞれ別のorderとして作成すること。"""
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row()]
+        )
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 1, "action": "inserted"}]
+        )
+
+        line_items = [
+            {
+                "product_name_raw": "B115105",
+                "product_number_raw": "B115105",
+                "quantity": q,
+                "delivery_date": f"2026-{month:02d}-01",
+                "certainty": "forecast",
+            }
+            for month, q in zip(range(10, 13), [100, 110, 120], strict=True)
+        ]
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment",
+                return_value=b"%PDF-fake",
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text",
+                return_value=PdfTextResult(
+                    text="無関係な文書です", failure_reason=None
+                ),
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_order_lines",
+                return_value=[],
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_email_order_lines",
+                return_value=line_items,
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+                return_value=100,
+            ),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 1, "orders_created": 3, "errors": 0}
 
     def test_pdf_and_body_both_yield_no_order_notifies_non_order_email(self):
         """PDFに明細がなく、メール本文からも注文情報が抽出できない場合、
@@ -146,13 +205,8 @@ class TestParsePendingOrderPdfs:
                 return_value=[],
             ),
             patch(
-                "app.services.pdf_order_parsing_service.extract_email_fields",
-                return_value={
-                    "product_name": "<UNKNOWN>",
-                    "quantity": None,
-                    "deadline_date": None,
-                    "order_number": None,
-                },
+                "app.services.pdf_order_parsing_service.extract_email_order_lines",
+                return_value=[],
             ),
         ):
             result = parse_pending_order_pdfs(mock_db)
@@ -174,6 +228,59 @@ class TestParsePendingOrderPdfs:
         )
         assert notif_insert["source_table"] == "gmail_message"
         assert notif_insert["source_id"] == "msg-1"
+
+    def test_non_pdf_staging_row_skips_pdf_extraction_and_uses_email_body(self):
+        """非PDF添付・添付なしメール由来のステージング行（Issue #280）は、
+        PDFテキスト抽出を経由せず直接メール本文から抽出すること。"""
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[
+                self._staging_row(
+                    storage_path="",
+                    original_filename="",
+                    content_type=None,
+                    size_bytes=None,
+                )
+            ]
+        )
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 9, "action": "inserted"}]
+        )
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment"
+            ) as mock_download,
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text"
+            ) as mock_extract_text,
+            patch(
+                "app.services.pdf_order_parsing_service.extract_email_order_lines",
+                return_value=[
+                    {
+                        "product_name_raw": "製品B",
+                        "product_number_raw": "CODE-B",
+                        "quantity": 3,
+                        "delivery_date": "2026-11-30",
+                        "certainty": "forecast_tentative",
+                    }
+                ],
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+                return_value=200,
+            ),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        mock_download.assert_not_called()
+        mock_extract_text.assert_not_called()
+        assert result == {"processed": 1, "orders_created": 1, "errors": 0}
+
+        attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert attachment_insert["order_id"] == 9
+        assert attachment_insert["parse_status"] == "failed_no_attachment"
+        assert attachment_insert["storage_path"] == ""
 
     def test_exception_during_processing_counts_as_error(self):
         mock_db = MagicMock()
@@ -380,11 +487,44 @@ class TestProcessLineItem:
         assert rpc_params["p_product_id"] == 100
         assert rpc_params["p_customer_certainty"] == "forecast"
         assert rpc_params["p_customer_id"] == 7
+        assert rpc_params["p_source_attachment_id"] == "att-1"
 
         attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
         assert attachment_insert["order_id"] == 555
         assert attachment_insert["parse_status"] == "success"
         assert attachment_insert["storage_path"] == "tenant-1/inbox/msg-1/order.pdf"
+
+    def test_no_storage_path_marks_attachment_failed_no_attachment(self):
+        """添付なしメール由来のステージング行（storage_path=""）から生成された
+        orderの order_attachments 行は parse_status='failed_no_attachment' で
+        作成されること（フロントエンドの表示分岐と揃える）。"""
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 555, "action": "inserted"}]
+        )
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "forecast",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(
+                mock_db,
+                self._staging_row(
+                    storage_path="", original_filename="", content_type=None
+                ),
+                line,
+            )
+
+        assert created is True
+        attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert attachment_insert["parse_status"] == "failed_no_attachment"
 
     def test_unknown_certainty_falls_back_to_forecast_tentative(self):
         """Claude抽出結果が想定外の値（揺れ・スキーマ変更等）を返した場合でも、
@@ -477,3 +617,62 @@ class TestProcessLineItem:
         attachment_insert = insert_calls[0].args[0]
         assert attachment_insert["order_id"] == 777
         assert not any("reason" in c.args[0] for c in insert_calls)
+
+    def test_quantity_above_threshold_notifies_multi_order_suspected(self):
+        """1明細の数量が閾値を超える場合、複数受注が1明細にマージされた疑いを
+        検知して multi_order_suspected を通知すること（Issue #280）。
+        通知はあくまで情報提供であり、order作成自体はブロックしない。"""
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 555, "action": "inserted"}]
+        )
+        line = {
+            "product_name_raw": "B115105",
+            "product_number_raw": "B115105",
+            "quantity": 999_999,
+            "delivery_date": "2026-08-01",
+            "certainty": "forecast",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is True
+        insert_calls = [
+            c.args[0] for c in mock_db.table().insert.call_args_list if c.args
+        ]
+        log_insert = next(
+            c for c in insert_calls if c.get("reason") == "multi_order_suspected"
+        )
+        assert log_insert["detail"]["quantity"] == 999_999
+        notif_insert = next(
+            c for c in insert_calls if c.get("notif_type") == "multi_order_suspected"
+        )
+        assert notif_insert["source_table"] == "order_parse_log"
+
+    def test_quantity_below_threshold_does_not_notify(self):
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 555, "action": "inserted"}]
+        )
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "forecast",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            _process_line_item(mock_db, self._staging_row(), line)
+
+        insert_calls = [
+            c.args[0] for c in mock_db.table().insert.call_args_list if c.args
+        ]
+        assert not any(c.get("reason") == "multi_order_suspected" for c in insert_calls)

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -438,6 +438,30 @@ class TestProcessLineItem:
         notif_insert = insert_calls[1].args[0]
         assert notif_insert["notif_type"] == "draft_conflict_skipped"
 
+    def test_invalid_quantity_type_skips_without_calling_rpc(self):
+        """quantityがint/None以外の想定外の型（スキーマ崩れ等）の場合、
+        不整合なorderを作らないよう明細をスキップし、ログのみ記録すること。"""
+        mock_db = MagicMock()
+        line = {
+            "product_name_raw": "製品A",
+            "product_number_raw": "CODE-1",
+            "quantity": "約100個",
+            "delivery_date": "2026-08-01",
+            "certainty": "confirmed",
+        }
+
+        with patch(
+            "app.services.pdf_order_parsing_service.match_product_by_code",
+            return_value=100,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is False
+        mock_db.rpc.assert_not_called()
+        log_insert = mock_db.table("order_parse_log").insert.call_args.args[0]
+        assert log_insert["reason"] == "invalid_quantity"
+        assert log_insert["detail"]["quantity"] == "約100個"
+
     def test_no_change_skips_without_logging(self):
         mock_db = MagicMock()
         mock_db.rpc().execute.return_value = MagicMock(

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -21,11 +21,12 @@ notifications_router = APIRouter(
 
 logger = get_logger(__name__)
 
-# order_parse_log 経由の通知（PDF照合失敗・格下げ/重複スキップ）
+# order_parse_log 経由の通知（PDF照合失敗・格下げ/重複スキップ・複数受注疑い）
 _PARSE_LOG_NOTIF_TYPES = {
     "no_product_match",
     "downgrade_skipped",
     "draft_conflict_skipped",
+    "multi_order_suspected",
 }
 
 

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -17,28 +17,6 @@ def _safe_filename(filename: str) -> str:
     return uuid.uuid4().hex + ext
 
 
-def upload_attachment(
-    admin_client: Client,
-    tenant_id: str,
-    order_id: int,
-    filename: str,
-    content: bytes,
-    content_type: str,
-) -> str:
-    """
-    添付ファイルを Supabase Storage にアップロードし、storage_path を返す。
-    パス形式: {tenant_id}/orders/{order_id}/{safe_filename}
-    元のファイル名は呼び出し元が original_filename カラムに保存する。
-    """
-    storage_path = f"{tenant_id}/orders/{order_id}/{_safe_filename(filename)}"
-    admin_client.storage.from_(_BUCKET).upload(
-        path=storage_path,
-        file=content,
-        file_options={"content-type": content_type, "upsert": "true"},
-    )
-    return storage_path
-
-
 def upload_staged_attachment(
     admin_client: Client,
     tenant_id: str,

--- a/backend/app/services/email_extraction_service.py
+++ b/backend/app/services/email_extraction_service.py
@@ -1,58 +1,87 @@
 import os
-from typing import Any
+from typing import Any, cast
 
 import anthropic
 
 _client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
 _EXTRACT_TOOL: Any = {
-    "name": "extract_order_fields",
-    "description": "メール本文から注文情報を抽出する",
+    "name": "extract_email_order_lines",
+    "description": (
+        "メール本文から注文明細行を抽出する。"
+        "1通のメールに複数品番・複数納期・複数の確度（確定/内示/内々示）の明細が"
+        "含まれる場合（例: 品番ごとに複数月分の内示数量が並ぶ表）、行ごとに分けて返すこと。"
+    ),
     "input_schema": {
         "type": "object",
         "properties": {
-            "product_name": {
-                "type": ["string", "null"],
-                "description": "製品名・型番・品番等の文字列。見つからない場合はnull",
-            },
-            "quantity": {
-                "type": ["integer", "null"],
-                "description": "注文数量（整数）。見つからない場合はnull",
-            },
-            "deadline_date": {
-                "type": ["string", "null"],
-                "description": "希望納期 (ISO 8601: YYYY-MM-DD)。見つからない場合はnull",
-            },
-            "order_number": {
-                "type": ["string", "null"],
-                "description": "顧客注文番号・発注番号。見つからない場合はnull",
+            "line_items": {
+                "type": "array",
+                "description": (
+                    "メール本文内の注文明細行の配列。注文情報が見つからない場合は空配列。"
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "product_name_raw": {
+                            "type": ["string", "null"],
+                            "description": "製品名・型番・品番等の文字列。不明な場合はnull",
+                        },
+                        "product_number_raw": {
+                            "type": ["string", "null"],
+                            "description": "品番。不明な場合はnull",
+                        },
+                        "quantity": {
+                            "type": ["integer", "null"],
+                            "description": "数量（整数）。不明な場合はnull",
+                        },
+                        "delivery_date": {
+                            "type": ["string", "null"],
+                            "description": "希望納期 (ISO 8601: YYYY-MM-DD)。不明な場合はnull",
+                        },
+                        "certainty": {
+                            "type": "string",
+                            "enum": ["confirmed", "forecast", "forecast_tentative"],
+                            "description": (
+                                "明細の確度。"
+                                "confirmed=確定納期・確定発注書番号(PO番号)が明記されている確定分、"
+                                "forecast=「内示」「見込み」等、確定していないが具体的な数量・納期が"
+                                "提示されている分、"
+                                "forecast_tentative=「内々示」「予定」等、さらに不確実性が高い先の見込み分。"
+                                "文言（確定/内示/内々示、PO番号の有無等）を根拠に判定すること。"
+                            ),
+                        },
+                    },
+                    "required": [
+                        "product_name_raw",
+                        "product_number_raw",
+                        "quantity",
+                        "delivery_date",
+                        "certainty",
+                    ],
+                },
             },
         },
-        "required": ["product_name", "quantity", "deadline_date", "order_number"],
+        "required": ["line_items"],
     },
 }
 
 
-def extract_email_fields(body: str) -> dict:
+def extract_email_order_lines(body: str) -> list[dict[str, Any]]:
     model = os.environ.get("EMAIL_EXTRACTION_MODEL", "claude-haiku-4-5-20251001")
     response = _client.messages.create(
         model=model,
-        max_tokens=512,
+        max_tokens=1024,
         tools=[_EXTRACT_TOOL],
-        tool_choice={"type": "tool", "name": "extract_order_fields"},
+        tool_choice={"type": "tool", "name": "extract_email_order_lines"},
         messages=[
             {
                 "role": "user",
-                "content": f"以下のメール本文から注文情報を抽出してください。\n\n{body}",
+                "content": f"以下のメール本文から注文明細を抽出してください。\n\n{body}",
             }
         ],
     )
     for block in response.content:
-        if block.type == "tool_use" and block.name == "extract_order_fields":
-            return block.input
-    return {
-        "product_name": None,
-        "quantity": None,
-        "deadline_date": None,
-        "order_number": None,
-    }
+        if block.type == "tool_use" and block.name == "extract_email_order_lines":
+            return cast(list[dict[str, Any]], block.input.get("line_items", []))
+    return []

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -7,14 +7,12 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
-from app.services.attachment_service import upload_attachment, upload_staged_attachment
+from app.services.attachment_service import upload_staged_attachment
 from app.services.customer_matching_service import (
     extract_sender_email,
     resolve_or_create_customer,
 )
-from app.services.email_extraction_service import extract_email_fields
 from app.services.notification_service import create_notification
-from app.services.product_matching_service import match_products
 from app.utils.logger import get_logger
 from supabase import Client
 
@@ -199,98 +197,15 @@ def _process_message(
         if not tenant_id:
             raise ValueError(f"tenant not found for label: {tenant_name}")
 
-        # 4. 添付ファイル取得（PDF判定のため単一フィールド抽出より前に行う）
+        # 4. 添付ファイル取得。PDFがあれば優先し、無ければ最初の添付を使う
+        #    （複数添付の個別処理は本Issueのスコープ外。1メール1添付を前提とする）
         attachments = _get_attachments(service, msg_id, msg.get("payload", {}))
         pdf_attachment = next(
             (a for a in attachments if a["content_type"] == "application/pdf"), None
         )
+        staged_attachment = pdf_attachment or (attachments[0] if attachments else None)
 
-        if pdf_attachment is not None:
-            # PDF添付メール: orderは作成せず、order_attachments にステージング保存する
-            # （パースして複数orderを生成する処理は後続Issueで実装）
-            sender_email = extract_sender_email(body)
-            customer_id, created_draft = resolve_or_create_customer(
-                db, tenant_id, body, msg.get("internalDate")
-            )
-            if created_draft:
-                create_notification(
-                    db,
-                    tenant_id,
-                    "customer_draft_created",
-                    "gmail_message",
-                    msg_id,
-                    {"customer_id": customer_id, "email": sender_email},
-                )
-
-            storage_path = upload_staged_attachment(
-                db,
-                tenant_id,
-                msg_id,
-                pdf_attachment["filename"],
-                pdf_attachment["data"],
-                pdf_attachment["content_type"],
-            )
-            db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
-                {
-                    "order_id": None,
-                    "tenant_id": tenant_id,
-                    "customer_id": customer_id,
-                    "gmail_message_id": msg_id,
-                    "source_raw": body,
-                    "storage_path": storage_path,
-                    "original_filename": pdf_attachment["filename"],
-                    "content_type": pdf_attachment["content_type"],
-                    "size_bytes": len(pdf_attachment["data"]),
-                    "parse_status": "pending",
-                }
-            ).execute()
-            logger.info(
-                f"msg {msg_id}: PDF attachment staged at {storage_path} "
-                f"(tenant={tenant_id}, order not created)"
-            )
-
-            # 5. 処理中 → 処理済み
-            _move_label(service, msg_id, done_id, processing_id)
-            return
-
-        # 添付なし・非PDF添付メール: 既存フロー（即時order作成）を維持する
-
-        # 5. Claude で注文フィールド抽出
-        raw_fields = extract_email_fields(body)
-        fields = {k: (None if v == "<UNKNOWN>" else v) for k, v in raw_fields.items()}
-        logger.info(f"msg {msg_id}: extracted fields={fields}")
-
-        # 5.5 受注メールでない（本文から注文項目が一切抽出できない）場合は
-        #     orderを作成せず通知のみ記録する。顧客レコードも作成しない
-        #     （迷惑メール送信元で顧客テーブルを汚染しないため）。
-        if all(
-            fields.get(k) is None
-            for k in ("product_name", "quantity", "deadline_date", "order_number")
-        ):
-            create_notification(
-                db,
-                tenant_id,
-                "non_order_email",
-                "gmail_message",
-                msg_id,
-                {"body_snippet": body[:200]},
-            )
-            logger.info(
-                f"msg {msg_id}: no order fields extracted, skipping order creation"
-            )
-            _move_label(service, msg_id, done_id, processing_id)
-            return
-
-        # 6. 製品マッチング
-        product_id: int | None = None
-        candidates: list[dict] = []
-        product_name: str | None = fields.get("product_name")
-        if product_name:
-            match = match_products(db, tenant_id, product_name)
-            product_id = match["product_id"]
-            candidates = match["candidates"]
-
-        # 7. 顧客マッチング
+        # 5. 顧客マッチング（メールの受注可否に関わらず、ソース単位で1回解決する）
         sender_email = extract_sender_email(body)
         customer_id, created_draft = resolve_or_create_customer(
             db, tenant_id, body, msg.get("internalDate")
@@ -305,65 +220,48 @@ def _process_message(
                 {"customer_id": customer_id, "email": sender_email},
             )
 
-        # 8. ドラフト注文を Supabase に登録
-        order_row: dict[str, Any] = {
-            "tenant_id": tenant_id,
-            "source_type": "email",
-            "source_raw": body,
-            "status": "draft",
-            "product_id": product_id,
-            "quantity": fields.get("quantity"),
-            "deadline_date": fields.get("deadline_date"),
-            "order_number": fields.get("order_number"),
-            "extracted_product_name": fields.get("product_name"),
-            "product_candidates": candidates if candidates else None,
-            "customer_id": customer_id,
-        }
-        insert_result = (
-            db.table(SupabaseTableName.ORDERS.value).insert(order_row).execute()
-        )
-        order_id: int = cast(list[dict[str, Any]], insert_result.data)[0]["id"]
-        logger.info(
-            f"msg {msg_id}: order draft created (id={order_id}) for tenant {tenant_id}"
-        )
-
-        # 9. 添付ファイル（非PDF）を Storage に保存し order_attachments に記録
-        if attachments:
-            # 現在は1メール1添付を前提とし、最初の添付のみ処理する
-            att = attachments[0]
-            storage_path = upload_attachment(
+        # 6. 添付ファイル（あれば）をStorageにステージング保存し、
+        #    order_attachments に order_id=NULL のステージング行として保存する。
+        #    実際のパース（本文/PDFからの line_items 抽出・複数order生成）は
+        #    parse_pending_order_pdfs（cron）が非同期に行う（Issue #248, #280）。
+        if staged_attachment is not None:
+            storage_path = upload_staged_attachment(
                 db,
                 tenant_id,
-                order_id,
-                att["filename"],
-                att["data"],
-                att["content_type"],
+                msg_id,
+                staged_attachment["filename"],
+                staged_attachment["data"],
+                staged_attachment["content_type"],
             )
-            db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
-                {
-                    "order_id": order_id,
-                    "tenant_id": tenant_id,
-                    "storage_path": storage_path,
-                    "original_filename": att["filename"],
-                    "content_type": att["content_type"],
-                    "size_bytes": len(att["data"]),
-                    "parse_status": "pending",
-                }
-            ).execute()
-            logger.info(f"msg {msg_id}: attachment saved to {storage_path}")
+            original_filename = staged_attachment["filename"]
+            content_type = staged_attachment["content_type"]
+            size_bytes = len(staged_attachment["data"])
         else:
-            db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
-                {
-                    "order_id": order_id,
-                    "tenant_id": tenant_id,
-                    "storage_path": "",
-                    "original_filename": "",
-                    "parse_status": "failed_no_attachment",
-                }
-            ).execute()
-            logger.info(f"msg {msg_id}: no attachment found")
+            storage_path = ""
+            original_filename = ""
+            content_type = None
+            size_bytes = None
 
-        # 10. 処理中 → 処理済み
+        db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+            {
+                "order_id": None,
+                "tenant_id": tenant_id,
+                "customer_id": customer_id,
+                "gmail_message_id": msg_id,
+                "source_raw": body,
+                "storage_path": storage_path,
+                "original_filename": original_filename,
+                "content_type": content_type,
+                "size_bytes": size_bytes,
+                "parse_status": "pending",
+            }
+        ).execute()
+        logger.info(
+            f"msg {msg_id}: staged for deferred parsing "
+            f"(tenant={tenant_id}, attachment={'yes' if staged_attachment else 'no'})"
+        )
+
+        # 7. 処理中 → 処理済み
         _move_label(service, msg_id, done_id, processing_id)
 
     except Exception as exc:

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -203,6 +203,31 @@ def _check_multi_order_suspected(
     )
 
 
+def _resolve_product_id(
+    db: Client,
+    tenant_id: str,
+    product_number_raw: str | None,
+    product_name_raw: str | None,
+) -> int | None:
+    """
+    1. products.code の完全一致
+    2. products.name に対する品番文字列でのpg_trgm検索
+       （code列が未整備で、name列に品番文字列が入っているテナントに対応するため）
+    3. products.name に対する品名文字列でのpg_trgm検索
+    の順にフォールバックして product_id を解決する。
+    """
+    product_id: int | None = None
+    if product_number_raw:
+        product_id = match_product_by_code(db, tenant_id, product_number_raw)
+    if product_id is None and product_number_raw:
+        match = match_products(db, tenant_id, product_number_raw)
+        product_id = match["product_id"]
+    if product_id is None and product_name_raw:
+        match = match_products(db, tenant_id, product_name_raw)
+        product_id = match["product_id"]
+    return product_id
+
+
 def _process_line_item(
     db: Client, staging_row: dict[str, Any], line: dict[str, Any]
 ) -> bool:
@@ -215,19 +240,9 @@ def _process_line_item(
     product_number_raw = line.get("product_number_raw")
     product_name_raw = line.get("product_name_raw")
 
-    # 1. products.code の完全一致
-    # 2. products.name に対する品番文字列でのpg_trgm検索
-    #    （code列が未整備で、name列に品番文字列が入っているテナントに対応するため）
-    # 3. products.name に対する品名文字列でのpg_trgm検索
-    product_id: int | None = None
-    if product_number_raw:
-        product_id = match_product_by_code(db, tenant_id, product_number_raw)
-    if product_id is None and product_number_raw:
-        match = match_products(db, tenant_id, product_number_raw)
-        product_id = match["product_id"]
-    if product_id is None and product_name_raw:
-        match = match_products(db, tenant_id, product_name_raw)
-        product_id = match["product_id"]
+    product_id = _resolve_product_id(
+        db, tenant_id, product_number_raw, product_name_raw
+    )
 
     if product_id is None:
         detail = {
@@ -257,6 +272,19 @@ def _process_line_item(
     )
     deadline_date = line.get("delivery_date")
 
+    # 抽出結果の揺れ・想定外の型（本来はツールスキーマで int|null に制約されるが、
+    # スキーマ変更等で崩れた場合の防御）。不正な値のまま RPC に渡すと不整合な
+    # order が作成されてしまうため、明細ごとスキップしてログのみ残す。
+    quantity = line.get("quantity")
+    if quantity is not None and not isinstance(quantity, int):
+        detail = {
+            "product_number_raw": product_number_raw,
+            "product_name_raw": product_name_raw,
+            "quantity": quantity,
+        }
+        _log_parse_event(db, tenant_id, attachment_id, "invalid_quantity", detail)
+        return False
+
     _check_multi_order_suspected(db, tenant_id, attachment_id, line)
 
     rpc_result = db.rpc(
@@ -265,7 +293,7 @@ def _process_line_item(
             "p_tenant_id": tenant_id,
             "p_customer_id": staging_row.get("customer_id"),
             "p_product_id": product_id,
-            "p_quantity": line.get("quantity"),
+            "p_quantity": quantity,
             "p_deadline_date": deadline_date,
             "p_customer_certainty": certainty,
             "p_source_type": "email",

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -1,9 +1,10 @@
+import os
 from datetime import UTC, datetime
 from typing import Any, cast
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.services.attachment_service import download_attachment
-from app.services.email_extraction_service import extract_email_fields
+from app.services.email_extraction_service import extract_email_order_lines
 from app.services.notification_service import create_notification
 from app.services.pdf_order_extraction_service import extract_order_lines
 from app.services.pdf_text_service import extract_text
@@ -23,11 +24,18 @@ _KNOWN_UPSERT_ACTIONS = {
     "skipped_draft_conflict",
 }
 
+# 自動抽出時に複数受注が1明細にマージされてしまった疑いを検知する粗いヒューリスティック。
+# まずは数量の異常値のみを対象とし、本番データの精度を見ながら閾値・条件を調整する前提
+# （Issue #280 未解決の論点）。
+_MULTI_ORDER_QUANTITY_THRESHOLD = int(
+    os.environ.get("MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD", "100000")
+)
+
 
 def parse_pending_order_pdfs(db: Client) -> dict[str, int]:
     """
     order_attachments のステージング行 (order_id IS NULL, parse_status='pending') を
-    ポーリングし、PDFをパースして複数の orders 行を生成する。
+    ポーリングし、PDF・メール本文をパースして複数の orders 行を生成する。
     """
     table = SupabaseTableName.ORDER_ATTACHMENTS.value
     result = (
@@ -70,41 +78,47 @@ def _parse_one(db: Client, row: dict[str, Any]) -> int:
     table = SupabaseTableName.ORDER_ATTACHMENTS.value
     attachment_id = row["id"]
 
-    content = download_attachment(db, row["storage_path"])
-    text_result = extract_text(content)
+    # PDF添付があればPDFのテキストから明細抽出を試み、明細が0件ならメール本文に
+    # フォールバックする。非PDF添付・添付なしメール（storage_path が空）は、
+    # そもそもPDFが存在しないため直接メール本文から抽出する（Issue #280）。
+    if row.get("content_type") == "application/pdf" and row.get("storage_path"):
+        content = download_attachment(db, row["storage_path"])
+        text_result = extract_text(content)
 
-    if text_result.failure_reason is not None:
-        db.table(table).update({"parse_status": text_result.failure_reason}).eq(
-            "id", attachment_id
-        ).execute()
-        create_notification(
-            db,
-            row["tenant_id"],
-            text_result.failure_reason,
-            SupabaseTableName.ORDER_ATTACHMENTS.value,
-            attachment_id,
-            {},
-        )
+        if text_result.failure_reason is not None:
+            db.table(table).update({"parse_status": text_result.failure_reason}).eq(
+                "id", attachment_id
+            ).execute()
+            create_notification(
+                db,
+                row["tenant_id"],
+                text_result.failure_reason,
+                SupabaseTableName.ORDER_ATTACHMENTS.value,
+                attachment_id,
+                {},
+            )
+            logger.info(
+                f"pdf_order_parsing: attachment {attachment_id} "
+                f"marked {text_result.failure_reason}"
+            )
+            return 0
+
+        line_items = extract_order_lines(cast(str, text_result.text))
         logger.info(
             f"pdf_order_parsing: attachment {attachment_id} "
-            f"marked {text_result.failure_reason}"
+            f"extracted {len(line_items)} line items"
         )
-        return 0
 
-    line_items = extract_order_lines(cast(str, text_result.text))
-    logger.info(
-        f"pdf_order_parsing: attachment {attachment_id} "
-        f"extracted {len(line_items)} line items"
-    )
-
-    if line_items:
-        created_count = sum(
-            1 for line in line_items if _process_line_item(db, row, line)
-        )
+        if line_items:
+            created_count = sum(
+                1 for line in line_items if _process_line_item(db, row, line)
+            )
+        else:
+            # PDFの内容が注文と無関係で明細が1件も抽出できなかった場合、
+            # メール本文（source_raw）からの抽出にフォールバックする（Issue #278）
+            created_count = _process_email_body(db, row)
     else:
-        # PDFの内容が注文と無関係で明細が1件も抽出できなかった場合、
-        # メール本文（source_raw）からの抽出にフォールバックする（Issue #278）
-        created_count = _fallback_to_body_extraction(db, row)
+        created_count = _process_email_body(db, row)
 
     db.table(table).update({"parse_status": "success"}).eq(
         "id", attachment_id
@@ -112,25 +126,24 @@ def _parse_one(db: Client, row: dict[str, Any]) -> int:
     return created_count
 
 
-def _fallback_to_body_extraction(db: Client, row: dict[str, Any]) -> int:
+def _process_email_body(db: Client, row: dict[str, Any]) -> int:
     """
-    PDFから明細が1件も抽出できなかった場合に、メール本文（source_raw）から
-    注文情報の抽出を試みるフォールバック。
+    メール本文（source_raw）から注文明細行を抽出し、order を生成する。
 
-    抽出できた場合は order を1件作成して1を返す。本文からも注文情報が
-    抽出できなかった場合は non_order_email として通知のみ記録し0を返す。
+    PDFから明細が1件も抽出できなかった場合のフォールバック（Issue #278）と、
+    非PDF添付・添付なしメールの本処理（Issue #280）を兼ねる共通経路。
+    1通のメールに複数明細が含まれる場合も line_items 配列として抽出できる。
+
+    本文からも注文情報が抽出できなかった場合は non_order_email として
+    通知のみ記録し0を返す。
     """
     tenant_id = row["tenant_id"]
     attachment_id = row["id"]
     body = cast(str, row.get("source_raw") or "")
 
-    raw_fields = extract_email_fields(body)
-    fields = {k: (None if v == "<UNKNOWN>" else v) for k, v in raw_fields.items()}
+    line_items = extract_email_order_lines(body)
 
-    if all(
-        fields.get(k) is None
-        for k in ("product_name", "quantity", "deadline_date", "order_number")
-    ):
+    if not line_items:
         detail = {"body_snippet": body[:200]}
         _log_parse_event(db, tenant_id, attachment_id, "non_order_email", detail)
         # non_order_email 通知は notifications router 側で source_id を
@@ -146,50 +159,48 @@ def _fallback_to_body_extraction(db: Client, row: dict[str, Any]) -> int:
         )
         logger.info(
             f"pdf_order_parsing: attachment {attachment_id} "
-            "PDF had no order lines and body extraction also failed"
+            "no order information found in email body"
         )
         return 0
 
-    product_id: int | None = None
-    candidates: list[dict[str, Any]] = []
-    product_name = cast(str | None, fields.get("product_name"))
-    if product_name:
-        match = match_products(db, tenant_id, product_name)
-        product_id = match["product_id"]
-        candidates = match["candidates"]
-
-    order_row: dict[str, Any] = {
-        "tenant_id": tenant_id,
-        "source_type": "email",
-        "source_raw": body,
-        "status": "draft",
-        "product_id": product_id,
-        "quantity": fields.get("quantity"),
-        "deadline_date": fields.get("deadline_date"),
-        "order_number": fields.get("order_number"),
-        "extracted_product_name": product_name,
-        "product_candidates": candidates if candidates else None,
-        "customer_id": row.get("customer_id"),
-    }
-    insert_result = db.table(SupabaseTableName.ORDERS.value).insert(order_row).execute()
-    order_id = cast(list[dict[str, Any]], insert_result.data)[0]["id"]
-
-    db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
-        {
-            "order_id": order_id,
-            "tenant_id": tenant_id,
-            "storage_path": row["storage_path"],
-            "original_filename": row.get("original_filename", ""),
-            "content_type": row.get("content_type"),
-            "size_bytes": row.get("size_bytes"),
-            "parse_status": "success",
-        }
-    ).execute()
+    created_count = sum(1 for line in line_items if _process_line_item(db, row, line))
     logger.info(
-        f"pdf_order_parsing: order {order_id} created from body fallback "
-        f"for attachment {attachment_id} (PDF had no order lines)"
+        f"pdf_order_parsing: attachment {attachment_id} "
+        f"extracted {len(line_items)} line items from email body, "
+        f"created {created_count} orders"
     )
-    return 1
+    return created_count
+
+
+def _check_multi_order_suspected(
+    db: Client, tenant_id: str, attachment_id: str, line: dict[str, Any]
+) -> None:
+    """
+    1メール/1PDFに複数受注が含まれるにもかかわらず1明細にマージされてしまった
+    疑いのあるケースを粗く検知し、通知する（Issue #280）。
+
+    現時点では数量が閾値を超える場合のみを対象とする単純なヒューリスティックであり、
+    受注の作成自体はブロックしない（情報提供目的の通知のみ）。
+    """
+    quantity = line.get("quantity")
+    if not isinstance(quantity, int) or quantity < _MULTI_ORDER_QUANTITY_THRESHOLD:
+        return
+    detail = {
+        "quantity": quantity,
+        "product_number_raw": line.get("product_number_raw"),
+        "product_name_raw": line.get("product_name_raw"),
+    }
+    log_id = _log_parse_event(
+        db, tenant_id, attachment_id, "multi_order_suspected", detail
+    )
+    create_notification(
+        db,
+        tenant_id,
+        "multi_order_suspected",
+        SupabaseTableName.ORDER_PARSE_LOG.value,
+        log_id,
+        detail,
+    )
 
 
 def _process_line_item(
@@ -246,6 +257,8 @@ def _process_line_item(
     )
     deadline_date = line.get("delivery_date")
 
+    _check_multi_order_suspected(db, tenant_id, attachment_id, line)
+
     rpc_result = db.rpc(
         "upsert_order_by_dedupe_key",
         {
@@ -258,6 +271,7 @@ def _process_line_item(
             "p_source_type": "email",
             "p_source_raw": staging_row.get("source_raw"),
             "p_extracted_product_name": product_name_raw,
+            "p_source_attachment_id": attachment_id,
         },
     ).execute()
     rpc_rows = cast(list[dict[str, Any]], rpc_result.data or [])
@@ -304,15 +318,20 @@ def _process_line_item(
 
     # action == "inserted" or "updated"
     order_id = rpc_rows[0]["order_id"]
+    # ソースに添付ファイル本体が無い場合（非PDF添付・添付なしメール由来）は、
+    # フロントエンドの表示分岐と揃えるため parse_status を "failed_no_attachment" にする
+    attachment_parse_status = (
+        "success" if staging_row.get("storage_path") else "failed_no_attachment"
+    )
     db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
         {
             "order_id": order_id,
             "tenant_id": tenant_id,
-            "storage_path": staging_row["storage_path"],
+            "storage_path": staging_row.get("storage_path", ""),
             "original_filename": staging_row.get("original_filename", ""),
             "content_type": staging_row.get("content_type"),
             "size_bytes": staging_row.get("size_bytes"),
-            "parse_status": "success",
+            "parse_status": attachment_parse_status,
         }
     ).execute()
     logger.info(

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -159,7 +159,13 @@ interface OrderCreate {
 
 `backend/app/services/` 配下に以下のサービスが実装済み。Vercel Cron または Azure Functions タイマートリガーから `poll_unread_emails()` を呼び出すことで動作する。
 
-### 処理フロー
+### 処理フロー（Issue #280 でPDF添付・非PDF添付・添付なしを統一）
+
+以前は非PDF添付・添付なしメールのみ `poll_unread_emails()` 内で即座に単一の `orders`
+行を作成していたが、「1メール = 1受注」前提が崩れているケース（1通に複数品番・複数月分の
+内示数量が含まれる等）に対応するため、Issue #280 で **すべてのソース種別（PDF添付・非PDF
+添付・添付なし）を同じステージング経路に統一**した。実際の注文情報抽出・`orders` 生成は
+`gmail_service.py` からは行わず、`parse_pending_order_pdfs()`（cron）が非同期に行う。
 
 ```
 [Cron/タイマー]
@@ -172,24 +178,26 @@ interface OrderCreate {
       │
       ├─ 3. テナント解決（`gmail_label_tenants` テーブルからテナント ID 取得）
       │
-      ├─ 4. Claude API によるフィールド抽出 [email_extraction_service.py]
-      │      ツール: extract_order_fields
-      │      出力:   product_name, quantity, deadline_date, order_number (全て nullable)
+      ├─ 4. 添付ファイル取得。PDFがあれば優先し、無ければ最初の添付を使う
+      │      （複数添付の個別処理は対象外。1メール1添付が前提）
       │
-      ├─ 5. 製品マッチング [product_matching_service.py]
-      │      pg_trgm RPC `match_products_by_name` で類似度検索
-      │      → 単一一致: product_id を確定
-      │      → 複数候補: candidates リストを order_row に保存
-      │
-      ├─ 6. 顧客マッチング [customer_matching_service.py]
+      ├─ 5. 顧客マッチング [customer_matching_service.py]
       │      送信者メールアドレスで検索 → 未登録の場合は draft 顧客を自動作成
+      │      （受注メールか否かに関わらず、ソース単位で1回だけ解決する）
       │
-      ├─ 7. draft 注文を Supabase に INSERT
-      │      (source_type="email", status="draft", source_raw=メール本文, ...)
+      ├─ 6. 添付ファイル（あれば）を Storage にステージング保存し、
+      │      `order_attachments` に order_id=NULL のステージング行を1件INSERT
+      │      （storage_path は添付が無ければ空文字）
       │
-      └─ 8. ラベルを `pp-done/{テナント名}` に移動
+      └─ 7. ラベルを `pp-done/{テナント名}` に移動
              （失敗時は `pp-error/{テナント名}` に移動）
 ```
+
+実際の注文抽出（`line_items` 配列形式でのメール本文/PDF解析、製品照合、
+`orders` へのUPSERT、`non_order_email`/`multi_order_suspected` 通知）は
+`parse_pending_order_pdfs()` が行う。詳細は
+[pdf-order-parsing.md](pdf-order-parsing.md) の「非PDF添付・添付なしメールの
+本処理への統一（Issue #280）」を参照。
 
 ### Gmail ラベル規約
 
@@ -208,8 +216,8 @@ interface OrderCreate {
 
 | エンドポイント | 役割 |
 |---|---|
-| `GET /api/cron/gmail-poll` | メール取得・フィールド抽出・非PDF添付の即時起票／PDF添付は `order_attachments` へのステージング保存のみ |
-| `GET /api/cron/parse-order-pdfs` | ステージング済みPDF（`order_attachments.parse_status='pending'`）をテキスト抽出・製品照合し、`orders` を実際にINSERT |
+| `GET /api/cron/gmail-poll` | メール取得・顧客解決・添付（あれば）のStorage保存を行い、`order_attachments` へのステージング保存のみ行う（Issue #280でPDF添付・非PDF添付・添付なしすべてこの経路に統一） |
+| `GET /api/cron/parse-order-pdfs` | ステージング済み行（`order_attachments.parse_status='pending'`）をテキスト抽出/本文抽出・製品照合し、`orders` を実際にINSERT/UPDATE |
 
 **設計方針（案1）: 2段目を高頻度で独立実行し、実行順序のズレを許容する。**
 
@@ -245,7 +253,8 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 | `GMAIL_LABEL_PREFIX_PROCESSING` | `pp-processing` | 処理中ラベルのプレフィックス |
 | `GMAIL_LABEL_PREFIX_DONE` | `pp-done` | 完了ラベルのプレフィックス |
 | `GMAIL_LABEL_PREFIX_ERROR` | `pp-error` | エラーラベルのプレフィックス |
-| `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | フィールド抽出に使用する Claude モデル |
+| `EMAIL_EXTRACTION_MODEL` | `claude-haiku-4-5-20251001` | メール本文からの明細行(`line_items`)抽出に使用する Claude モデル |
+| `MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD` | `100000` | 自動抽出時に複数受注が1明細にマージされた疑いを検知する数量閾値（Issue #280） |
 | `PRODUCT_MATCH_THRESHOLD` | `0.3` | pg_trgm 類似度の下限値 |
 | `PRODUCT_MATCH_TOP_N` | `5` | 候補製品の最大表示件数 |
 | `ANTHROPIC_API_KEY` | — | Claude API キー（必須） |

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -147,6 +147,11 @@ Issue #267 で `customer_certainty` カラムを新設して是正した。
 - あくまで情報提供目的の通知であり、order自体の作成はブロックしない
 - 閾値・条件は本番データの精度を見ながら調整する前提（Issue #280 未解決の論点）
 
+また、`quantity` が本来のツールスキーマ（`int | null`）から外れた想定外の型で
+返ってきた場合（スキーマ変更・抽出結果の崩れ等への防御）は、不整合な `orders`
+行を作らないよう `reason='invalid_quantity'` で `order_parse_log` に記録した上で
+その明細をスキップする（PRレビュー指摘対応）。
+
 ### なぜ postgrest-py の `on_conflict` を使わないか
 
 supabase-py（postgrest-py）の `.insert(..., on_conflict=...)` は単純なマージ用であり、

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -74,26 +74,78 @@ Issue #267 で `customer_certainty` カラムを新設して是正した。
    個々の失敗理由は order_parse_log 側で追跡する)
 ```
 
-### PDFが注文と無関係な内容だった場合のフォールバック（Issue #278）
+### メール本文からの複数明細抽出への統一（Issue #280）
 
-添付PDFが署名画像・会社案内・注文と無関係な資料等で、`extract_order_lines` が
-明細を1件も抽出できなかった場合（`line_items == []`）、そのままでは受注下書きが
-一切起票されず、本文に書かれた注文情報が失われていた。
+「1メール = 1受注」前提が崩れているケース（1通に部品番号ごとの複数月分の内示数量が
+表形式で含まれる等）が報告され（Issue #280）、メール本文からの抽出も PDF と同じ
+`line_items` 配列形式に統一した。
 
-`pdf_order_parsing_service._parse_one` は `line_items` が空のとき、ステージング行の
-`source_raw`（メール本文）に対して `email_extraction_service.extract_email_fields()`
-（[email-order-intake.md](email-order-intake.md) の添付なしメールと同じ抽出ロジック）
-によるフォールバック抽出を行う（`_fallback_to_body_extraction`）。
+- `email_extraction_service.extract_email_order_lines(body)` が
+  `product_name_raw`/`product_number_raw`/`quantity`/`delivery_date`/`certainty` を
+  持つ明細の配列を返す（`pdf_order_extraction_service.extract_order_lines()` と
+  同じスキーマ・`EMAIL_EXTRACTION_MODEL` を使用）。単一スカラー値のみ返す旧
+  `extract_email_fields()` は廃止した
+- `pdf_order_parsing_service._process_email_body()`（旧 `_fallback_to_body_extraction`）が
+  この配列を明細ごとに既存の `_process_line_item()` に渡すため、1通のメールから
+  複数の `orders` 行を正しく生成できる。製品照合・`upsert_order_by_dedupe_key` による
+  dedupe・`order_attachments` 紐付けは PDF由来の明細処理と完全に同じ経路を通る
+- 明細が1件も抽出できなかった場合は、従来通り order を作成せず `non_order_email` として
+  `create_notification` のみ行う
 
-- 本文から `product_name`/`quantity`/`deadline_date`/`order_number` のいずれかが
-  抽出できた場合: 製品照合の上、`orders` に1件 `status='draft'` で直接INSERTし、
-  ステージング行の添付ファイルを紐付ける `order_attachments` 行を追加する
-- 本文からも何も抽出できなかった場合: order は作成せず、`non_order_email` として
-  `create_notification` のみ行う（添付なしメールの「対象外メール」通知と同じ扱い）
+`_process_email_body()` は以下の2つのケースで呼ばれる共通経路になっている:
 
-このフォールバックは `upsert_order_by_dedupe_key` によるdedupe処理を経由しない
-直接INSERTのため、既存のPDF明細処理（複数品番・確度別のupsert）とは独立した
-単発の下書き起票として扱われる。
+1. PDFに明細が1件も無かった場合のフォールバック（Issue #278）
+2. 非PDF添付・添付なしメールの本処理（Issue #280、後述）
+
+### 非PDF添付・添付なしメールの本処理への統一（Issue #280）
+
+従来、非PDF添付・添付なしメールは `gmail_service.py` 内で単一フィールド抽出→即座に
+`orders` を1件直接INSERTする独立した経路を持っていた（PDF添付メールのみ
+`order_attachments` へのステージング保存＋非同期パースだった）。この経路は
+「1メール1受注」前提のままで Issue #280 の対象外だったため、PDF添付メールと同じ
+ステージング＋非同期パース経路に統一した。
+
+- `gmail_service._process_message()` は PDF・非PDF添付・添付なしのいずれであっても、
+  顧客解決後に `order_attachments` へ `order_id=NULL` のステージング行を1件INSERTする
+  だけになった（添付が無い場合は `storage_path=""`）。`orders` への直接INSERTは行わない
+- `pdf_order_parsing_service._parse_one()` はステージング行の `content_type` が
+  `application/pdf` かつ `storage_path` がある場合のみPDFテキスト抽出を行い、それ以外
+  （非PDF添付・添付なし）は `_process_email_body()` へ直接ルーティングする
+- 添付ファイル本体が無いソースから生成された `orders` の `order_attachments` 行は、
+  フロントエンドの表示分岐（`parse_status === 'failed_no_attachment'`）と合わせるため
+  `parse_status='failed_no_attachment'` で作成する（`storage_path` が空か否かで判定）
+- これにより添付ファイルは常に「1ソースにつき1回」だけ Storage に保存される
+  （非PDF添付を複数明細に分割してもファイル本体は複製しない）
+
+### 受注ソースの「1ソース:N受注」モデル（Issue #280）
+
+`orders.source_attachment_id`（`order_attachments.id` への nullable FK）を追加し、
+1つの `order_attachments` ステージング行（1ソース）に対してN件の `orders` を
+紐づけられるようにした。
+
+- `upsert_order_by_dedupe_key` RPC に `p_source_attachment_id` パラメータを追加し、
+  新規INSERT時にのみ設定する（既存行のUPDATE時は最初に作成したソースを保ったまま
+  変更しない）
+- 既存データは以下の方針でバックフィル済み（`20260706000000_add_orders_source_attachment_id.sql`）:
+  - PDF由来: ステージング行（`order_id IS NULL`）と、そこから生成された各 `orders` に
+    紐づく `order_attachments` 行（`storage_path` を複製したもの）を対応付けて設定
+  - 非PDF添付・添付なしメール由来: 専用のステージング行が存在しないため、その
+    `orders` に紐づく `order_attachments` 行自身を自己参照的な「ソース」として設定
+- 手動分割UI（誤って1件にマージされた下書きから同じ `source_attachment_id` を
+  参照するN件の下書きを生成する機能）は本Issueのスコープ外とし、後続Issueで対応する
+
+### 複数受注の疑いの検知（Issue #280）
+
+`line_items` 配列形式への統一により「1通のメールに複数月分の数量が含まれる」
+ケースの多くは正しく複数明細として抽出されるようになったが、それでも1明細に
+複数月分がマージされてしまうケースに備え、粗いヒューリスティックによる検知を
+`_process_line_item()` に追加した。
+
+- 1明細の `quantity` が `MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD`（デフォルト
+  100,000）を超える場合、`order_parse_log` に `reason='multi_order_suspected'` で
+  記録し、`notifications` に `notif_type='multi_order_suspected'` で通知する
+- あくまで情報提供目的の通知であり、order自体の作成はブロックしない
+- 閾値・条件は本番データの精度を見ながら調整する前提（Issue #280 未解決の論点）
 
 ### なぜ postgrest-py の `on_conflict` を使わないか
 
@@ -245,6 +297,27 @@ Issue #267 での変更（顧客側の確度とProductPlannerステータスの�
 - `frontend/src/components/orders/order-table-row.tsx` /
   `frontend/src/app/orders/[id]/page.tsx`: 顧客側の確度バッジを追加表示
 
+Issue #280 での変更（1ソース:N受注モデル・メール本文/非PDF添付の複数明細対応）:
+
+- `supabase/migrations/20260706000000_add_orders_source_attachment_id.sql`:
+  `orders.source_attachment_id` 追加・既存データバックフィル・
+  `upsert_order_by_dedupe_key` に `p_source_attachment_id` 追加・
+  `notifications.notif_type` に `multi_order_suspected` 追加
+- `backend/app/services/email_extraction_service.py`: `extract_email_fields()` を
+  廃止し、`extract_email_order_lines()`（line_items配列形式）に置き換え
+- `backend/app/services/pdf_order_parsing_service.py`: `_fallback_to_body_extraction`
+  を `_process_email_body`（PDFフォールバックと非PDF添付・添付なしメールの共通経路）に
+  一般化。`_parse_one` にPDF/非PDF分岐を追加。`_check_multi_order_suspected` を追加
+- `backend/app/services/gmail_service.py`: 非PDF添付・添付なしメールの即時order作成
+  経路を削除し、PDF添付と同じステージング保存のみに統一
+- `backend/app/services/attachment_service.py`: 呼び出し元が無くなった
+  `upload_attachment()` を削除
+- `backend/app/routers/transaction/notifications.py`: `_PARSE_LOG_NOTIF_TYPES` に
+  `multi_order_suspected` を追加
+- `frontend/src/types/notification.ts` / `notification-bell.tsx`:
+  `multi_order_suspected`（および従前抜けていた `customer_draft_created`）の
+  型・表示ラベルを追加
+
 ---
 
 ## 環境変数
@@ -256,6 +329,9 @@ PDF_EXTRACTION_MODEL=claude-sonnet-5  # デフォルト。EMAIL_EXTRACTION_MODEL
 # 製品マッチング (pg_trgm) の自動確定しきい値
 PRODUCT_MATCH_AUTO_CONFIRM_THRESHOLD=0.75  # 最上位候補スコアの下限
 PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の下限
+
+# 複数受注疑いの検知（Issue #280、粗いヒューリスティック）
+MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを超えると通知
 ```
 
 ---
@@ -287,6 +363,14 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 - [x] PDF文面上で確定納期・PO番号が明記された明細（certainty='confirmed'）でも、
       ユーザーが `/orders/{id}/confirm` を実行するまで `status` は `confirmed` に
       ならない（Issue #267）
+- [x] `orders.source_attachment_id` により1ソース(order_attachments)につきN件の
+      `orders` を紐づけられる。既存データはバックフィル済み（Issue #280）
+- [x] メール本文フォールバック抽出・非PDF添付メール処理が `line_items` 配列形式で
+      1メールから複数受注を抽出できる（Issue #280）
+- [x] 自動抽出時に1明細の数量が閾値を超える場合、`multi_order_suspected` として
+      通知される（Issue #280、粗いヒューリスティック）
+- [x] 添付ファイルは1ソースにつき1回のみStorageに保存される（非PDF添付・添付なし
+      メールもPDF添付と同じステージング経路に統一、Issue #280）
 
 ---
 
@@ -300,6 +384,10 @@ PRODUCT_MATCH_AUTO_CONFIRM_MARGIN=0.15     # 次点候補とのスコア差の�
 - `deadline_date` 変更を「同一注文の引き継ぎ」として明示的にUI上で提示する機能（Issue #252スコープ外）
 - `order_history`（変更履歴・監査ログ）テーブルの新設（Issue #252スコープ外）
 - ステータスの手動格下げ操作、`superseded_at` レコードの物理削除・アーカイブ処理（Issue #252スコープ外）
+- 手動分割UI（誤って1件にマージされた下書きから、同じ `source_attachment_id` を参照する
+  N件の下書きを生成する機能）は後続Issueで対応（Issue #280スコープ外）
+- 複数受注疑い検知の閾値・ヒューリスティックの精緻化（数量異常値以外の条件追加等）は
+  本番データの精度を見ながら別途調整（Issue #280スコープ外）
 
 ---
 

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -19,6 +19,8 @@ const NOTIF_TYPE_LABELS: Record<NotificationType, string> = {
   failed_encrypted: "読み取り不可（暗号化PDF）",
   failed_image: "読み取り不可（画像PDF）",
   non_order_email: "対象外メール",
+  customer_draft_created: "顧客の下書き作成",
+  multi_order_suspected: "複数受注の疑い",
 }
 
 function groupByType(notifications: Notification[]): [NotificationType, Notification[]][] {

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -5,6 +5,8 @@ export type NotificationType =
   | "failed_encrypted"
   | "failed_image"
   | "non_order_email"
+  | "customer_draft_created"
+  | "multi_order_suspected"
 
 export interface Notification {
   id: string

--- a/supabase/migrations/20260706000000_add_orders_source_attachment_id.sql
+++ b/supabase/migrations/20260706000000_add_orders_source_attachment_id.sql
@@ -19,6 +19,8 @@ CREATE INDEX idx_orders_source_attachment_id ON orders (source_attachment_id);
 -- ==========================================
 -- PDF由来: order_id IS NULL のステージング行と、そこから生成された各 orders に
 -- 紐づく order_attachments 行（storage_path を複製したもの）を対応付けて設定する。
+-- 手動作成の受注（source_type != 'email'）は、たまたま同一storage_pathの添付を
+-- 持っていたとしても対象外とする（コメント通り手動作成はNULLのままにするため）。
 UPDATE orders o
 SET source_attachment_id = staging.id
 FROM order_attachments staging
@@ -27,15 +29,18 @@ JOIN order_attachments real_att
  AND real_att.tenant_id = staging.tenant_id
 WHERE staging.order_id IS NULL
   AND real_att.order_id = o.id
-  AND o.source_attachment_id IS NULL;
+  AND o.source_attachment_id IS NULL
+  AND o.source_type = 'email';
 
 -- 非PDF添付・添付なしメール由来: 専用のステージング行が存在しないため、
 -- その orders に紐づく order_attachments 行自身を自己参照的な「ソース」として設定する。
+-- 手動作成の受注（source_type != 'email'）は対象外とする。
 UPDATE orders o
 SET source_attachment_id = oa.id
 FROM order_attachments oa
 WHERE oa.order_id = o.id
-  AND o.source_attachment_id IS NULL;
+  AND o.source_attachment_id IS NULL
+  AND o.source_type = 'email';
 
 -- ==========================================
 -- upsert_order_by_dedupe_key: p_source_attachment_id を追加

--- a/supabase/migrations/20260706000000_add_orders_source_attachment_id.sql
+++ b/supabase/migrations/20260706000000_add_orders_source_attachment_id.sql
@@ -1,0 +1,164 @@
+-- 受注ソースの「1ソース:N受注」モデル対応 (Issue #280)
+-- メール本文・添付ファイルを「ソース」(order_attachments) として orders から独立させ、
+-- 1ソースに対してN件の orders を紐づけられるようにする。
+
+-- ==========================================
+-- orders.source_attachment_id カラム追加
+-- ==========================================
+ALTER TABLE orders ADD COLUMN source_attachment_id uuid REFERENCES order_attachments(id);
+
+COMMENT ON COLUMN orders.source_attachment_id IS
+  '受注の起票元となった order_attachments 行（1ソース）への参照。'
+  'PDF/メール本文起票の受注は自動抽出処理が参照する order_attachments のステージング行'
+  '（order_id IS NULL）を指す。手動作成の受注では NULL。';
+
+CREATE INDEX idx_orders_source_attachment_id ON orders (source_attachment_id);
+
+-- ==========================================
+-- 既存データのバックフィル
+-- ==========================================
+-- PDF由来: order_id IS NULL のステージング行と、そこから生成された各 orders に
+-- 紐づく order_attachments 行（storage_path を複製したもの）を対応付けて設定する。
+UPDATE orders o
+SET source_attachment_id = staging.id
+FROM order_attachments staging
+JOIN order_attachments real_att
+  ON real_att.storage_path = staging.storage_path
+ AND real_att.tenant_id = staging.tenant_id
+WHERE staging.order_id IS NULL
+  AND real_att.order_id = o.id
+  AND o.source_attachment_id IS NULL;
+
+-- 非PDF添付・添付なしメール由来: 専用のステージング行が存在しないため、
+-- その orders に紐づく order_attachments 行自身を自己参照的な「ソース」として設定する。
+UPDATE orders o
+SET source_attachment_id = oa.id
+FROM order_attachments oa
+WHERE oa.order_id = o.id
+  AND o.source_attachment_id IS NULL;
+
+-- ==========================================
+-- upsert_order_by_dedupe_key: p_source_attachment_id を追加
+-- ==========================================
+-- 新規INSERT時にのみ source_attachment_id を設定する。既存行のupdate時は
+-- 最初にレコードを作成したソースを保ったままにする（更新元のソースへの付け替えは行わない）。
+DROP FUNCTION IF EXISTS upsert_order_by_dedupe_key(
+  uuid, bigint, bigint, int, date, text, text, text, text
+);
+
+CREATE OR REPLACE FUNCTION upsert_order_by_dedupe_key(
+  p_tenant_id              uuid,
+  p_customer_id            bigint,
+  p_product_id             bigint,
+  p_quantity               int,
+  p_deadline_date          date,
+  p_customer_certainty     text,
+  p_source_type            text,
+  p_source_raw             text,
+  p_extracted_product_name text,
+  p_source_attachment_id   uuid DEFAULT NULL
+)
+RETURNS TABLE (order_id bigint, action text)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_existing        orders%ROWTYPE;
+  v_new_id          bigint;
+  v_existing_priority int;
+  v_new_priority      int;
+BEGIN
+  -- 先にINSERTを試み、UNIQUE制約(orders_dedupe_key)の競合でしか
+  -- 「既存あり」を判定しない。SELECTしてから未存在ならINSERTする順序だと、
+  -- 同一dedupeキーへの並行呼び出しが両方SELECTでNOT FOUNDと判定してしまい、
+  -- 片方が23505で例外終了する競合が起こり得るため。
+  INSERT INTO orders (
+    tenant_id, customer_id, product_id, quantity, deadline_date,
+    status, customer_certainty, source_type, source_raw, extracted_product_name,
+    source_attachment_id
+  )
+  VALUES (
+    p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
+    'draft', p_customer_certainty, p_source_type, p_source_raw, p_extracted_product_name,
+    p_source_attachment_id
+  )
+  ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
+  RETURNING orders.id INTO v_new_id;
+
+  IF v_new_id IS NOT NULL THEN
+    RETURN QUERY SELECT v_new_id, 'inserted'::text;
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_existing
+  FROM orders
+  WHERE tenant_id = p_tenant_id
+    AND customer_id = p_customer_id
+    AND product_id = p_product_id
+    AND deadline_date = p_deadline_date
+  FOR UPDATE;
+
+  -- confirmed/completed/canceled (ユーザーが確定・完了させた、またはキャンセルした注文)
+  -- はPDF自動処理から完全に保護し、常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status IN ('confirmed', 'completed', 'canceled') THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  -- status='draft' かつ source_type='manual' (手動下書き) は自動更新の対象外。
+  -- 常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status = 'draft' AND v_existing.source_type = 'manual' THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_draft_conflict'::text;
+    RETURN;
+  END IF;
+
+  -- ここから先は既存行が draft かつ source_type != 'manual'
+  -- (メール/PDF起票の確認待ちdraft) のケース。
+  -- customer_certainty の優先順位（数値が大きいほど確度が高い）で判定する。
+  v_existing_priority := CASE v_existing.customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE -1
+  END;
+  v_new_priority := CASE p_customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE NULL
+  END;
+
+  IF v_new_priority IS NULL
+     OR v_new_priority < v_existing_priority THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  IF v_new_priority = v_existing_priority AND v_existing.quantity = p_quantity THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_no_change'::text;
+    RETURN;
+  END IF;
+
+  UPDATE orders
+  SET customer_certainty     = p_customer_certainty,
+      quantity                = p_quantity,
+      source_type             = p_source_type,
+      source_raw              = p_source_raw,
+      extracted_product_name  = p_extracted_product_name
+  WHERE id = v_existing.id;
+
+  RETURN QUERY SELECT v_existing.id, 'updated'::text;
+END;
+$$;
+
+-- ==========================================
+-- notifications.notif_type: multi_order_suspected を追加
+-- ==========================================
+-- 自動抽出時に複数受注の疑いがあるケース（数量異常値等）を検知した際の通知 (Issue #280)。
+ALTER TABLE notifications DROP CONSTRAINT notifications_notif_type_check;
+ALTER TABLE notifications ADD CONSTRAINT notifications_notif_type_check
+CHECK (notif_type IN (
+  'no_product_match', 'downgrade_skipped', 'draft_conflict_skipped',
+  'failed_encrypted', 'failed_image', 'non_order_email', 'customer_draft_created',
+  'multi_order_suspected'
+));


### PR DESCRIPTION
## Summary

Issue #280 のうち、以下のスコープ（Phase1+2）を実装。手動分割UIは別PRに分離。

- `orders.source_attachment_id`（`order_attachments.id` への nullable FK）を追加し、1ソース（`order_attachments`）に対してN件の `orders` を紐づけられるようにした。既存データはバックフィル済み
- メール本文フォールバック抽出（Issue #278）・非PDF添付/添付なしメールの本処理を、PDFと同じ `line_items` 配列形式に統一。1通のメールに複数品番・複数月分の内示数量が含まれるケースでも正しく複数の `orders` を生成できるようにした（Issue #280 の実例: B115105 の6ヶ月分内示が1レコードにマージされていた不具合の根本対応）
- 非PDF添付・添付なしメールを、PDF添付メールと同じ「ステージング保存 → 非同期パース」経路に統一。添付ファイルは常に1ソースにつき1回のみStorageに保存される
- 自動抽出時、1明細の数量が閾値（`MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD`、デフォルト100,000）を超える場合に `multi_order_suspected` 通知を追加（粗いヒューリスティック、情報提供目的でorder作成はブロックしない）

## スコープ外（後続Issue）

- 手動分割UI（誤って1件にマージされた下書きから同じ `source_attachment_id` を参照するN件の下書きを生成する機能）
- 複数受注疑い検知の閾値・条件の精緻化（本番データを見ながら調整）

## Test plan

- [x] `pytest __tests__/unit __tests__/api` 全件パス
- [x] `ruff check` / `mypy` （変更ファイルのみ、pre-commit hook経由）パス
- [x] `npx tsc --noEmit`（frontend）パス
- [x] マイグレーション: `orders.source_attachment_id` 追加・既存データバックフィル・`upsert_order_by_dedupe_key` 拡張・`notifications.notif_type` 追加のSQLをレビュー
- [x] （手元で `supabase start` の上で）integration/e2e テストの実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)