### PR TITLE
fix: スケジューリングをホストTZ非依存のJST基準に修正

### DIFF
--- a/backend/__tests__/unit/test_scheduler.py
+++ b/backend/__tests__/unit/test_scheduler.py
@@ -2,7 +2,7 @@
 スケジューリングロジックの単体テスト
 """
 
-from datetime import UTC, datetime
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,6 +11,7 @@ from app.scheduler_logic import (
     routings_are_confirmed,
     schedule_order,
 )
+from app.utils.calendar import JST
 
 
 @pytest.mark.unit
@@ -47,14 +48,14 @@ class TestScheduleOrder:
             if equipment_id == 1:
                 return None  # 空き
             elif equipment_id == 2:
-                return datetime(2025, 1, 6, 14, 0, tzinfo=UTC)  # 月曜日 14:00に終了予定
+                return datetime(2025, 1, 6, 14, 0, tzinfo=JST)  # 月曜日 14:00に終了予定
 
         mock_schedule_repo.get_last_end_time.side_effect = get_last_end_time_side_effect
         mock_schedule_repo.create.return_value = None
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（開始時刻を固定して時刻依存を排除）
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)  # 月曜日 9:00
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)  # 月曜日 9:00
         result = schedule_order(
             order_id=1,
             product_id=1,
@@ -122,7 +123,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（開始時刻を9:00に固定して、日またぎが発生しないようにする）
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)  # 月曜日 9:00
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)  # 月曜日 9:00
         result = schedule_order(
             order_id=2,
             product_id=2,
@@ -176,7 +177,7 @@ class TestScheduleOrder:
 
         # 設備1は遠い未来まで使用中、設備2は近い未来まで使用中
         # 設備2の方が早く開始できるべき
-        now = datetime.now(tz=UTC)
+        now = datetime.now(tz=JST)
 
         def get_last_end_time_side_effect(equipment_id: int):
             if equipment_id == 1:
@@ -279,9 +280,9 @@ class TestScheduleOrder:
             {"equipment_id": 1}
         ]
 
-        # 設備の最終終了時刻を今日の 16:00 に設定
+        # 設備の最終終了時刻を今日の 16:00 (JST) に設定
         # 2時間の作業を開始すると18:00になるため、2つのスケジュールに分割されるべき
-        now = datetime.now(tz=UTC)
+        now = datetime.now(tz=JST)
         mock_schedule_repo.get_last_end_time.return_value = now.replace(
             hour=16, minute=0, second=0, microsecond=0
         )
@@ -340,7 +341,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（dry_run=True、開始時刻を固定）
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
         result = schedule_order(
             order_id=1,
             product_id=1,
@@ -389,7 +390,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（dry_run=False、開始時刻を固定）
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
         result = schedule_order(
             order_id=1,
             product_id=1,
@@ -438,9 +439,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（月曜日9:00から開始）
-        from datetime import UTC
-
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)  # 月曜日 9:00
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)  # 月曜日 9:00
         result = schedule_order(
             order_id=7,
             product_id=7,
@@ -512,9 +511,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行（金曜日14:00から開始）
-        from datetime import UTC
-
-        start_time = datetime(2025, 1, 10, 14, 0, tzinfo=UTC)  # 金曜日 14:00
+        start_time = datetime(2025, 1, 10, 14, 0, tzinfo=JST)  # 金曜日 14:00
         result = schedule_order(
             order_id=8,
             product_id=8,
@@ -563,7 +560,7 @@ class TestScheduleOrder:
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
         # テスト実行
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)  # 月曜日 9:00
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)  # 月曜日 9:00
         result = schedule_order(
             order_id=10,
             product_id=10,
@@ -617,7 +614,7 @@ class TestScheduleOrder:
         mock_schedule_repo.create.return_value = None
         mock_schedule_repo.get_schedules_by_equipment.return_value = []
 
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)  # 月曜日 9:00
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)  # 月曜日 9:00
         result = schedule_order(
             order_id=11,
             product_id=11,
@@ -673,13 +670,13 @@ class TestGapFillScheduling:
             }
         ]
         # 月曜 9:00 開始、30分の作業 → 9:30 終了
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
         # 既存スケジュール: 10:00-17:00 (gap = 9:00-10:00 = 60分)
         existing = [
             {
                 "id": 99,
-                "start_datetime": "2025-01-06T10:00:00+00:00",
-                "end_datetime": "2025-01-06T17:00:00+00:00",
+                "start_datetime": "2025-01-06T10:00:00+09:00",
+                "end_datetime": "2025-01-06T17:00:00+09:00",
             }
         ]
         mock_product_repo, mock_schedule_repo = self._make_repos(
@@ -703,25 +700,25 @@ class TestGapFillScheduling:
         # ギャップ内 (9:00-10:00) に収まっていること
         assert start_dt.hour == 9
         assert start_dt.minute == 0
-        assert end_dt <= datetime(2025, 1, 6, 10, 0, tzinfo=UTC)
+        assert end_dt <= datetime(2025, 1, 6, 10, 0, tzinfo=JST)
 
     def test_gap_fill_falls_back_on_max_fragments_exceeded(self) -> None:
         """断片数が最大断片数(1)を超えたとき _try_gap_fill が None を返すこと"""
         from app.models.common.scheduling_settings import SchedulingParams
         from app.scheduler_logic import _try_gap_fill
 
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
         # 30分ギャップが2つ → 20分ずつ2セグメント必要 → max_fragments=1 で超過
         existing = [
             {
                 "id": 1,
-                "start_datetime": "2025-01-06T09:30:00+00:00",
-                "end_datetime": "2025-01-06T10:00:00+00:00",
+                "start_datetime": "2025-01-06T09:30:00+09:00",
+                "end_datetime": "2025-01-06T10:00:00+09:00",
             },
             {
                 "id": 2,
-                "start_datetime": "2025-01-06T10:30:00+00:00",
-                "end_datetime": "2025-01-06T17:00:00+00:00",
+                "start_datetime": "2025-01-06T10:30:00+09:00",
+                "end_datetime": "2025-01-06T17:00:00+09:00",
             },
         ]
         _, mock_schedule_repo = self._make_repos([], [1], existing)
@@ -747,12 +744,12 @@ class TestGapFillScheduling:
         from app.scheduler_logic import _try_gap_fill
 
         # 9:00-9:30 のギャップ (30分) だが guard_time=25分なので有効スロット=5分 → 20分入らない
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
         existing = [
             {
                 "id": 99,
-                "start_datetime": "2025-01-06T09:30:00+00:00",
-                "end_datetime": "2025-01-06T17:00:00+00:00",
+                "start_datetime": "2025-01-06T09:30:00+09:00",
+                "end_datetime": "2025-01-06T17:00:00+09:00",
             }
         ]
         _, mock_schedule_repo = self._make_repos([], [1], existing)
@@ -825,7 +822,7 @@ class TestScheduleOrderRoutingGuard:
             }
         ]
         mock_product_repo, mock_schedule_repo = self._make_repos(routings)
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
 
         # 例外なく実行できることを確認
         result = schedule_order(
@@ -853,7 +850,7 @@ class TestScheduleOrderRoutingGuard:
             }
         ]
         mock_product_repo, mock_schedule_repo = self._make_repos(routings)
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
 
         with pytest.raises(RoutingUnconfirmedError):
             schedule_order(
@@ -882,7 +879,7 @@ class TestScheduleOrderRoutingGuard:
         ]
         mock_product_repo, mock_schedule_repo = self._make_repos(routings)
         mock_schedule_repo.create.return_value = None
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
 
         result = schedule_order(
             order_id=1,
@@ -909,7 +906,7 @@ class TestScheduleOrderRoutingGuard:
             }
         ]
         mock_product_repo, mock_schedule_repo = self._make_repos(routings)
-        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=UTC)
+        start_time = datetime(2025, 1, 6, 9, 0, tzinfo=JST)
 
         with pytest.raises(RoutingUnconfirmedError) as exc_info:
             schedule_order(

--- a/backend/app/scheduler_logic.py
+++ b/backend/app/scheduler_logic.py
@@ -20,6 +20,7 @@ from app.repositories.supa_infra.master.product_repo import ProductRepository
 from app.repositories.supa_infra.transaction.schedule_repo import ScheduleRepository
 from app.services.scheduling_settings_service import get_effective_params
 from app.utils.calendar import (
+    JST,
     CalendarConfig,
     get_next_available_start_time,
     split_work_across_days,
@@ -95,7 +96,7 @@ def schedule_order(
         raise RoutingUnconfirmedError(desired_deadline=desired_deadline)
 
     created_schedules = []
-    current_process_start = start_time if start_time else datetime.now().astimezone()
+    current_process_start = start_time if start_time else datetime.now(JST)
 
     for routing in routings:
         equipment_group_id = routing["equipment_group_id"]

--- a/backend/app/utils/calendar.py
+++ b/backend/app/utils/calendar.py
@@ -252,9 +252,6 @@ def calculate_end_time(
     break_start = start_dt.replace(
         hour=BREAK_START_HOUR, minute=BREAK_START_MINUTE, second=0, microsecond=0
     )
-    start_dt.replace(
-        hour=BREAK_END_HOUR, minute=BREAK_END_MINUTE, second=0, microsecond=0
-    )
 
     # 作業が休憩時間をまたぐ場合、終了時刻に休憩時間分を加算
     if start_dt < break_start and end_dt > break_start:
@@ -314,9 +311,6 @@ def calculate_remaining_work_minutes(
     # 休憩時間が残り時間に含まれているかチェック
     break_start = start_dt.replace(
         hour=BREAK_START_HOUR, minute=BREAK_START_MINUTE, second=0, microsecond=0
-    )
-    start_dt.replace(
-        hour=BREAK_END_HOUR, minute=BREAK_END_MINUTE, second=0, microsecond=0
     )
 
     # 開始時刻が休憩開始前で、休憩時間が含まれる場合、休憩時間分を差し引く

--- a/backend/app/utils/calendar.py
+++ b/backend/app/utils/calendar.py
@@ -7,6 +7,11 @@
 """
 
 from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+# 稼働時間(9:00-17:00)はJST基準。実行ホストのタイムゾーンに関わらず
