### PR TITLE
fix(frontend): 注文削除時のnull表示を解消し確認導線を強化

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -326,7 +326,7 @@ frontend/src/
     page.tsx                              # エントリーポイント（~160行）
   components/orders/
     edit-order-dialog.tsx                 # 注文編集ダイアログ
-    delete-order-dialog.tsx               # 削除確認 AlertDialog
+    delete-order-dialog.tsx               # 削除確認 AlertDialog（注文番号/製品/顧客/数量/希望納期/確定納期のサマリー表示、#284）
     order-notification-cards.tsx          # 下書き/情報不足サマリーカード
     orders-filter-bar.tsx                 # ステータスタブ + ソートセレクト
     order-table-row.tsx                   # テーブル行
@@ -411,3 +411,4 @@ frontend/src/
 | 工程未確定注文の希望納期フォールバック表示 | 中 | ❌ 未実装 (#201) |
 | シミュレーション結果での設備衝突警告 | 中 | ❌ 未実装 (#202) |
 | フィルタータブを orders.status のみに限定（情報不足・工程未確認タブ削除） | 中 | ❌ 未実装 (#215) |
+| 削除確認ダイアログの注文サマリー表示・削除トーストの簡略化 | 中 | ✅ 実装済 (#284) |

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -201,6 +201,8 @@ export default function OrdersPage() {
 
         <DeleteOrderDialog
           order={deleteTargetOrder}
+          products={products}
+          customers={customers}
           isPending={deleteOrder.isPending}
           onConfirm={handleConfirmDelete}
           onOpenChange={(open) => { if (!open) setDeleteTargetOrder(null) }}

--- a/frontend/src/components/orders/delete-order-dialog.tsx
+++ b/frontend/src/components/orders/delete-order-dialog.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
 import { buttonVariants } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -11,16 +13,28 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import { getProductName, getCustomerName } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
+import type { Product } from "@/types/product"
+import type { Customer } from "@/types/customer"
 
 interface DeleteOrderDialogProps {
   order: Order | null
+  products?: Product[]
+  customers?: Customer[]
   isPending: boolean
   onConfirm: () => void
   onOpenChange: (open: boolean) => void
 }
 
-export function DeleteOrderDialog({ order, isPending, onConfirm, onOpenChange }: DeleteOrderDialogProps) {
+export function DeleteOrderDialog({
+  order,
+  products,
+  customers,
+  isPending,
+  onConfirm,
+  onOpenChange,
+}: DeleteOrderDialogProps) {
   return (
     <AlertDialog
       open={order !== null}
@@ -29,8 +43,46 @@ export function DeleteOrderDialog({ order, isPending, onConfirm, onOpenChange }:
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>注文の削除</AlertDialogTitle>
-          <AlertDialogDescription>
-            注文「{order?.order_no}」を削除しますか？この操作は取り消せません。
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              <p>この注文を削除しますか？この操作は取り消せません。</p>
+              {order && (
+                <div className="rounded-md border p-3 text-sm text-foreground space-y-1">
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">注文番号</span>
+                    <span>{order.order_no ?? "未設定"}</span>
+                  </div>
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">製品</span>
+                    <span>{getProductName(order.product_id, products)}</span>
+                  </div>
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">顧客</span>
+                    <span>{getCustomerName(order.customer_id, customers)}</span>
+                  </div>
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">数量</span>
+                    <span>{order.quantity}</span>
+                  </div>
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">希望納期</span>
+                    <span>
+                      {order.desired_deadline
+                        ? format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
+                        : "未設定"}
+                    </span>
+                  </div>
+                  <div className="flex justify-between gap-4">
+                    <span className="text-muted-foreground">確定納期</span>
+                    <span>
+                      {order.confirmed_deadline
+                        ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", { locale: ja })
+                        : "-"}
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -162,10 +162,9 @@ export function useOrdersPage() {
   const handleConfirmDelete = () => {
     if (!deleteTargetOrder) return
     const targetId = deleteTargetOrder.id
-    const targetNo = deleteTargetOrder.order_no
     deleteOrder.mutate(targetId, {
       onSuccess: () => {
-        toast.success(`注文「${targetNo}」を削除しました`)
+        toast.success("注文を削除しました")
         setDeleteTargetOrder(null)
         if (expandedOrderId === targetId) {
           setExpandedOrderId(null)


### PR DESCRIPTION
## Summary
- `order_no` が null の注文を削除すると、確認ダイアログと成功トーストに「null」という文字列がそのまま表示されていた不具合を修正
- 削除確認ダイアログに注文番号（未設定時は「未設定」）・製品・顧客・数量・希望納期・確定納期のサマリーを表示し、削除対象の妥当性を確認しやすくした
- 削除成功トーストは注文番号を含めず「注文を削除しました」に簡略化

## Test plan
- [x] `tsc --noEmit` / `eslint` エラーなしを確認
- [x] ローカルSupabase + `order_number = NULL` の注文データで実ブラウザ動作確認（Playwright）
  - 削除確認ダイアログに「注文番号: 未設定」を含むサマリーが表示されることを確認
  - 削除成功トーストが「注文を削除しました」のみになることを確認
- [x] `docs/features/order-management-ui-design.md` を更新

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)