### PR TITLE
fix: seed_scenario.pyのorders投入をON CONFLICTから select→insert/update方式に変更 (#286)

### DIFF
--- a/backend/__tests__/scripts/test_seed_scenario.py
+++ b/backend/__tests__/scripts/test_seed_scenario.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.seed_scenario import (
     import_groups,
+    import_orders,
     import_products,
     import_routings,
     load_json,
@@ -107,3 +108,62 @@ class TestImporters:
             )
 
         assert not mock_db["table"].upsert.called
+
+
+class TestImportOrders:
+    """orders インポート処理のテスト（部分ユニークインデックス対応）"""
+
+    def test_import_orders_inserts_new_order(self, mock_db):
+        table = mock_db["table"]
+        # order_number で検索したが既存レコードなし
+        table.select.return_value.eq.return_value.eq.return_value.execute.return_value.data = []
+        test_data = [
+            {"order_number": "ORD-1", "product_code": "PROD-A", "quantity": 10}
+        ]
+
+        with patch("scripts.seed_scenario.load_json", return_value=test_data):
+            import_orders(mock_db["client"], "tenant-1", "/path", {"PROD-A": 10})
+
+        assert table.insert.called
+        assert not table.update.called
+        assert not table.upsert.called
+
+    def test_import_orders_updates_existing_order(self, mock_db):
+        table = mock_db["table"]
+        # order_number で検索したら既存レコードあり
+        table.select.return_value.eq.return_value.eq.return_value.execute.return_value.data = [
+            {"id": 99}
+        ]
+        test_data = [
+            {"order_number": "ORD-1", "product_code": "PROD-A", "quantity": 10}
+        ]
+
+        with patch("scripts.seed_scenario.load_json", return_value=test_data):
+            import_orders(mock_db["client"], "tenant-1", "/path", {"PROD-A": 10})
+
+        assert table.update.called
+        table.update.return_value.eq.assert_called_with("id", 99)
+
+    def test_import_orders_without_order_number_inserts_directly(self, mock_db):
+        table = mock_db["table"]
+        test_data = [{"product_code": "PROD-A", "quantity": 10}]
+
+        with patch("scripts.seed_scenario.load_json", return_value=test_data):
+            import_orders(mock_db["client"], "tenant-1", "/path", {"PROD-A": 10})
+
+        assert table.insert.called
+        assert not table.select.called
+        assert not table.upsert.called
+
+    def test_import_orders_skips_missing_product(self, mock_db):
+        table = mock_db["table"]
+        test_data = [
+            {"order_number": "ORD-1", "product_code": "MISSING", "quantity": 10}
+        ]
+
+        with patch("scripts.seed_scenario.load_json", return_value=test_data):
+            import_orders(mock_db["client"], "tenant-1", "/path", {"PROD-A": 10})
+
+        assert not table.insert.called
+        assert not table.update.called
+        assert not table.select.called

--- a/backend/scripts/seed_scenario.py
+++ b/backend/scripts/seed_scenario.py
@@ -14,7 +14,9 @@ Note:
     - equipment_group_members: (equipment_group_id, equipment_id)
     - products: (tenant_id, code)
     - process_routings: (product_id, sequence_order)
-    - orders: (tenant_id, order_number)
+    - orders: order_number は nullable のため部分ユニークインデックス
+      (tenant_id, order_number) WHERE order_number IS NOT NULL のみが存在する。
+      ON CONFLICT では対応できないため、select→insert/update で冪等性を担保する。
 """
 
 import argparse
@@ -282,22 +284,38 @@ def import_orders(
             continue
 
         product_id = product_map[product_code]
+        order_number = order_data.get("order_number")
 
-        # 注文を登録（upsert）
-        client.table("orders").upsert(
-            {
-                "order_number": order_data["order_number"],
-                "product_id": product_id,
-                "quantity": order_data["quantity"],
-                "deadline_date": order_data.get("deadline_date"),
-                "tenant_id": tenant_id,
-            },
-            on_conflict="tenant_id, order_number",
-        ).execute()
+        payload = {
+            "order_number": order_number,
+            "product_id": product_id,
+            "quantity": order_data["quantity"],
+            "deadline_date": order_data.get("deadline_date"),
+            "tenant_id": tenant_id,
+        }
+
+        # order_number は nullable かつ部分ユニークインデックスのため、
+        # ON CONFLICT ではなく select して存在すれば update、なければ insert する
+        if order_number:
+            existing = (
+                client.table("orders")
+                .select("id")
+                .eq("tenant_id", tenant_id)
+                .eq("order_number", order_number)
+                .execute()
+            )
+            if existing.data:
+                order_id = existing.data[0]["id"]
+                client.table("orders").update(payload).eq("id", order_id).execute()
+            else:
+                client.table("orders").insert(payload).execute()
+        else:
+            client.table("orders").insert(payload).execute()
 
         order_count += 1
+        order_label = order_number or "(no order_number)"
         print(
-            f"  ✓ Created order: {order_data['order_number']} "
+            f"  ✓ Created order: {order_label} "
             f"({product_code} x {order_data['quantity']})"
         )
 

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -303,3 +303,4 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 | Claude API によるメール本文解析 (`email_extraction_service.py`) | ✅ 実装済み |
 | pg_trgm 製品名マッチング (`product_matching_service.py`) | ✅ 実装済み |
 | 顧客自動解決・作成 (`customer_matching_service.py`) | ✅ 実装済み |
+| `seed_scenario.py` の `order_number` 部分ユニークインデックス対応 | ✅ #286 |


### PR DESCRIPTION
## Summary
- `seed_scenario.py` の `import_orders` が `orders` テーブルへ `upsert(on_conflict="tenant_id, order_number")` していたが、#280/#281 で `order_number` が nullable 化され通常のUNIQUE制約が部分ユニークインデックス (`WHERE order_number IS NOT NULL`) に置き換わったため、PostgRESTのON CONFLICT指定がマッチせず `42P10` エラーになっていた
- `order_number` がある場合は select して既存レコードがあれば `update`、なければ `insert`、`order_number` が無い場合はそのまま `insert` する方式に変更し、ON CONFLICT に依存しないようにした
- `docs/features/email-order-intake.md` の実装状況テーブルに本対応を追記

## Test plan
- [x] `pytest __tests__/scripts/test_seed_scenario.py` — 新規/既存注文/order_number無し/製品未検出のケースを追加してパス
- [x] `pytest __tests__/unit/ __tests__/api/` — 既存テスト全体がパス
- [x] `ruff check` / `mypy` — 変更ファイルでエラーなし
- [ ] ローカル `supabase start` + `python scripts/seed_scenario.py standard_demo` の実行完走確認（要ローカルSupabase環境）

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)