+# 常にJSTで判定するため、稼働時間判定を行う全関数の入口でこのTZへ変換する。
+JST = ZoneInfo("Asia/Tokyo")
 
 # 定数定義
 WORK_START_HOUR = 9
@@ -21,6 +26,18 @@ BREAK_DURATION_MINUTES = 60  # 1時間
 MAX_DAILY_WORK_HOURS = (WORK_END_HOUR - WORK_START_HOUR) - (
     BREAK_DURATION_MINUTES / 60
 )  # 7時間
+
+
+def _to_business_tz(dt: datetime) -> datetime:
+    """
+    稼働時間判定用にJSTの壁時計時刻へ変換する。
+
+    tz-awareな場合はJSTへ変換する（実行ホストのタイムゾーンに依存しないようにするため）。
+    naive(tzinfoなし)な場合は、既にJSTの壁時計時刻を表しているものとみなしてそのまま返す。
+    """
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(JST)
 
 
 class CalendarConfig:
@@ -55,6 +72,7 @@ class CalendarConfig:
         Returns:
             bool: 休日の場合True、稼働日の場合False
         """
+        dt = _to_business_tz(dt)
         target_date = dt.date()
 
         # 明示的に稼働日として設定されている場合（土日出勤など）
@@ -83,6 +101,7 @@ def is_during_break(dt: datetime) -> bool:
     Returns:
         bool: 休憩時間中の場合True、それ以外の場合False
     """
