### PR TITLE
fix(orders): 注文編集ダイアログの未保存値が再オープン時に残る不具合を修正

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -200,6 +200,9 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 
 エンドポイント: `PATCH /orders/{order_id}`（実装済み）
 
+**内部状態のリセット**
+`EditOrderDialog` は開くたびに `key={`${selectedOrder.id}-${editDialogGeneration}`}` で再マウントされる（`editDialogGeneration` はダイアログを開く操作のたびにインクリメント）。同一注文を「未保存でキャンセル→再オープン」した場合でも、DB上の値で初期化し直される (#277)。
+
 ---
 
 ## バックエンド追加事項

--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -201,7 +201,8 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 エンドポイント: `PATCH /orders/{order_id}`（実装済み）
 
 **内部状態のリセット**
-`EditOrderDialog` は開くたびに `key={`${selectedOrder.id}-${editDialogGeneration}`}` で再マウントされる（`editDialogGeneration` はダイアログを開く操作のたびにインクリメント）。同一注文を「未保存でキャンセル→再オープン」した場合でも、DB上の値で初期化し直される (#277)。
+`EditOrderDialog` は開くたびに `key` に `editDialogGeneration`（ダイアログを開く操作のたびにインクリメントするカウンタ）を含めて再マウントされる。同一注文を「未保存でキャンセル→再オープン」した場合でも、DB上の値で初期化し直される (#277)。
+一覧ページ (`orders/page.tsx`) は `key={`${selectedOrder.id}-${editDialogGeneration}`}`、注文詳細ページ (`orders/[id]/page.tsx`) は `key={editDialogGeneration}` を使用。
 
 ---
 

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -58,8 +58,14 @@ export default function OrderDetailPage() {
 
   const [simulationResult, setSimulationResult] = useState<OrderSimulateResponse | null>(null)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [editDialogGeneration, setEditDialogGeneration] = useState(0)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isSplitDialogOpen, setIsSplitDialogOpen] = useState(false)
+
+  const handleOpenEditDialog = () => {
+    setIsEditDialogOpen(true)
+    setEditDialogGeneration((prev) => prev + 1)
+  }
 
   const handleSimulate = async () => {
     try {
@@ -299,7 +305,7 @@ export default function OrderDetailPage() {
             {isDraft && (
               <Button
                 variant="outline"
-                onClick={() => setIsEditDialogOpen(true)}
+                onClick={handleOpenEditDialog}
               >
                 <Pencil className="mr-2 h-4 w-4" />
                 編集
@@ -337,6 +343,7 @@ export default function OrderDetailPage() {
       </div>
 
       <EditOrderDialog
+        key={editDialogGeneration}
         order={isEditDialogOpen ? order : null}
         open={isEditDialogOpen}
         onOpenChange={setIsEditDialogOpen}

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -42,6 +42,7 @@ export default function OrdersPage() {
     isEditDialogOpen,
     setIsEditDialogOpen,
     selectedOrder,
+    editDialogGeneration,
     deleteTargetOrder,
     setDeleteTargetOrder,
     expandedOrderId,
@@ -192,7 +193,7 @@ export default function OrdersPage() {
 
         {selectedOrder && (
           <EditOrderDialog
-            key={selectedOrder.id}
+            key={`${selectedOrder.id}-${editDialogGeneration}`}
             order={selectedOrder}
             open={isEditDialogOpen}
             onOpenChange={setIsEditDialogOpen}

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -36,6 +36,7 @@ export function useOrdersPage() {
 
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
+  const [editDialogGeneration, setEditDialogGeneration] = useState(0)
   const [deleteTargetOrder, setDeleteTargetOrder] = useState<Order | null>(null)
   const [expandedOrderId, setExpandedOrderId] = useState<number | null>(null)
   const [expandedSimResult, setExpandedSimResult] = useState<OrderSimulateResponse | null>(null)
@@ -157,6 +158,7 @@ export function useOrdersPage() {
   const handleOpenEditDialog = (order: Order) => {
     setSelectedOrder(order)
     setIsEditDialogOpen(true)
+    setEditDialogGeneration((prev) => prev + 1)
   }
 
   const handleConfirmDelete = () => {
@@ -317,6 +319,7 @@ export function useOrdersPage() {
     isEditDialogOpen,
     setIsEditDialogOpen,
     selectedOrder,
+    editDialogGeneration,
     deleteTargetOrder,
     setDeleteTargetOrder,
     expandedOrderId,


### PR DESCRIPTION
## Summary
- Closes #277
- `EditOrderDialog` は `key={selectedOrder.id}` のみで再マウントしていたため、同一注文を「未保存でキャンセル→再オープン」した際に、キャンセル前の未保存の入力値がそのまま残ってしまっていた
- ダイアログを開く操作 (`handleOpenEditDialog`) のたびにインクリメントする `editDialogGeneration` を導入し、`key` に含めることで、同一注文の再オープン時も確実に再マウント・状態リセットされるようにした
- `open` 状態自体を key に含める案は、ダイアログを閉じる瞬間にも即座に remount が走り Radix Dialog のクローズアニメーションが壊れるため採用せず、「開いた回数」をカウントする方式にした
- **追加修正**: レビュー中に発見した派生バグとして、注文詳細ページ (`orders/[id]/page.tsx`) の編集ダイアログでも同様の根本原因(keyなしで `order` propが変わってもuseStateが再初期化されない)により、「編集」ボタンを押してもフォームが空欄のまま表示される不具合があったため、同じ `editDialogGeneration` パターンで修正した(こちらは main でも再現する既存バグで、本PRのリファクタが原因ではないことを確認済み)

## Test plan
- [x] `npx tsc --noEmit` (frontend) が通ることを確認
- [x] `npx eslint` (変更ファイル) でエラーがないことを確認
- [x] Playwright で自動確認: 注文詳細ページで「編集」ボタンを押すと製品・顧客・数量が正しく表示されることを確認(修正前は空欄になることを確認済み)
- [x] ブラウザで以下を手動確認: 一覧ページの注文編集→数量変更→キャンセル→同じ注文を再度編集→DB上の値が表示されること
- [x] 異なる注文に切り替えた場合も従来通り正しくリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)