### PR TITLE
docs: Azure Functions関連の記述をFastAPI/Cloud Run(uvicorn)の実態に合わせて修正

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -33,14 +33,14 @@
 * **Pydantic V2**: データモデルはPydantic V2構文 (`model_dump`, `field_validator` 等) を使用する。
 * **Docstrings**: クラスおよび関数にはGoogle StyleのDocstringを記述する。
 
-### 2.2 FastAPI / Azure Functions 実装
+### 2.2 FastAPI 実装
 
 * **Dependency Injection**: リポジトリや共通処理は `dependencies.py` に定義し、`Depends()` を使用して注入する。
 * OK: `def get_orders(repo: OrderRepository = Depends(get_order_repo))`
 * NG: 関数内で `repo = OrderRepository()` を直接インスタンス化。
 
 
-* **Router構成**: `master` (マスタデータ) と `transaction` (業務データ) でディレクトリを分け、`__init__.py` で集約して `function_app.py` に登録する。
+* **Router構成**: `master` (マスタデータ) と `transaction` (業務データ) でディレクトリを分け、`__init__.py` で集約して `main.py` の FastAPI アプリに登録する。
 
 ### 2.3 Phase 1 ビジネスロジック要件 (Scheduling)
 
@@ -142,7 +142,7 @@
 
 * **仮想環境**: `.venv` を使用。
 * **起動コマンド**:
-* Backend: `func host start`
+* Backend: `uvicorn app.main:app --reload --port 8000`
 * DB: `supabase start`
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 中小製造業向けの生産計画 SaaS。受注入力 → シミュレーション → 確定 のワークフローで、設備ごとのガントチャート表示・手動調整まで対応するマルチテナントシステム。(詳細は[product_planner_knowledge.md](docs/product_planner_knowledge.md) 参照)
 
-- **Backend**: FastAPI (Python) + Supabase (PostgreSQL) + Azure Functions
+- **Backend**: FastAPI (Python) + Supabase (PostgreSQL)、Cloud Run 上で uvicorn により稼働
 - **Frontend**: Next.js 14+ (App Router) + TanStack Query + shadcn/ui
 - **Multi-tenancy**: Supabase Auth + Row Level Security (RLS)
 
@@ -45,7 +45,7 @@ docs/features/          # 機能別ドキュメント (PR 完了後に更新)
 
 ```bash
 # Backend 起動
-cd backend && func host start
+cd backend && uvicorn app.main:app --reload --port 8000
 
 # Frontend 起動
 cd frontend && npm run dev

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ### Backend
 
 * **Runtime**: Python 3.11
-* **Framework**: [Azure Functions](https://learn.microsoft.com/azure/azure-functions/) (v4 Programming Model), [FastAPI](https://fastapi.tiangolo.com/)
+* **Framework**: [FastAPI](https://fastapi.tiangolo.com/)（[Cloud Run](https://cloud.google.com/run) 上で uvicorn により稼働）
 * **Architecture**: Clean Architecture / Repository Pattern
 
 ### Database & Auth
@@ -41,7 +41,7 @@
 
 ```text
 .
-├── backend/            # Python Azure Functions (API)
+├── backend/            # Python FastAPI (API)
 │   ├── app/            # アプリケーションコード (Routers, Models, Logic)
 │   ├── tests/          # Pytest (Unit, Integration)
 │   └── scripts/        # データ投入用スクリプト
@@ -61,7 +61,6 @@
 * Python 3.11
 * Docker Desktop
 * [Supabase CLI](https://supabase.com/docs/guides/cli)
-* [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 
 ### 1. データベース (Supabase) の起動
 
@@ -91,11 +90,11 @@ cp .env.example .env
 # .env 内の SUPABASE_URL, SUPABASE_ANON_KEY などを手順1の値に設定
 
 # サーバー起動
-func host start
+uvicorn app.main:app --reload --port 8000
 
 ```
 
-APIは `http://localhost:7071/api` で起動します。
+APIは `http://localhost:8000` で起動します。
 
 ### 3. フロントエンド (Frontend) のセットアップ
 

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -91,9 +91,9 @@ Gmail連携機能（GMAIL_ORDER_INTAKE）で生成される下書き受注（`so
 
 ### 追加の前提条件
 
-- バックエンドが起動していること（`func host start`）
+- バックエンドが起動していること（`uvicorn app.main:app --reload --port 8000`）
 - `SUPABASE_API_KEY`（`get_token.py` が参照するキー）
-- `BACKEND_URL`（省略時: `http://localhost:7071`）
+- `BACKEND_URL`（省略時: `http://localhost:8000`）
 
 > **注意:** 先に `seed_scenario.py standard_demo` を実行して製品データを用意してください。`orders.json` 内の製品コードが見つからない場合はその注文はスキップされます。
 

--- a/backend/scripts/create_product.py
+++ b/backend/scripts/create_product.py
@@ -45,9 +45,8 @@ def create_product():
         "type": "standard",
     }
 
-    response = requests.post(
-        "http://localhost:7071/api/products/", headers=headers, json=data
-    )
+    backend_url = os.environ.get("BACKEND_URL", "http://localhost:8000")
+    response = requests.post(f"{backend_url}/products/", headers=headers, json=data)
     if response.status_code != 200:
         # APIリクエストが失敗した場合は、エラーを投げて終了
         raise Exception(f"Failed to create product: {response.text}")

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -157,7 +157,7 @@ interface OrderCreate {
 
 ## メール解析パイプライン（実装済み）
 
-`backend/app/services/` 配下に以下のサービスが実装済み。Vercel Cron または Azure Functions タイマートリガーから `poll_unread_emails()` を呼び出すことで動作する。
+`backend/app/services/` 配下に以下のサービスが実装済み。Vercel Cron（将来的には Cloud Run + Cloud Scheduler へ移行検討中、詳細は [docs/infra/env-setup-gmail-cron.md](../infra/env-setup-gmail-cron.md) 参照）から `/api/cron/gmail-poll` を叩き `poll_unread_emails()` を呼び出すことで動作する。
 
 ### 処理フロー（Issue #280 でPDF添付・非PDF添付・添付なしを統一）
 


### PR DESCRIPTION
## Summary
- 本アプリのバックエンドは実際には Cloud Run 上で `uvicorn app.main:app` により稼働する FastAPI アプリであり、Azure Functions は使用していない（Dockerfile も uvicorn 起動のみ）
- `CLAUDE.md` / `README.md` / `Agent.md` / `backend/scripts/USAGE.md` / `backend/scripts/create_product.py` に残っていた `func host start` / Azure Functions / ポート `7071` 等の古い記述を、実際の起動コマンド（`uvicorn app.main:app --reload --port 8000`）・ポート番号に修正
- メール起票の cron トリガーに関する記述（`docs/features/email-order-intake.md`）も、実際の Vercel Cron 方式（将来 Cloud Run + Cloud Scheduler へ移行検討中）に合わせて修正

## Test plan
- [x] `ruff check` / `ruff format` / 該当ファイルの `git diff` を確認
- [x] ドキュメント修正のみのため、リポジトリ内の他の Azure Functions / `func host start` / `:7071` 参照が残っていないことを `grep` で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)