### PR TITLE
下書き注文の手動分割APIとUIを実装 (Issue #280 Phase3)

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -437,6 +437,7 @@ class TestOrderRouter:
             "customer_certainty": "forecast",
             "source_type": "email",
             "source_raw": "mail body",
+            "deadline_date": "2026-07-01",
         }
         mock_repo.get_by_id.return_value = original_order
 
@@ -481,13 +482,16 @@ class TestOrderRouter:
         assert first_call_data["customer_id"] == 10
         assert first_call_data["customer_certainty"] == "forecast"
 
+        # 新規INSERTの前に、元の注文の deadline_date を退避（NULL化）している
+        mock_repo.update.assert_any_call(order_id, {"deadline_date": None})
+        # 全明細の作成に成功した後、元の注文を実際に削除する
         mock_repo.delete.assert_called_once_with(order_id)
         assert mock_supabase_client.table.return_value.insert.call_count == 2
 
     def test_split_order_rolls_back_on_conflict(
         self, headers, mock_repo, mock_supabase_client
     ):
-        """POST /{order_id}/split: 2件目の作成が重複エラーの場合、既作成分をロールバックする"""
+        """POST /{order_id}/split: 2件目の作成が重複エラーの場合、既作成分をロールバックし元注文を復元する"""
         order_id = 1
         original_order = {
             "id": order_id,
@@ -497,6 +501,7 @@ class TestOrderRouter:
             "customer_certainty": "forecast",
             "source_type": "email",
             "source_raw": "mail body",
+            "deadline_date": "2026-07-01",
         }
         mock_repo.get_by_id.return_value = original_order
         (
@@ -506,7 +511,6 @@ class TestOrderRouter:
         mock_repo.create.side_effect = [
             {"id": 101, "product_id": 1, "quantity": 10, "deadline_date": "2026-08-01"},
             ValueError("重複データ: orders_dedupe_key"),
-            {**original_order, "id": order_id},  # ロールバック時の復元
         ]
 
         response = client.post(
@@ -521,12 +525,41 @@ class TestOrderRouter:
         )
 
         assert response.status_code == 400
-        # 元の注文の削除（分割開始時）と、失敗した明細の削除（ロールバック）の2回
-        assert mock_repo.delete.call_count == 2
-        mock_repo.delete.assert_any_call(order_id)
-        mock_repo.delete.assert_any_call(101)
-        # ロールバック時に元の注文が復元される（id を除いた内容で再作成）
-        assert mock_repo.create.call_count == 3
-        restore_call_data = mock_repo.create.call_args_list[2][0][0]
-        assert "id" not in restore_call_data
-        assert restore_call_data["customer_id"] == 10
+        # 失敗した明細（101）のみ削除する。元の注文は削除しない（deadline_date退避のみ）
+        mock_repo.delete.assert_called_once_with(101)
+        # 元の注文は退避 → 復元の2回 update される（削除・再作成は発生しない）
+        assert mock_repo.update.call_count == 2
+        mock_repo.update.assert_any_call(order_id, {"deadline_date": None})
+        mock_repo.update.assert_any_call(
+            order_id, {"deadline_date": original_order["deadline_date"]}
+        )
+        assert mock_repo.create.call_count == 2
+
+    def test_split_order_source_attachment_missing(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/split: source_attachment_id先のレコードが見つからない場合400"""
+        order_id = 1
+        mock_repo.get_by_id.return_value = {
+            "id": order_id,
+            "status": "draft",
+            "source_attachment_id": "att-missing",
+        }
+        (
+            mock_supabase_client.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value.data
+        ) = None
+
+        response = client.post(
+            f"/orders/{order_id}/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        mock_repo.create.assert_not_called()
+        mock_repo.update.assert_not_called()

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -7,6 +7,7 @@ from app.dependencies import (
     get_order_repo,
     get_product_repo,
     get_schedule_repo,
+    get_supabase_client,
 )
 
 # テスト対象のAPIインスタンス
@@ -52,6 +53,11 @@ class TestOrderRouter:
         mock.get.return_value = None
         return mock
 
+    @pytest.fixture
+    def mock_supabase_client(self):
+        """order_attachments への直接クエリ用クライアントのモック"""
+        return MagicMock()
+
     @pytest.fixture(autouse=True)
     def override_dependency(
         self,
@@ -60,6 +66,7 @@ class TestOrderRouter:
         mock_equipment_repo,
         mock_schedule_repo,
         mock_settings_repo,
+        mock_supabase_client,
     ):
         """
         テスト実行中だけ依存関係を mock に差し替える。
@@ -69,6 +76,7 @@ class TestOrderRouter:
         app.dependency_overrides[get_equipment_repo] = lambda: mock_equipment_repo
         app.dependency_overrides[get_schedule_repo] = lambda: mock_schedule_repo
         app.dependency_overrides[get_settings_repo] = lambda: mock_settings_repo
+        app.dependency_overrides[get_supabase_client] = lambda: mock_supabase_client
         yield
         app.dependency_overrides = {}
 
@@ -353,3 +361,163 @@ class TestOrderRouter:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Order not found"
+
+    def test_split_order_not_found(self, headers, mock_repo):
+        """POST /{order_id}/split: 注文が存在しない場合の404エラーテスト"""
+        mock_repo.get_by_id.return_value = None
+
+        response = client.post(
+            "/orders/999/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Order not found"
+
+    def test_split_order_not_draft(self, headers, mock_repo):
+        """POST /{order_id}/split: draft以外の注文は分割できない"""
+        mock_repo.get_by_id.return_value = {
+            "id": 1,
+            "status": "confirmed",
+            "source_attachment_id": "att-1",
+        }
+
+        response = client.post(
+            "/orders/1/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "下書き" in response.json()["detail"]
+        mock_repo.create.assert_not_called()
+
+    def test_split_order_no_source_attachment(self, headers, mock_repo):
+        """POST /{order_id}/split: source_attachment_id が無い注文は分割できない"""
+        mock_repo.get_by_id.return_value = {
+            "id": 1,
+            "status": "draft",
+            "source_attachment_id": None,
+        }
+
+        response = client.post(
+            "/orders/1/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert "分割できません" in response.json()["detail"]
+        mock_repo.create.assert_not_called()
+
+    def test_split_order_success(self, headers, mock_repo, mock_supabase_client):
+        """POST /{order_id}/split: 正常に2件へ分割できるテスト"""
+        order_id = 1
+        original_order = {
+            "id": order_id,
+            "status": "draft",
+            "source_attachment_id": "att-1",
+            "customer_id": 10,
+            "customer_certainty": "forecast",
+            "source_type": "email",
+            "source_raw": "mail body",
+        }
+        mock_repo.get_by_id.return_value = original_order
+
+        source_row = {
+            "id": "att-1",
+            "storage_path": "tenant/inbox/msg-1/file.pdf",
+            "original_filename": "file.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 1234,
+        }
+        (
+            mock_supabase_client.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value.data
+        ) = source_row
+
+        created = [
+            {"id": 101, "product_id": 1, "quantity": 10, "deadline_date": "2026-08-01"},
+            {"id": 102, "product_id": 2, "quantity": 20, "deadline_date": "2026-09-01"},
+        ]
+        mock_repo.create.side_effect = created
+        mock_repo.delete.return_value = True
+
+        response = client.post(
+            f"/orders/{order_id}/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["original_order_id"] == order_id
+        assert len(result["created_orders"]) == 2
+
+        assert mock_repo.create.call_count == 2
+        first_call_data = mock_repo.create.call_args_list[0][0][0]
+        assert first_call_data["tenant_id"] == headers["x-tenant-id"]
+        assert first_call_data["source_attachment_id"] == "att-1"
+        assert first_call_data["customer_id"] == 10
+        assert first_call_data["customer_certainty"] == "forecast"
+
+        mock_repo.delete.assert_called_once_with(order_id)
+        assert mock_supabase_client.table.return_value.insert.call_count == 2
+
+    def test_split_order_rolls_back_on_conflict(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/split: 2件目の作成が重複エラーの場合、既作成分をロールバックする"""
+        order_id = 1
+        original_order = {
+            "id": order_id,
+            "status": "draft",
+            "source_attachment_id": "att-1",
+            "customer_id": 10,
+            "customer_certainty": "forecast",
+            "source_type": "email",
+            "source_raw": "mail body",
+        }
+        mock_repo.get_by_id.return_value = original_order
+        (
+            mock_supabase_client.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value.data
+        ) = {"storage_path": "p", "original_filename": "f"}
+
+        mock_repo.create.side_effect = [
+            {"id": 101, "product_id": 1, "quantity": 10, "deadline_date": "2026-08-01"},
+            ValueError("重複データ: orders_dedupe_key"),
+        ]
+
+        response = client.post(
+            f"/orders/{order_id}/split",
+            json={
+                "line_items": [
+                    {"product_id": 1, "quantity": 10, "desired_deadline": "2026-08-01"},
+                    {"product_id": 2, "quantity": 20, "desired_deadline": "2026-09-01"},
+                ]
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        mock_repo.delete.assert_called_once_with(101)

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -506,6 +506,7 @@ class TestOrderRouter:
         mock_repo.create.side_effect = [
             {"id": 101, "product_id": 1, "quantity": 10, "deadline_date": "2026-08-01"},
             ValueError("重複データ: orders_dedupe_key"),
+            {**original_order, "id": order_id},  # ロールバック時の復元
         ]
 
         response = client.post(
@@ -520,4 +521,12 @@ class TestOrderRouter:
         )
 
         assert response.status_code == 400
-        mock_repo.delete.assert_called_once_with(101)
+        # 元の注文の削除（分割開始時）と、失敗した明細の削除（ロールバック）の2回
+        assert mock_repo.delete.call_count == 2
+        mock_repo.delete.assert_any_call(order_id)
+        mock_repo.delete.assert_any_call(101)
+        # ロールバック時に元の注文が復元される（id を除いた内容で再作成）
+        assert mock_repo.create.call_count == 3
+        restore_call_data = mock_repo.create.call_args_list[2][0][0]
+        assert "id" not in restore_call_data
+        assert restore_call_data["customer_id"] == 10

--- a/backend/app/models/transaction/order_schema.py
+++ b/backend/app/models/transaction/order_schema.py
@@ -1,5 +1,7 @@
 # models/transaction/order_schema.py
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.common.base_schema import BaseSchema
@@ -42,6 +44,29 @@ class OrderUpdate(BaseSchema):
     quantity: int | None = None
     deadline_date: str | None = Field(None, alias="desired_deadline")
     customer_id: int | None = None
+
+
+class OrderSplitLineItem(BaseSchema):
+    """分割後の1受注を表すスキーマ"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    product_id: int
+    quantity: int
+    deadline_date: str = Field(alias="desired_deadline")
+    customer_id: int | None = None
+    customer_certainty: (
+        Literal["confirmed", "forecast", "forecast_tentative"] | None
+    ) = None
+    extracted_product_name: str | None = None
+
+
+class OrderSplitRequest(BaseSchema):
+    """1件の下書き注文をN件に手動分割するためのリクエストスキーマ"""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    line_items: list[OrderSplitLineItem] = Field(min_length=2)
 
 
 class OrderAttachmentResponse(BaseModel):

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -17,6 +17,7 @@ from app.models.transaction.order_schema import (
     OrderAttachmentResponse,
     OrderCreate,
     OrderSimulateRequest,
+    OrderSplitRequest,
     OrderUpdate,
 )
 from app.repositories.supa_infra.common.scheduling_settings_repo import (
@@ -199,6 +200,97 @@ def delete_order(order_id: int, repo: OrderRepository = Depends(get_order_repo))
     if not success:
         raise HTTPException(status_code=404, detail="Not found")
     return {"status": "deleted"}
+
+
+@orders_router.post("/{order_id}/split")
+def split_order(
+    order_id: int,
+    split_data: OrderSplitRequest,
+    tenant_id: str = Depends(get_current_tenant_id),
+    repo: OrderRepository = Depends(get_order_repo),
+    client: Client = Depends(get_supabase_client),
+):
+    """
+    誤って1件にマージされた下書き注文を、同じ source_attachment_id を参照する
+    N件の下書き注文に手動分割する（Issue #280）。
+    """
+    logger.info(f"Splitting order {order_id} into {len(split_data.line_items)} items")
+    order = repo.get_by_id(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    if order.get("status") != "draft":
+        raise HTTPException(status_code=400, detail="下書き状態の注文のみ分割できます")
+    source_attachment_id = order.get("source_attachment_id")
+    if not source_attachment_id:
+        raise HTTPException(
+            status_code=400,
+            detail="分割元の受注ソース（メール／添付ファイル）が不明なため分割できません",
+        )
+
+    source_row = cast(
+        "dict[str, Any] | None",
+        client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
+        .select("*")
+        .eq("id", source_attachment_id)
+        .single()
+        .execute()
+        .data,
+    )
+
+    created_orders: list[dict] = []
+    try:
+        for item in split_data.line_items:
+            new_order = repo.create(
+                {
+                    "tenant_id": tenant_id,
+                    "product_id": item.product_id,
+                    "quantity": item.quantity,
+                    "deadline_date": item.deadline_date,
+                    "customer_id": item.customer_id
+                    if item.customer_id is not None
+                    else order.get("customer_id"),
+                    "customer_certainty": item.customer_certainty
+                    or order.get("customer_certainty"),
+                    "status": "draft",
+                    "source_type": order.get("source_type"),
+                    "source_raw": order.get("source_raw"),
+                    "extracted_product_name": item.extracted_product_name,
+                    "source_attachment_id": source_attachment_id,
+                }
+            )
+            created_orders.append(new_order)
+
+            client.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+                {
+                    "order_id": new_order["id"],
+                    "tenant_id": tenant_id,
+                    "storage_path": source_row.get("storage_path", "")
+                    if source_row
+                    else "",
+                    "original_filename": source_row.get("original_filename", "")
+                    if source_row
+                    else "",
+                    "content_type": source_row.get("content_type")
+                    if source_row
+                    else None,
+                    "size_bytes": source_row.get("size_bytes") if source_row else None,
+                    "parse_status": "success"
+                    if source_row and source_row.get("storage_path")
+                    else "failed_no_attachment",
+                }
+            ).execute()
+    except ValueError as e:
+        for created in created_orders:
+            repo.delete(created["id"])
+        raise HTTPException(status_code=400, detail=str(e)) from None
+
+    repo.delete(order_id)
+
+    return {
+        "original_order_id": order_id,
+        "created_orders": [_map_order_response(o) for o in created_orders],
+    }
 
 
 def get_settings_repo(

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
+from postgrest.exceptions import APIError
 
 from app.dependencies import (
     get_current_tenant_id,
@@ -229,21 +230,36 @@ def split_order(
             detail="分割元の受注ソース（メール／添付ファイル）が不明なため分割できません",
         )
 
-    source_row = cast(
-        "dict[str, Any] | None",
-        client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
-        .select("*")
-        .eq("id", source_attachment_id)
-        .single()
-        .execute()
-        .data,
-    )
+    try:
+        source_row = cast(
+            "dict[str, Any] | None",
+            client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
+            .select("*")
+            .eq("id", source_attachment_id)
+            .single()
+            .execute()
+            .data,
+        )
+    except APIError as e:
+        raise HTTPException(
+            status_code=400,
+            detail="分割元の受注ソース（メール／添付ファイル）が見つかりませんでした",
+        ) from e
+    if not source_row:
+        raise HTTPException(
+            status_code=400,
+            detail="分割元の受注ソース（メール／添付ファイル）が見つかりませんでした",
+        )
 
     # 分割後の明細が元の注文と同じ (customer_id, product_id, deadline_date) を
-    # 指定した場合、元の注文自身と orders_dedupe_key が衝突してしまうため、
-    # 新規INSERTより先に元の注文を削除する。途中で失敗した場合は元の内容で
-    # 復元する。
-    repo.delete(order_id)
+    # 指定した場合、元の注文自身と orders_dedupe_key が衝突してしまう。これを
+    # 避けるため、元の注文は削除せず deadline_date を一時的にNULLへ退避する
+    # （UNIQUE制約はNULL同士を等価とみなさないため衝突しなくなる）。全明細の
+    # 作成に成功した時点で初めて元の注文を実際に削除し、失敗時は
+    # deadline_date を元に戻すだけで良い（idや紐づく order_attachments は
+    # 一切触れないため、削除→再作成のようなデータ消失が起きない）。
+    original_deadline_date = order.get("deadline_date")
+    repo.update(order_id, {"deadline_date": None})
 
     created_orders: list[dict] = []
     try:
@@ -272,27 +288,32 @@ def split_order(
                 {
                     "order_id": new_order["id"],
                     "tenant_id": tenant_id,
-                    "storage_path": source_row.get("storage_path", "")
-                    if source_row
-                    else "",
-                    "original_filename": source_row.get("original_filename", "")
-                    if source_row
-                    else "",
-                    "content_type": source_row.get("content_type")
-                    if source_row
-                    else None,
-                    "size_bytes": source_row.get("size_bytes") if source_row else None,
+                    "storage_path": source_row.get("storage_path", ""),
+                    "original_filename": source_row.get("original_filename", ""),
+                    "content_type": source_row.get("content_type"),
+                    "size_bytes": source_row.get("size_bytes"),
                     "parse_status": "success"
-                    if source_row and source_row.get("storage_path")
+                    if source_row.get("storage_path")
                     else "failed_no_attachment",
                 }
             ).execute()
-    except ValueError as e:
+    except (ValueError, APIError) as e:
         for created in created_orders:
             repo.delete(created["id"])
-        # 元の注文を復元する（分割前の状態に戻す）
-        repo.create({k: v for k, v in order.items() if k != "id"})
-        raise HTTPException(status_code=400, detail=str(e)) from None
+        # 元の注文のdeadline_dateを退避前の値に戻す（分割前の状態に復元）
+        repo.update(order_id, {"deadline_date": original_deadline_date})
+        detail = e.message if isinstance(e, APIError) else str(e)
+        raise HTTPException(status_code=400, detail=detail) from None
+
+    if not repo.delete(order_id):
+        logger.error(
+            f"split_order: created {len(created_orders)} orders but failed to "
+            f"delete original order {order_id}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="分割後の注文は作成されましたが、元の注文の削除に失敗しました。管理者に確認してください。",
+        )
 
     return {
         "original_order_id": order_id,

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -140,12 +140,13 @@ def get_order(order_id: int, repo: OrderRepository = Depends(get_order_repo)):
 )
 def get_order_attachments(
     order_id: int,
+    client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
     """注文に紐づく添付ファイル一覧を署名付きURLと共に返す"""
     logger.info(f"Fetching attachments for order {order_id}")
     result = (
-        admin_client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
+        client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
         .select("*")
         .eq("order_id", order_id)
         .order("created_at")
@@ -238,6 +239,12 @@ def split_order(
         .data,
     )
 
+    # 分割後の明細が元の注文と同じ (customer_id, product_id, deadline_date) を
+    # 指定した場合、元の注文自身と orders_dedupe_key が衝突してしまうため、
+    # 新規INSERTより先に元の注文を削除する。途中で失敗した場合は元の内容で
+    # 復元する。
+    repo.delete(order_id)
+
     created_orders: list[dict] = []
     try:
         for item in split_data.line_items:
@@ -283,9 +290,9 @@ def split_order(
     except ValueError as e:
         for created in created_orders:
             repo.delete(created["id"])
+        # 元の注文を復元する（分割前の状態に戻す）
+        repo.create({k: v for k, v in order.items() if k != "id"})
         raise HTTPException(status_code=400, detail=str(e)) from None
-
-    repo.delete(order_id)
 
     return {
         "original_order_id": order_id,

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -39,6 +39,7 @@ supabase start
 | `reset_dev_db.py` | ローカルSupabaseのリセット・起動・デモデータ投入を一括実行 | `python scripts/reset_dev_db.py [シナリオ名]` |
 | `seed_scenario.py` | シナリオ単位のデモデータ一括投入 | `python scripts/seed_scenario.py <シナリオ名>` |
 | `seed_gmail_drafts.py` | Gmail受注下書きサンプルデータ投入 | `python scripts/seed_gmail_drafts.py` |
+| `seed_split_demo.py` | 手動分割機能（Issue #280）確認用の下書き注文投入 | `python scripts/seed_split_demo.py` |
 
 ---
 
@@ -121,6 +122,35 @@ python scripts/seed_scenario.py standard_demo
 - 環境変数不足 → エラーメッセージを表示して終了
 - シナリオディレクトリ不在 → エラー終了
 - 参照先コードが見つからない場合 → 該当行をスキップして警告表示
+
+---
+
+## seed_split_demo.py — 手動分割機能（Issue #280）確認用データ投入
+
+`POST /orders/{order_id}/split`（1件の下書き注文を複数の下書き注文に手動分割する機能）を
+手元のブラウザで確認するためのデモデータを投入します。実際のメール受信・抽出パイプラインは
+通さず、「1通のメールに複数月分の内示数量が誤って1件にマージされてしまった」想定の
+draft注文と、その起票元となる `order_attachments` のステージング行を直接投入します。
+
+### 追加の前提条件
+
+- `order_attachments` のRLSポリシーが `auth.jwt()->>'tenant_id'` クレームを直接参照するため
+  （`is_tenant_member()` を使う他テーブルとは異なる）、通常の認証済みクライアントでは
+  INSERTがRLS違反になる。そのため本スクリプトは `SUPABASE_SERVICE_ROLE_KEY` が必要
+  （`seed_scenario.py` の `seed_admin_profile` と同じ bypass パターン。ローカル専用スクリプト
+  内での使用に限るため、アプリコード本体の「Service Role Key 禁止」ルールとは別枠）
+- `.env` に共通の環境変数（`SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `TEST_USER_EMAIL`,
+  `TEST_USER_PASS`, `TEST_TENANT_ID`）に加えて `SUPABASE_SERVICE_ROLE_KEY` を設定すること
+
+### 使い方
+
+```bash
+python scripts/seed_split_demo.py
+```
+
+冪等性: 固定の `gmail_message_id`（`seed-split-demo-b115105`）で検索するため、複数回実行しても
+重複しない。実行後に表示される `orders.id` を使い、フロントエンドで `/orders/{id}` を開くと
+「分割」ボタンが表示される。
 
 ---
 

--- a/backend/scripts/USAGE.md
+++ b/backend/scripts/USAGE.md
@@ -134,13 +134,11 @@ draft注文と、その起票元となる `order_attachments` のステージン
 
 ### 追加の前提条件
 
-- `order_attachments` のRLSポリシーが `auth.jwt()->>'tenant_id'` クレームを直接参照するため
-  （`is_tenant_member()` を使う他テーブルとは異なる）、通常の認証済みクライアントでは
-  INSERTがRLS違反になる。そのため本スクリプトは `SUPABASE_SERVICE_ROLE_KEY` が必要
-  （`seed_scenario.py` の `seed_admin_profile` と同じ bypass パターン。ローカル専用スクリプト
-  内での使用に限るため、アプリコード本体の「Service Role Key 禁止」ルールとは別枠）
 - `.env` に共通の環境変数（`SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `TEST_USER_EMAIL`,
-  `TEST_USER_PASS`, `TEST_TENANT_ID`）に加えて `SUPABASE_SERVICE_ROLE_KEY` を設定すること
+  `TEST_USER_PASS`, `TEST_TENANT_ID`）が設定されていること（`seed_scenario.py` と共通）
+- `order_attachments` のRLSポリシーは他テーブルと同じ `is_tenant_member(tenant_id)` に
+  統一済み（Issue #280 Phase3、`20260710000000_fix_order_attachments_rls_tenant_member.sql`）
+  のため、通常の認証済みクライアントのみで投入できる（service role key は不要）
 
 ### 使い方
 

--- a/backend/scripts/seed_split_demo.py
+++ b/backend/scripts/seed_split_demo.py
@@ -17,11 +17,6 @@ Usage:
 Required environment variables (.env): seed_scenario.py と共通
     SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, TEST_USER_EMAIL, TEST_USER_PASS,
     TEST_TENANT_ID
-    SUPABASE_SERVICE_ROLE_KEY — order_attachments のRLSポリシーが
-    auth.jwt()->>'tenant_id' クレーム（is_tenant_member() ではなく）を直接参照する
-    ため、通常の認証済みクライアントではINSERTがRLS違反になる。ローカル専用の
-    シードスクリプトのため service role で bypass する（アプリコード本体では
-    SUPABASE_SERVICE_ROLE_KEY 使用禁止、CLAUDE.md 参照）。
 """
 
 import os
@@ -30,8 +25,6 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 from seed_scenario import init_client  # noqa: E402 (認証済みクライアント取得を再利用)
-
-from supabase import create_client  # noqa: E402
 
 DEMO_GMAIL_MESSAGE_ID = "seed-split-demo-b115105"
 DEMO_PRODUCT_CODE = "B115105"
@@ -137,7 +130,6 @@ def ensure_staging_attachment(client, tenant_id: str, customer_id: int) -> str:
 
 def ensure_merged_order(
     client,
-    admin_client,
     tenant_id: str,
     product_id: int,
     customer_id: int,
@@ -185,13 +177,13 @@ def ensure_merged_order(
     # 実運用の _process_line_item と同じパターンで、注文自身に紐づく
     # order_attachments 行も複製しておく（添付ファイルパネルの表示確認用）
     real_attachment = (
-        admin_client.table("order_attachments")
+        client.table("order_attachments")
         .select("id")
         .eq("order_id", order_id)
         .execute()
     )
     if not real_attachment.data:
-        admin_client.table("order_attachments").insert(
+        client.table("order_attachments").insert(
             {
                 "tenant_id": tenant_id,
                 "order_id": order_id,
@@ -214,25 +206,17 @@ def main() -> None:
 
     client, tenant_id = init_client()
 
-    service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
-    if not service_role_key:
-        raise ValueError(
-            "SUPABASE_SERVICE_ROLE_KEY is required to seed order_attachments "
-            "(そのRLSポリシーは auth.jwt()->>'tenant_id' クレームを直接参照するため)"
-        )
-    admin_client = create_client(os.environ["SUPABASE_URL"], service_role_key)
-
     customer_id = ensure_customer(client, tenant_id)
     print(f"✓ Customer ready: {DEMO_CUSTOMER_NAME} (ID: {customer_id})")
 
     product_id = ensure_product(client, tenant_id)
     print(f"✓ Product ready: {DEMO_PRODUCT_CODE} (ID: {product_id})")
 
-    staging_id = ensure_staging_attachment(admin_client, tenant_id, customer_id)
+    staging_id = ensure_staging_attachment(client, tenant_id, customer_id)
     print(f"✓ Source staging row ready (order_attachments.id: {staging_id})")
 
     order_id = ensure_merged_order(
-        client, admin_client, tenant_id, product_id, customer_id, staging_id
+        client, tenant_id, product_id, customer_id, staging_id
     )
     print(f"✓ Merged draft order ready (orders.id: {order_id})")
 

--- a/backend/scripts/seed_split_demo.py
+++ b/backend/scripts/seed_split_demo.py
@@ -1,0 +1,249 @@
+"""
+手動分割機能（Issue #280 Phase3、POST /orders/{id}/split）を手元で確認するための
+デモデータ投入スクリプト。
+
+実際のメール受信 → 抽出パイプラインは通さず、1通のメールに複数月分の内示数量が
+誤って1件にマージされてしまった想定の draft 注文と、その起票元となる
+order_attachments のステージング行（source_attachment_id が参照する行）を
+直接投入する。フロントエンドの注文詳細ページ (/orders/{id}) を開くと
+「分割」ボタンが表示され、実際に分割APIを試せる。
+
+冪等性: 固定の gmail_message_id で検索し、既存があれば再利用・更新する
+（複数回実行しても重複しない）。
+
+Usage:
+    cd backend && python scripts/seed_split_demo.py
+
+Required environment variables (.env): seed_scenario.py と共通
+    SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, TEST_USER_EMAIL, TEST_USER_PASS,
+    TEST_TENANT_ID
+    SUPABASE_SERVICE_ROLE_KEY — order_attachments のRLSポリシーが
+    auth.jwt()->>'tenant_id' クレーム（is_tenant_member() ではなく）を直接参照する
+    ため、通常の認証済みクライアントではINSERTがRLS違反になる。ローカル専用の
+    シードスクリプトのため service role で bypass する（アプリコード本体では
+    SUPABASE_SERVICE_ROLE_KEY 使用禁止、CLAUDE.md 参照）。
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from seed_scenario import init_client  # noqa: E402 (認証済みクライアント取得を再利用)
+
+from supabase import create_client  # noqa: E402
+
+DEMO_GMAIL_MESSAGE_ID = "seed-split-demo-b115105"
+DEMO_PRODUCT_CODE = "B115105"
+DEMO_PRODUCT_NAME = "分割デモ部品B115105"
+DEMO_CUSTOMER_NAME = "分割デモ商事"
+
+# Issue #280 で報告された実例（部品番号B115105、6ヶ月分の内示が1レコードに
+# マージされてしまったケース）を模したメール本文
+DEMO_SOURCE_RAW = """件名: 内示のご連絡
+
+いつもお世話になっております。分割デモ商事です。
+下記の通り、部品番号 B115105 について今後6ヶ月分の内示数量をご連絡いたします。
+
+10月: 5,000個
+11月: 5,200個
+12月: 4,800個
+1月: 5,500個
+2月: 5,100個
+3月: 5,400個
+
+よろしくお願いいたします。
+"""
+
+# 6ヶ月分の合計（5000+5200+4800+5500+5100+5400）が1明細に誤ってマージされた想定
+MERGED_QUANTITY = 31000
+
+
+def ensure_customer(client, tenant_id: str) -> int:
+    existing = (
+        client.table("customers")
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("name", DEMO_CUSTOMER_NAME)
+        .execute()
+    )
+    if existing.data:
+        return int(existing.data[0]["id"])
+
+    created = (
+        client.table("customers")
+        .insert({"tenant_id": tenant_id, "name": DEMO_CUSTOMER_NAME})
+        .execute()
+    )
+    return int(created.data[0]["id"])
+
+
+def ensure_product(client, tenant_id: str) -> int:
+    response = (
+        client.table("products")
+        .upsert(
+            {
+                "tenant_id": tenant_id,
+                "code": DEMO_PRODUCT_CODE,
+                "name": DEMO_PRODUCT_NAME,
+                "type": "standard",
+            },
+            on_conflict="tenant_id, code",
+        )
+        .execute()
+    )
+    return int(response.data[0]["id"])
+
+
+def ensure_staging_attachment(client, tenant_id: str, customer_id: int) -> str:
+    """
+    order_attachments のステージング行（order_id IS NULL）を作成・更新する。
+    実運用では poll_unread_emails() がINSERTし、parse_pending_order_pdfs() が
+    処理完了後に parse_status='success' に更新する行に相当する。
+    """
+    existing = (
+        client.table("order_attachments")
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("gmail_message_id", DEMO_GMAIL_MESSAGE_ID)
+        .is_("order_id", "null")
+        .execute()
+    )
+    if existing.data:
+        staging_id = existing.data[0]["id"]
+        client.table("order_attachments").update(
+            {"customer_id": customer_id, "source_raw": DEMO_SOURCE_RAW}
+        ).eq("id", staging_id).execute()
+        return staging_id
+
+    created = (
+        client.table("order_attachments")
+        .insert(
+            {
+                "tenant_id": tenant_id,
+                "order_id": None,
+                "storage_path": "",
+                "original_filename": "",
+                "customer_id": customer_id,
+                "source_raw": DEMO_SOURCE_RAW,
+                "gmail_message_id": DEMO_GMAIL_MESSAGE_ID,
+                "parse_status": "success",
+            }
+        )
+        .execute()
+    )
+    return created.data[0]["id"]
+
+
+def ensure_merged_order(
+    client,
+    admin_client,
+    tenant_id: str,
+    product_id: int,
+    customer_id: int,
+    staging_id: str,
+) -> int:
+    existing = (
+        client.table("orders")
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("source_attachment_id", staging_id)
+        .execute()
+    )
+    if existing.data:
+        order_id = existing.data[0]["id"]
+        client.table("orders").update(
+            {
+                "status": "draft",
+                "product_id": product_id,
+                "customer_id": customer_id,
+                "quantity": MERGED_QUANTITY,
+            }
+        ).eq("id", order_id).execute()
+    else:
+        created = (
+            client.table("orders")
+            .insert(
+                {
+                    "tenant_id": tenant_id,
+                    "product_id": product_id,
+                    "customer_id": customer_id,
+                    "quantity": MERGED_QUANTITY,
+                    "deadline_date": "2026-10-01",
+                    "status": "draft",
+                    "source_type": "email",
+                    "customer_certainty": "forecast",
+                    "source_raw": DEMO_SOURCE_RAW,
+                    "extracted_product_name": DEMO_PRODUCT_NAME,
+                    "source_attachment_id": staging_id,
+                }
+            )
+            .execute()
+        )
+        order_id = created.data[0]["id"]
+
+    # 実運用の _process_line_item と同じパターンで、注文自身に紐づく
+    # order_attachments 行も複製しておく（添付ファイルパネルの表示確認用）
+    real_attachment = (
+        admin_client.table("order_attachments")
+        .select("id")
+        .eq("order_id", order_id)
+        .execute()
+    )
+    if not real_attachment.data:
+        admin_client.table("order_attachments").insert(
+            {
+                "tenant_id": tenant_id,
+                "order_id": order_id,
+                "storage_path": "",
+                "original_filename": "",
+                "customer_id": customer_id,
+                "source_raw": DEMO_SOURCE_RAW,
+                "gmail_message_id": DEMO_GMAIL_MESSAGE_ID,
+                "parse_status": "failed_no_attachment",
+            }
+        ).execute()
+
+    return order_id
+
+
+def main() -> None:
+    print("\n" + "=" * 60)
+    print("🚀 Seeding split-demo data (Issue #280 Phase3)")
+    print("=" * 60)
+
+    client, tenant_id = init_client()
+
+    service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    if not service_role_key:
+        raise ValueError(
+            "SUPABASE_SERVICE_ROLE_KEY is required to seed order_attachments "
+            "(そのRLSポリシーは auth.jwt()->>'tenant_id' クレームを直接参照するため)"
+        )
+    admin_client = create_client(os.environ["SUPABASE_URL"], service_role_key)
+
+    customer_id = ensure_customer(client, tenant_id)
+    print(f"✓ Customer ready: {DEMO_CUSTOMER_NAME} (ID: {customer_id})")
+
+    product_id = ensure_product(client, tenant_id)
+    print(f"✓ Product ready: {DEMO_PRODUCT_CODE} (ID: {product_id})")
+
+    staging_id = ensure_staging_attachment(admin_client, tenant_id, customer_id)
+    print(f"✓ Source staging row ready (order_attachments.id: {staging_id})")
+
+    order_id = ensure_merged_order(
+        client, admin_client, tenant_id, product_id, customer_id, staging_id
+    )
+    print(f"✓ Merged draft order ready (orders.id: {order_id})")
+
+    print(f"\n{'=' * 60}")
+    print(f"✅ Done! /orders/{order_id} を開いて「分割」ボタンを確認してください")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        sys.exit(1)

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -304,3 +304,4 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 | pg_trgm 製品名マッチング (`product_matching_service.py`) | ✅ 実装済み |
 | 顧客自動解決・作成 (`customer_matching_service.py`) | ✅ 実装済み |
 | `seed_scenario.py` の `order_number` 部分ユニークインデックス対応 | ✅ #286 |
+| 手動分割UI（`POST /orders/{id}/split`、詳細は[pdf-order-parsing.md](pdf-order-parsing.md)） | ✅ #280 |

--- a/docs/features/order-attachments.md
+++ b/docs/features/order-attachments.md
@@ -81,6 +81,15 @@ create policy "tenant isolation" on order_attachments
 ステージング行は `order_id=NULL` で作成され、後続Issue（PDFパース）が実際の `orders` 行を
 生成した時点で `order_id` を持つ行が別途 INSERT される想定。
 
+**RLSポリシー修正（Issue #280 Phase3）**: 上記の `auth.jwt() ->> 'tenant_id'` は
+実際には発行されないクレームであり、他の全テーブルが使う `is_tenant_member(tenant_id)`
+とは異なる方式だったため、通常のユーザーJWTクライアントでは SELECT/INSERT が常に
+RLS違反になっていた（`GET /orders/{id}/attachments` はこれを service role キーで
+回避していた）。`supabase/migrations/20260710000000_fix_order_attachments_rls_tenant_member.sql`
+でポリシーを `is_tenant_member(tenant_id)` に統一し、通常のユーザークライアントで
+扱えるように修正した。詳細は [pdf-order-parsing.md](pdf-order-parsing.md) の
+「手動分割UI（Issue #280 Phase3）」を参照。
+
 ### `parse_status` の定義
 
 | 値                       | 意味                            |

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -132,7 +132,8 @@ Issue #267 で `customer_certainty` カラムを新設して是正した。
   - 非PDF添付・添付なしメール由来: 専用のステージング行が存在しないため、その
     `orders` に紐づく `order_attachments` 行自身を自己参照的な「ソース」として設定
 - 手動分割UI（誤って1件にマージされた下書きから同じ `source_attachment_id` を
-  参照するN件の下書きを生成する機能）は本Issueのスコープ外とし、後続Issueで対応する
+  参照するN件の下書きを生成する機能）は `POST /orders/{order_id}/split` として実装済み。
+  詳細は本ファイル末尾の「手動分割UI（Issue #280 Phase3）」を参照
 
 ### 複数受注の疑いの検知（Issue #280）
 
@@ -376,6 +377,39 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
       通知される（Issue #280、粗いヒューリスティック）
 - [x] 添付ファイルは1ソースにつき1回のみStorageに保存される（非PDF添付・添付なし
       メールもPDF添付と同じステージング経路に統一、Issue #280）
+- [x] 手動分割UIにより、誤って1件にマージされた下書きから、同じ `source_attachment_id`
+      を参照するN件の下書きを生成できる（Issue #280 Phase3）
+
+### 手動分割UI（Issue #280 Phase3）
+
+自動抽出でも1明細に複数受注がマージされてしまうケース（`multi_order_suspected` の
+粗いヒューリスティックで検知しきれない場合を含む）に備え、ユーザーが手動で
+下書き注文をN件に分割できるUIを実装した。
+
+- `POST /orders/{order_id}/split`（`backend/app/routers/transaction/orders.py`）
+  - リクエスト: `{"line_items": [{"product_id", "quantity", "desired_deadline",
+    "customer_id"?, "customer_certainty"?, "extracted_product_name"?}, ...]}`
+    （`line_items` は2件以上必須）
+  - 分割対象の注文が `status='draft'` かつ `source_attachment_id` を持つ場合のみ許可
+    （手動作成 (`source_type='manual'`) の注文や確定済み注文は分割不可、400）
+  - 各明細ごとに新しい `orders` 行を作成し、`source_attachment_id` は元の注文と
+    同じ値を設定する。`customer_id`/`customer_certainty` は明細で指定が無ければ
+    元の注文の値を引き継ぐ
+  - 元の注文が参照していたソース（`order_attachments` の `source_attachment_id`
+    行）から `storage_path`/`original_filename`/`content_type`/`size_bytes` を
+    取得し、新しい注文それぞれに対して `order_attachments` 行を1件ずつ複製する
+    （`_process_line_item` と同じパターン。添付ファイル本体は複製しない）
+  - 元の注文は分割完了後に削除する（`order_attachments` は `ON DELETE CASCADE`
+    のため元の注文分の添付レコードも同時に削除される）
+  - `orders_dedupe_key` の一意制約違反等で作成が一部失敗した場合、その分割リクエスト
+    内で既に作成済みの注文をロールバック（削除）してから400エラーを返す
+- フロントエンド: 注文詳細ページ (`/orders/[id]`) に「分割」ボタンを追加
+  （`status='draft'` かつ `source_type='email'` かつ `source_attachment_id` あり
+  の場合のみ表示）。`SplitOrderDialog`
+  (`frontend/src/components/orders/split-order-dialog.tsx`) で明細を2件以上
+  入力し、送信すると分割後の一覧ページに遷移する
+- `useSplitOrder`（`frontend/src/hooks/use-orders.ts`）が上記APIを呼び出し、
+  成功時に注文一覧のキャッシュを無効化する
 
 ---
 

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -399,15 +399,26 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
     行）から `storage_path`/`original_filename`/`content_type`/`size_bytes` を
     取得し、新しい注文それぞれに対して `order_attachments` 行を1件ずつ複製する
     （`_process_line_item` と同じパターン。添付ファイル本体は複製しない）
-  - 元の注文は分割完了後に削除する（`order_attachments` は `ON DELETE CASCADE`
-    のため元の注文分の添付レコードも同時に削除される）
-  - `orders_dedupe_key` の一意制約違反等で作成が一部失敗した場合、その分割リクエスト
-    内で既に作成済みの注文をロールバック（削除）してから400エラーを返す
+  - **元の注文は新規INSERTより先に削除する**。分割後の明細が元の注文と同じ
+    `(customer_id, product_id, deadline_date)` を指定するケース（内容はそのまま
+    に品番だけ変えたい等）では、元の注文が残ったまま新規INSERTすると
+    `orders_dedupe_key` が自分自身と衝突してしまうため。作成が一部失敗した場合は
+    ロールバック（作成済み注文の削除 + 元の注文を同一内容で復元）した上で400を返す
+  - `order_attachments` のRLSポリシーは元々 `auth.jwt()->>'tenant_id'` クレームを
+    直接参照しており、`is_tenant_member(tenant_id)` を使う他の全テーブルと方式が
+    異なっていたため、通常のユーザーJWTクライアントでは常にRLS違反になっていた
+    （`GET /orders/{id}/attachments` は元々この問題を service role キーで回避して
+    いた）。`supabase/migrations/20260710000000_fix_order_attachments_rls_tenant_member.sql`
+    でポリシーを他テーブルと同じ `is_tenant_member(tenant_id)` に統一し、
+    通常のユーザークライアントで読み書きできるようにした（service role キーは
+    アプリコードで使わないという方針を維持するため、根本原因のポリシー自体を修正）
 - フロントエンド: 注文詳細ページ (`/orders/[id]`) に「分割」ボタンを追加
   （`status='draft'` かつ `source_type='email'` かつ `source_attachment_id` あり
   の場合のみ表示）。`SplitOrderDialog`
-  (`frontend/src/components/orders/split-order-dialog.tsx`) で明細を2件以上
-  入力し、送信すると分割後の一覧ページに遷移する
+  (`frontend/src/components/orders/split-order-dialog.tsx`) は左ペインに参照元
+  メール（件名・顧客・本文・添付ファイル一覧）、右ペインに明細フォーム（2件以上）
+  を表示する2ペインレイアウトで、分割単位を判断するのに必要な情報を見ながら
+  入力できる。送信すると分割後の一覧ページに遷移する
 - `useSplitOrder`（`frontend/src/hooks/use-orders.ts`）が上記APIを呼び出し、
   成功時に注文一覧のキャッシュを無効化する
 

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -398,12 +398,19 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
   - 元の注文が参照していたソース（`order_attachments` の `source_attachment_id`
     行）から `storage_path`/`original_filename`/`content_type`/`size_bytes` を
     取得し、新しい注文それぞれに対して `order_attachments` 行を1件ずつ複製する
-    （`_process_line_item` と同じパターン。添付ファイル本体は複製しない）
-  - **元の注文は新規INSERTより先に削除する**。分割後の明細が元の注文と同じ
-    `(customer_id, product_id, deadline_date)` を指定するケース（内容はそのまま
-    に品番だけ変えたい等）では、元の注文が残ったまま新規INSERTすると
-    `orders_dedupe_key` が自分自身と衝突してしまうため。作成が一部失敗した場合は
-    ロールバック（作成済み注文の削除 + 元の注文を同一内容で復元）した上で400を返す
+    （`_process_line_item` と同じパターン。添付ファイル本体は複製しない）。
+    このソース行が見つからない場合（レコード不整合等）は400を返す
+  - 分割後の明細が元の注文と同じ `(customer_id, product_id, deadline_date)` を
+    指定するケース（内容はそのままに品番だけ変えたい等）では、元の注文が
+    残ったまま新規INSERTすると `orders_dedupe_key` が自分自身と衝突してしまう。
+    これを避けるため、新規INSERTの前に元の注文の `deadline_date` を一時的に
+    `NULL` へ退避する（UNIQUE制約はNULL同士を等価とみなさないため衝突しなくなる）。
+    全明細の作成に成功した時点で初めて元の注文を実際に削除し、失敗時は
+    `deadline_date` を元に戻すだけで復元が完了する（`id` や紐づく
+    `order_attachments` 行を一度も削除しないため、削除→再作成のような
+    データ消失は起きない）
+  - `orders_dedupe_key` の一意制約違反等で作成が一部失敗した場合、その分割
+    リクエスト内で既に作成済みの注文をロールバック（削除）した上で400を返す
   - `order_attachments` のRLSポリシーは元々 `auth.jwt()->>'tenant_id'` クレームを
     直接参照しており、`is_tenant_member(tenant_id)` を使う他の全テーブルと方式が
     異なっていたため、通常のユーザーJWTクライアントでは常にRLS違反になっていた

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   Download,
   Paperclip,
   Pencil,
+  Split,
   Trash2,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -20,6 +21,7 @@ import { Badge } from "@/components/ui/badge"
 import { SimulationResult } from "@/components/simulation-result"
 import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
 import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
+import { SplitOrderDialog } from "@/components/orders/split-order-dialog"
 import {
   useOrder,
   useOrderAttachments,
@@ -57,6 +59,7 @@ export default function OrderDetailPage() {
   const [simulationResult, setSimulationResult] = useState<OrderSimulateResponse | null>(null)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isSplitDialogOpen, setIsSplitDialogOpen] = useState(false)
 
   const handleSimulate = async () => {
     try {
@@ -302,6 +305,15 @@ export default function OrderDetailPage() {
                 編集
               </Button>
             )}
+            {isDraft && order.source_type === "email" && order.source_attachment_id && (
+              <Button
+                variant="outline"
+                onClick={() => setIsSplitDialogOpen(true)}
+              >
+                <Split className="mr-2 h-4 w-4" />
+                分割
+              </Button>
+            )}
             {canDelete && (
               <Button
                 variant="destructive"
@@ -335,6 +347,13 @@ export default function OrderDetailPage() {
         isPending={deleteMutation.isPending}
         onConfirm={handleDelete}
         onOpenChange={(open) => { if (!open) setIsDeleteDialogOpen(false) }}
+      />
+
+      <SplitOrderDialog
+        order={isSplitDialogOpen ? order : null}
+        open={isSplitDialogOpen}
+        onOpenChange={setIsSplitDialogOpen}
+        onSplit={() => router.push("/orders")}
       />
     </div>
   )

--- a/frontend/src/components/orders/split-order-dialog.tsx
+++ b/frontend/src/components/orders/split-order-dialog.tsx
@@ -1,0 +1,212 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ProductSelector } from "@/components/product-selector"
+import { CustomerSelector } from "@/components/customer-selector"
+import { useSplitOrder } from "@/hooks/use-orders"
+import type { Order } from "@/types/order"
+
+interface SplitOrderDialogProps {
+  order: Order | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSplit?: () => void
+}
+
+interface SplitLineItemForm {
+  productId: string
+  customerId: string
+  quantity: string
+  desiredDeadline: string
+}
+
+function emptyLineItem(order: Order): SplitLineItemForm {
+  return {
+    productId: order.product_id?.toString() ?? "",
+    customerId: order.customer_id?.toString() ?? "",
+    quantity: "",
+    desiredDeadline: order.desired_deadline ? order.desired_deadline.slice(0, 10) : "",
+  }
+}
+
+export function SplitOrderDialog({
+  order,
+  open,
+  onOpenChange,
+  onSplit,
+}: SplitOrderDialogProps) {
+  const splitOrder = useSplitOrder()
+  const [items, setItems] = useState<SplitLineItemForm[]>([])
+  const [error, setError] = useState("")
+
+  // ダイアログを開いた時点の注文内容を初期値として2行を用意する
+  useEffect(() => {
+    if (open && order) {
+      setItems([emptyLineItem(order), emptyLineItem(order)])
+      setError("")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, order?.id])
+
+  if (!order) return null
+
+  const updateItem = (index: number, patch: Partial<SplitLineItemForm>) => {
+    setItems((prev) => prev.map((item, i) => (i === index ? { ...item, ...patch } : item)))
+  }
+
+  const addItem = () => setItems((prev) => [...prev, emptyLineItem(order)])
+
+  const removeItem = (index: number) => {
+    setItems((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleClose = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setItems([])
+      setError("")
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const handleSubmit = () => {
+    setError("")
+
+    if (items.length < 2) {
+      setError("分割後の明細は2件以上入力してください")
+      return
+    }
+
+    const lineItems = []
+    for (const item of items) {
+      const parsedProductId = parseInt(item.productId, 10)
+      const parsedQuantity = parseInt(item.quantity, 10)
+      if (!item.productId || isNaN(parsedProductId)) {
+        setError("すべての明細で製品を選択してください")
+        return
+      }
+      if (isNaN(parsedQuantity) || parsedQuantity <= 0) {
+        setError("すべての明細で数量を正しく入力してください")
+        return
+      }
+      if (!item.desiredDeadline) {
+        setError("すべての明細で希望納期を入力してください")
+        return
+      }
+      lineItems.push({
+        product_id: parsedProductId,
+        quantity: parsedQuantity,
+        desired_deadline: item.desiredDeadline,
+        customer_id: item.customerId ? parseInt(item.customerId, 10) : undefined,
+      })
+    }
+
+    splitOrder.mutate(
+      { id: order.id, data: { line_items: lineItems } },
+      {
+        onSuccess: () => {
+          toast.success(`注文を${lineItems.length}件に分割しました`)
+          handleClose(false)
+          onSplit?.()
+        },
+        onError: (err: Error) => {
+          setError(err.message || "分割に失敗しました")
+        },
+      }
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[640px] max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>注文の分割</DialogTitle>
+          <DialogDescription>
+            誤って1件にマージされた下書き注文を、複数の下書き注文に分割します。
+            分割後の各注文は、元の注文と同じメール／添付ファイルを参照します。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {items.map((item, index) => (
+            <div key={index} className="rounded-md border p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">明細 {index + 1}</span>
+                {items.length > 2 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeItem(index)}
+                    className="h-7 w-7 p-0 text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+
+              <ProductSelector
+                value={item.productId}
+                onValueChange={(value) => updateItem(index, { productId: value })}
+              />
+
+              <CustomerSelector
+                value={item.customerId}
+                onValueChange={(value) => updateItem(index, { customerId: value })}
+              />
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor={`split-quantity-${index}`}>数量 *</Label>
+                  <Input
+                    id={`split-quantity-${index}`}
+                    type="number"
+                    min={1}
+                    value={item.quantity}
+                    onChange={(e) => updateItem(index, { quantity: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor={`split-deadline-${index}`}>希望納期 *</Label>
+                  <Input
+                    id={`split-deadline-${index}`}
+                    type="date"
+                    value={item.desiredDeadline}
+                    onChange={(e) => updateItem(index, { desiredDeadline: e.target.value })}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <Button variant="outline" size="sm" onClick={addItem} className="w-full">
+            <Plus className="mr-2 h-4 w-4" />
+            明細を追加
+          </Button>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleClose(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleSubmit} disabled={splitOrder.isPending}>
+            {splitOrder.isPending ? "分割中..." : `${items.length}件に分割する`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/orders/split-order-dialog.tsx
+++ b/frontend/src/components/orders/split-order-dialog.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { Plus, Trash2 } from "lucide-react"
+import {
+  AlertTriangle,
+  Download,
+  Mail,
+  Paperclip,
+  Plus,
+  Trash2,
+} from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -16,8 +23,26 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { ProductSelector } from "@/components/product-selector"
 import { CustomerSelector } from "@/components/customer-selector"
-import { useSplitOrder } from "@/hooks/use-orders"
+import { useSplitOrder, useOrderAttachments } from "@/hooks/use-orders"
+import { useCustomers } from "@/hooks/use-customers"
+import { getCustomerName } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
+
+/**
+ * source_raw の先頭に含まれる「件名: ...」行を件名として切り出し、
+ * 残りを本文として返す。件名行が見つからない場合は全体を本文として扱う。
+ */
+function splitSubjectAndBody(sourceRaw?: string | null): {
+  subject?: string
+  body?: string
+} {
+  if (!sourceRaw) return {}
+  const match = sourceRaw.match(/^件名[:：]\s*(.*)$/m)
+  if (!match || match.index == null) return { body: sourceRaw }
+  const subject = match[1].trim()
+  const body = sourceRaw.slice(match.index + match[0].length).replace(/^\s+/, "")
+  return { subject: subject || undefined, body: body || undefined }
+}
 
 interface SplitOrderDialogProps {
   order: Order | null
@@ -51,6 +76,10 @@ export function SplitOrderDialog({
   const splitOrder = useSplitOrder()
   const [items, setItems] = useState<SplitLineItemForm[]>([])
   const [error, setError] = useState("")
+
+  const { data: attachments } = useOrderAttachments(order?.id ?? 0)
+  const { data: customers } = useCustomers()
+  const { subject, body } = splitSubjectAndBody(order?.source_raw)
 
   // ダイアログを開いた時点の注文内容を初期値として2行を用意する
   useEffect(() => {
@@ -130,8 +159,8 @@ export function SplitOrderDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[640px] max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[960px]">
+        <DialogHeader className="px-6 pb-4 pt-6">
           <DialogTitle>注文の分割</DialogTitle>
           <DialogDescription>
             誤って1件にマージされた下書き注文を、複数の下書き注文に分割します。
@@ -139,66 +168,151 @@ export function SplitOrderDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          {items.map((item, index) => (
-            <div key={index} className="rounded-md border p-4 space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">明細 {index + 1}</span>
-                {items.length > 2 && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => removeItem(index)}
-                    className="h-7 w-7 p-0 text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-
-              <ProductSelector
-                value={item.productId}
-                onValueChange={(value) => updateItem(index, { productId: value })}
-              />
-
-              <CustomerSelector
-                value={item.customerId}
-                onValueChange={(value) => updateItem(index, { customerId: value })}
-              />
-
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-2">
-                  <Label htmlFor={`split-quantity-${index}`}>数量 *</Label>
-                  <Input
-                    id={`split-quantity-${index}`}
-                    type="number"
-                    min={1}
-                    value={item.quantity}
-                    onChange={(e) => updateItem(index, { quantity: e.target.value })}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor={`split-deadline-${index}`}>希望納期 *</Label>
-                  <Input
-                    id={`split-deadline-${index}`}
-                    type="date"
-                    value={item.desiredDeadline}
-                    onChange={(e) => updateItem(index, { desiredDeadline: e.target.value })}
-                  />
-                </div>
-              </div>
+        <div className="flex min-h-0 flex-1 border-t">
+          {/* 左: 参照元メール（分割単位を判断するための情報） */}
+          <div className="w-[300px] shrink-0 space-y-4 overflow-y-auto border-r bg-muted/30 p-5">
+            <div className="flex items-center gap-1.5 text-sm font-medium">
+              <Mail className="h-4 w-4" />
+              参照元メール
             </div>
-          ))}
 
-          <Button variant="outline" size="sm" onClick={addItem} className="w-full">
-            <Plus className="mr-2 h-4 w-4" />
-            明細を追加
-          </Button>
+            {subject && (
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">件名</p>
+                <p className="text-sm font-medium break-words">{subject}</p>
+              </div>
+            )}
 
-          {error && <p className="text-sm text-destructive">{error}</p>}
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground">顧客</p>
+              <p className="text-sm font-medium">
+                {order.customer_id ? (
+                  getCustomerName(order.customer_id, customers)
+                ) : (
+                  <span className="text-muted-foreground">未設定</span>
+                )}
+              </p>
+            </div>
+
+            {body && (
+              <div className="rounded-md border bg-background p-3">
+                <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {body}
+                </pre>
+              </div>
+            )}
+
+            <div className="space-y-1.5 border-t pt-3">
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Paperclip className="h-3.5 w-3.5" />
+                添付ファイル
+              </p>
+              {attachments && attachments.length > 0 ? (
+                <ul className="space-y-1.5">
+                  {attachments.map((att) => (
+                    <li key={att.id} className="text-xs">
+                      {att.parse_status === "failed_no_attachment" ? (
+                        <span className="text-muted-foreground">添付ファイルなし</span>
+                      ) : att.parse_status === "failed_encrypted" ||
+                        att.parse_status === "failed_image" ? (
+                        <span className="flex items-center gap-1 text-amber-600">
+                          <AlertTriangle className="h-3 w-3 shrink-0" />
+                          自動読み取り不可
+                          {att.signed_url && (
+                            <a
+                              href={att.signed_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="ml-1 underline text-primary"
+                            >
+                              {att.original_filename}
+                            </a>
+                          )}
+                        </span>
+                      ) : (
+                        <a
+                          href={att.signed_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 text-primary underline"
+                        >
+                          <Download className="h-3 w-3 shrink-0" />
+                          {att.original_filename}
+                        </a>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-xs text-muted-foreground">添付ファイルなし</p>
+              )}
+            </div>
+          </div>
+
+          {/* 右: 分割フォーム */}
+          <div className="flex-1 space-y-4 overflow-y-auto p-5">
+            {items.map((item, index) => (
+              <div key={index} className="rounded-md border p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">明細 {index + 1}</span>
+                  {items.length > 2 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeItem(index)}
+                      className="h-7 w-7 p-0 text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+
+                <ProductSelector
+                  value={item.productId}
+                  onValueChange={(value) => updateItem(index, { productId: value })}
+                />
+
+                <CustomerSelector
+                  value={item.customerId}
+                  onValueChange={(value) => updateItem(index, { customerId: value })}
+                />
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-2">
+                    <Label htmlFor={`split-quantity-${index}`}>数量 *</Label>
+                    <Input
+                      id={`split-quantity-${index}`}
+                      type="number"
+                      min={1}
+                      value={item.quantity}
+                      onChange={(e) => updateItem(index, { quantity: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor={`split-deadline-${index}`}>希望納期 *</Label>
+                    <Input
+                      id={`split-deadline-${index}`}
+                      type="date"
+                      value={item.desiredDeadline}
+                      onChange={(e) =>
+                        updateItem(index, { desiredDeadline: e.target.value })
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            <Button variant="outline" size="sm" onClick={addItem} className="w-full">
+              <Plus className="mr-2 h-4 w-4" />
+              明細を追加
+            </Button>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="border-t px-6 py-4">
           <Button variant="outline" onClick={() => handleClose(false)}>
             キャンセル
           </Button>

--- a/frontend/src/hooks/use-orders.ts
+++ b/frontend/src/hooks/use-orders.ts
@@ -8,6 +8,8 @@ import type {
   OrderCreate,
   OrderSimulateRequest,
   OrderSimulateResponse,
+  OrderSplitRequest,
+  OrderSplitResponse,
 } from "@/types/order"
 
 // クエリキーを定数化
@@ -128,6 +130,24 @@ export function useOrderAttachments(orderId: number) {
     queryKey: ["orders", orderId, "attachments"],
     queryFn: () => apiClient<OrderAttachment[]>(`/orders/${orderId}/attachments`),
     enabled: !!orderId,
+  })
+}
+
+/**
+ * 誤って1件にマージされた下書き注文を、同じソースを参照するN件の下書きに分割するフック
+ */
+export function useSplitOrder() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: OrderSplitRequest }) =>
+      apiClient<OrderSplitResponse>(`/orders/${id}/split`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ORDERS_QUERY_KEY })
+    },
   })
 }
 

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -16,6 +16,7 @@ export interface Order {
   has_unconfirmed_routings?: boolean
   source_type: 'manual' | 'email'
   source_raw?: string
+  source_attachment_id?: string | null
   tenant_id: string
   created_at: string | null
   updated_at: string | null
@@ -71,6 +72,33 @@ export interface BulkSimulateResult {
   orderNo: string
   desiredDeadline?: string // ユーザー希望納期 (ISO 8601形式)
   result: OrderSimulateResponse | null // null = シミュレーション失敗
+}
+
+/**
+ * 注文分割時の1明細分のデータ型
+ */
+export interface OrderSplitLineItem {
+  product_id: number
+  quantity: number
+  desired_deadline: string
+  customer_id?: number
+  customer_certainty?: 'confirmed' | 'forecast' | 'forecast_tentative'
+  extracted_product_name?: string
+}
+
+/**
+ * 注文分割リクエストのデータ型
+ */
+export interface OrderSplitRequest {
+  line_items: OrderSplitLineItem[]
+}
+
+/**
+ * 注文分割結果のデータ型
+ */
+export interface OrderSplitResponse {
+  original_order_id: number
+  created_orders: Order[]
 }
 
 /**

--- a/supabase/migrations/20260710000000_fix_order_attachments_rls_tenant_member.sql
+++ b/supabase/migrations/20260710000000_fix_order_attachments_rls_tenant_member.sql
@@ -1,0 +1,20 @@
+-- order_attachments のRLSポリシー修正
+--
+-- 従来のポリシーは auth.jwt() ->> 'tenant_id' クレームを直接参照していたが、
+-- このクレームは実際には発行されておらず、他の全テーブルが使っている
+-- is_tenant_member(tenant_id)（organization_members テーブルでの所属確認）
+-- とは異なる方式だった。そのため通常のユーザーJWTクライアントでは
+-- order_attachments に対するSELECT/INSERTが常にRLS違反になり、
+-- POST /orders/{id}/split 実装時にサービスロールキーでの回避が
+-- 必要になっていた（本来はこのポリシー自体の不整合が原因）。
+--
+-- 他テーブルと同じ is_tenant_member(tenant_id) に統一し、通常の
+-- ユーザークライアントで order_attachments を扱えるようにする。
+
+drop policy "tenant isolation" on order_attachments;
+
+create policy "Tenant isolation for order_attachments"
+  on order_attachments
+  for all
+  using ( is_tenant_member(tenant_id) )
+  with check ( is_tenant_member(tenant_id) );


### PR DESCRIPTION
## Summary

Issue #280 のうち、PR #281 (Phase1+2) でスコープ外としていた「手動分割UI」を実装。
これで Issue #280 の受け入れ条件をすべて満たす。

- `POST /orders/{order_id}/split` を新設。誤って1件にマージされた下書き注文
  (`status='draft'` かつ `source_attachment_id` あり) を、同じ `source_attachment_id`
  を参照するN件の下書きに分割できる
  - 分割元が draft でない、または `source_attachment_id` が無い（手動作成の注文）場合は 400
  - 各明細ごとに新規 `orders` 行を作成し、`customer_id`/`customer_certainty` は明細指定が
    無ければ元の注文の値を引き継ぐ
  - 元の `source_attachment_id` が指すステージング行から `storage_path` 等を取得し、
    `order_attachments` 行を新規注文ごとに複製（添付ファイル本体は複製しない）
  - 一意制約違反等で途中失敗した場合は、そのリクエスト内で作成済みの注文をロールバックして 400
  - 元の注文は分割完了後に削除（`order_attachments` は `ON DELETE CASCADE` で追従）
- フロントエンド: 注文詳細ページ (`/orders/[id]`) に「分割」ボタンを追加し、
  `SplitOrderDialog` で2件以上の明細（製品・顧客・数量・希望納期）を入力して分割を実行できる
- `docs/features/pdf-order-parsing.md` / `email-order-intake.md` を更新

## Test plan

- [x] `pytest __tests__/unit __tests__/api` 全件パス
- [x] `ruff check` / `mypy`（pre-commit hook経由）パス
- [x] `npx tsc --noEmit` / `eslint`（frontend）パス
- [x] 分割APIの正常系・異常系（404/400/ロールバック）をユニットテストでカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)