+    dt = _to_business_tz(dt)
     break_start = time(BREAK_START_HOUR, BREAK_START_MINUTE)
     break_end = time(BREAK_END_HOUR, BREAK_END_MINUTE)
     return break_start <= dt.time() < break_end
@@ -98,6 +117,7 @@ def adjust_start_time_for_break(dt: datetime) -> datetime:
     Returns:
         datetime: 調整後の日時（休憩時間中でない場合はそのまま返す）
     """
+    dt = _to_business_tz(dt)
     if is_during_break(dt):
         return dt.replace(
             hour=BREAK_END_HOUR, minute=BREAK_END_MINUTE, second=0, microsecond=0
@@ -133,6 +153,8 @@ def get_next_work_start(
     Returns:
         datetime: 次の稼働開始日時（9:00）
     """
+    dt = _to_business_tz(dt)
+
     # 既に今日の始業前なら、今日の9:00
     if is_workday(dt, calendar_config) and dt.time() < time(WORK_START_HOUR, 0):
         return dt.replace(hour=WORK_START_HOUR, minute=0, second=0, microsecond=0)
@@ -166,6 +188,8 @@ def get_next_available_start_time(
     Returns:
         datetime: 作業を開始可能な日時
     """
+    current_dt = _to_business_tz(current_dt)
+
     # 1. まず基本的な稼働時間帯に乗せる
     if not is_workday(current_dt, calendar_config) or current_dt.time() >= time(
         WORK_END_HOUR, 0
@@ -207,6 +231,8 @@ def calculate_end_time(
     Raises:
         ValueError: 開始時刻が稼働時間外の場合、または終了時刻が17:00を超える場合
     """
+    start_dt = _to_business_tz(start_dt)
+
     # 開始時刻が稼働日かつ稼働時間内であることを確認
     if not is_workday(start_dt, calendar_config):
         raise ValueError(f"開始日時が稼働日ではありません: {start_dt}")
@@ -265,6 +291,8 @@ def calculate_remaining_work_minutes(
     Raises:
         ValueError: 開始時刻が稼働時間外の場合
     """
+    start_dt = _to_business_tz(start_dt)
+
     # 開始時刻が稼働日かつ稼働時間内であることを確認
     if not is_workday(start_dt, calendar_config):
         raise ValueError(f"開始日時が稼働日ではありません: {start_dt}")
@@ -321,6 +349,8 @@ def split_work_across_days(
     # 所要時間の検証
     if duration_minutes <= 0:
         raise ValueError(f"所要時間は正の値である必要があります: {duration_minutes}分")
+
+    start_dt = _to_business_tz(start_dt)
 
     # 開始時刻が稼働日かつ稼働時間内であることを確認
     if not is_workday(start_dt, calendar_config):
@@ -422,9 +452,10 @@ def split_work_in_window(
     if duration_minutes <= 0:
         return [], 0.0
 
+    current_start = _to_business_tz(start_dt)
+    window_end = _to_business_tz(window_end)
     segments: list[tuple[datetime, datetime]] = []
     remaining_duration = duration_minutes
-    current_start = start_dt
     epsilon = 0.01
 
     while remaining_duration > epsilon:

--- a/backend/scripts/patch_schedule_timezone.py
+++ b/backend/scripts/patch_schedule_timezone.py
@@ -1,0 +1,104 @@
+"""
+production_schedules のタイムゾーン不具合(Issue #282)を修正するデータパッチスクリプト。
+
+不具合の内容:
+    scheduler_logic.py が実行ホストのローカルタイムゾーンで「現在時刻」を取得し、
+    calendar.py の稼働時間判定(9:00-17:00)がその時刻をJSTの壁時計時刻とみなして
+    計算していたため、ホストがUTCで動作している場合は本来のJST稼働時間より
+    9時間遅い時刻がUTCとしてそのまま保存されてしまっていた。
+    (例: 本来 JST 9:00 = UTC 00:00 であるべきところ、UTC 09:00 として保存された)
+
+このスクリプトは、影響を受けた production_schedules の start_datetime / end_datetime から
+9時間を差し引くことで、正しいUTC値(JST基準)に補正する。
+
+Usage:
+    # 対象レコードの確認のみ（DBは変更しない）
+    python scripts/patch_schedule_timezone.py --env-file scripts/.env.cloud
+
+    # 実際に補正を適用する
+    python scripts/patch_schedule_timezone.py --env-file scripts/.env.cloud --apply
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+
+from supabase import create_client
+
+SHIFT = timedelta(hours=9)
+
+
+def _get_admin_client(env_file: str):
+    load_dotenv(env_file)
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        missing = [
+            v
+            for v, val in [("SUPABASE_URL", url), ("SUPABASE_SERVICE_ROLE_KEY", key)]
+            if not val
+        ]
+        print(
+            f"エラー: 環境変数が設定されていません: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return create_client(url, key)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--env-file",
+        default="scripts/.env.cloud",
+        help="Supabase接続情報を含む.envファイルのパス",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="指定した場合のみ実際にDBを更新する（未指定の場合はドライラン）",
+    )
+    args = parser.parse_args()
+
+    client = _get_admin_client(args.env_file)
+
+    res = (
+        client.table("production_schedules")
+        .select("id,start_datetime,end_datetime")
+        .order("id")
+        .execute()
+    )
+    rows = res.data or []
+    print(f"対象レコード数: {len(rows)}")
+
+    for row in rows:
+        old_start = datetime.fromisoformat(row["start_datetime"])
+        old_end = datetime.fromisoformat(row["end_datetime"])
+        new_start = old_start - SHIFT
+        new_end = old_end - SHIFT
+
+        print(
+            f"id={row['id']}: "
+            f"start {old_start.isoformat()} -> {new_start.isoformat()}, "
+            f"end {old_end.isoformat()} -> {new_end.isoformat()}"
+        )
+
+        if args.apply:
+            client.table("production_schedules").update(
+                {
+                    "start_datetime": new_start.isoformat(),
+                    "end_datetime": new_end.isoformat(),
+                }
+            ).eq("id", row["id"]).execute()
+
+    if args.apply:
+        print("補正を適用しました。")
+    else:
+        print("ドライランです。--apply を付けて実行すると実際に更新されます。")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/patch_schedule_timezone.py
+++ b/backend/scripts/patch_schedule_timezone.py
@@ -8,8 +8,11 @@ production_schedules のタイムゾーン不具合(Issue #282)を修正する�
     9時間遅い時刻がUTCとしてそのまま保存されてしまっていた。
     (例: 本来 JST 9:00 = UTC 00:00 であるべきところ、UTC 09:00 として保存された)
 
-このスクリプトは、影響を受けた production_schedules の start_datetime / end_datetime から
-9時間を差し引くことで、正しいUTC値(JST基準)に補正する。
+このスクリプトは、不具合のパターンに一致するレコード（UTC時刻の time-of-day が
+稼働時間帯 9:00-17:00 に収まっているもの）のみを対象に、start_datetime / end_datetime
+から9時間を差し引くことで正しいUTC値(JST基準)に補正する。既に正しく補正済みの
+レコード（UTC time-of-day が 9:00-17:00 の範囲外になったもの）は対象外となるため、
+複数回実行しても安全（冪等）。
 
 Usage:
     # 対象レコードの確認のみ（DBは変更しない）
@@ -22,13 +25,24 @@ Usage:
 import argparse
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 
 from dotenv import load_dotenv
 
 from supabase import create_client
 
 SHIFT = timedelta(hours=9)
+# 不具合の兆候: UTC time-of-day がこの範囲に収まっている（本来はJSTの9:00-17:00のはずが
+# ホストTZ依存によりUTCとしてそのまま保存された値）
+SUSPECT_RANGE = (time(9, 0), time(17, 0))
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _is_suspect(dt: datetime) -> bool:
+    return SUSPECT_RANGE[0] <= dt.time() <= SUSPECT_RANGE[1]
 
 
 def _get_admin_client(env_file: str):
@@ -72,11 +86,17 @@ def main() -> None:
         .execute()
     )
     rows = res.data or []
-    print(f"対象レコード数: {len(rows)}")
+    print(f"取得レコード数: {len(rows)}")
 
+    target_count = 0
     for row in rows:
-        old_start = datetime.fromisoformat(row["start_datetime"])
-        old_end = datetime.fromisoformat(row["end_datetime"])
+        old_start = _parse_iso(row["start_datetime"])
+        old_end = _parse_iso(row["end_datetime"])
+
+        if not (_is_suspect(old_start) and _is_suspect(old_end)):
+            continue
+
+        target_count += 1
         new_start = old_start - SHIFT
         new_end = old_end - SHIFT
 
@@ -94,6 +114,7 @@ def main() -> None:
                 }
             ).eq("id", row["id"]).execute()
 
+    print(f"補正対象レコード数: {target_count}")
     if args.apply:
         print("補正を適用しました。")
     else:

--- a/docs/features/simulation-engine.md
+++ b/docs/features/simulation-engine.md
@@ -389,8 +389,8 @@ class CalendarConfig:
 
 - **設備選択は最小負荷方式**: グループ内で「最も早く空く設備」を選択。設備の均等配分は保証しない
 - **既存スケジュールは再計算されない**: confirm 実行時に他の受注の確定済みスケジュールは変更されない。設備の空き時間は `production_schedules` の最終 `end_datetime` を基準とするため、手動でキャンセルした受注のスケジュールが残っている場合は空き時間の判定に影響する
-- **start_time デフォルト**: `schedule_order()` の `start_time=None` の場合、現在時刻（`datetime.now()`）が基準になる。テストや過去日付での計算が必要な場合は明示的に渡す
-- **タイムゾーン**: 全 datetime は UTC（`timestamptz`）で保存。フロントエンドの表示は日本語ロケールに変換
+- **start_time デフォルト**: `schedule_order()` の `start_time=None` の場合、JST基準の現在時刻（`datetime.now(JST)`、`app.utils.calendar.JST`）が基準になる。テストや過去日付での計算が必要な場合は明示的に渡す
+- **タイムゾーン**: 全 datetime は UTC（`timestamptz`）で保存。フロントエンドの表示は日本語ロケールに変換。稼働時間判定（9:00-17:00・休憩12:00-13:00）は `app/utils/calendar.py` の `_to_business_tz()` により実行ホストのタイムゾーンに関わらず常に JST(`Asia/Tokyo`) へ正規化してから行われる（Issue #282: 以前はホストのローカルタイムゾーンをそのままJSTとみなしていたため、UTCで動作するホストでは実際の稼働時間が JST 18:00-翌2:00 相当にずれる不具合があった）
 - **複数日分割**: 1 工程が 7 時間を超える場合、翌稼働日の 9:00 に続きが割り当てられる。分割された各セグメントが個別の `production_schedules` レコードとなる
 - **工程確定ガード**: `is_confirmed=false` の工程が 1 件でもある場合、`dry_run=False`（ガント登録）はブロックされる。`dry_run=True`（シミュレーション）はブロックされない。詳細は「工程確定ガード」セクション参照
 - **`is_confirmed` フィールド不在の扱い**: `routings_are_confirmed()` は `r.get("is_confirmed", False)` で評価するため、マイグレーション前のレコード（フィールドなし）も未確定として扱われる


### PR DESCRIPTION
## Summary
- `backend/app/utils/calendar.py` の稼働時間判定（9:00-17:00・休憩12:00-13:00）を、実行ホストのタイムゾーンに依存せず常に JST (`Asia/Tokyo`) に正規化してから行うよう修正
- `backend/app/scheduler_logic.py` の `datetime.now().astimezone()`（ホストのローカルTZに依存）を `datetime.now(JST)` に変更
- Render（UTC想定ホスト）で動作していたことにより、本番の `production_schedules` 全35件がJST換算で本来より9時間遅い時刻（工場稼働時間外）で保存されていたため、`backend/scripts/patch_schedule_timezone.py` を作成し、既存データを補正済み
- `docs/features/simulation-engine.md` のタイムゾーン仕様の記述を更新

## 背景
Supabase上の `production_schedules.start_datetime`/`end_datetime` (`timestamptz`) は正しくUTCで保存され、フロントエンドも正しくJSTに変換して表示していたが、バックエンドのスケジューリングロジックがホストのローカルタイムゾーンをJSTの壁時計時刻とみなして「9:00-17:00」を計算していたため、UTCで動作するホスト上では実質 JST 18:00-翌2:00 相当の時間帯にスケジュールが組まれてしまっていた。

Closes #282

## Test plan
- [x] `pytest __tests__/unit/utils/test_calendar.py __tests__/unit/utils/test_calendar_config.py __tests__/unit/test_scheduler.py` がパスすること（既存テストのうちホストTZ依存だったフィクスチャをJST明示に修正）
- [x] `pytest __tests__/unit/ __tests__/api/` 全体がパスすること
- [x] `ruff check` / `mypy` がエラーなしであること
- [x] 本番Supabaseの `production_schedules`（35件）に対し `scripts/patch_schedule_timezone.py --apply` を実行し、全レコードがJST 9:00-17:00の範囲に収まる値に補正されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)