### PR TITLE
fix(orders): 希望納期・確定納期の日付/時刻・タイムゾーン処理を統一

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -204,6 +204,9 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 `EditOrderDialog` は開くたびに `key` に `editDialogGeneration`（ダイアログを開く操作のたびにインクリメントするカウンタ）を含めて再マウントされる。同一注文を「未保存でキャンセル→再オープン」した場合でも、DB上の値で初期化し直される (#277)。
 一覧ページ (`orders/page.tsx`) は `key={`${selectedOrder.id}-${editDialogGeneration}`}`、注文詳細ページ (`orders/[id]/page.tsx`) は `key={editDialogGeneration}` を使用。
 
+**希望納期・確定納期の日付/時刻の扱い (#293)**
+`desired_deadline`（DB上は `deadline_date`）・`confirmed_deadline` はいずれも「日付のみ」(`YYYY-MM-DD`) で、時刻情報を持たない。`new Date(dateStr)` でパースして `format` すると環境のタイムゾーンによって存在しない時刻が表示されてしまうため、`lib/order-utils.ts` の `formatDeadlineDate`（表示用、文字列の先頭10文字をそのまま整形）・`toDateInputValue`（`<input type="date">` バインド用）に処理を統一した。`EditOrderDialog` と新規注文作成ページの希望納期入力欄も `type="datetime-local"` から `type="date"` に変更している。なお、シミュレーション結果の `calculated_deadline` はスケジューラが計算した実際の日時（時刻を持つ）のため対象外。
+
 ---
 
 ## バックエンド追加事項
@@ -416,3 +419,4 @@ frontend/src/
 | シミュレーション結果での設備衝突警告 | 中 | ❌ 未実装 (#202) |
 | フィルタータブを orders.status のみに限定（情報不足・工程未確認タブ削除） | 中 | ❌ 未実装 (#215) |
 | 削除確認ダイアログの注文サマリー表示・削除トーストの簡略化 | 中 | ✅ 実装済 (#284) |
+| 希望納期・確定納期の日付/時刻表示の統一（タイムゾーンズレ修正） | 高 | ✅ 実装済 (#293) |

--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -205,7 +205,7 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 一覧ページ (`orders/page.tsx`) は `key={`${selectedOrder.id}-${editDialogGeneration}`}`、注文詳細ページ (`orders/[id]/page.tsx`) は `key={editDialogGeneration}` を使用。
 
 **希望納期・確定納期の日付/時刻の扱い (#293)**
-`desired_deadline`（DB上は `deadline_date`）・`confirmed_deadline` はいずれも「日付のみ」(`YYYY-MM-DD`) で、時刻情報を持たない。`new Date(dateStr)` でパースして `format` すると環境のタイムゾーンによって存在しない時刻が表示されてしまうため、`lib/order-utils.ts` の `formatDeadlineDate`（表示用、文字列の先頭10文字をそのまま整形）・`toDateInputValue`（`<input type="date">` バインド用）に処理を統一した。`EditOrderDialog` と新規注文作成ページの希望納期入力欄も `type="datetime-local"` から `type="date"` に変更している。なお、シミュレーション結果の `calculated_deadline` はスケジューラが計算した実際の日時（時刻を持つ）のため対象外。
+`desired_deadline`（DB上は `deadline_date`）・`confirmed_deadline` はいずれも「日付のみ」(`YYYY-MM-DD`) で、時刻情報を持たない。`new Date(dateStr)` でパースして `format` すると環境のタイムゾーンによって存在しない時刻が表示されてしまうため、`lib/order-utils.ts` の `formatDeadlineDate`（表示用、文字列の先頭10文字をそのまま整形）・`toDateInputValue`（`<input type="date">` バインド用）に処理を統一した。`EditOrderDialog` と新規注文作成ページの希望納期入力欄も `type="datetime-local"` から `type="date"` に変更している。`BulkSimulateSummaryDialog` の希望納期表示も同様に対応済み。なお、シミュレーション結果の `calculated_deadline` はスケジューラが計算した実際の日時（時刻を持つ）のため対象外。
 
 ---
 

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -3,8 +3,6 @@
 import { useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { toast } from "sonner"
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
 import {
   AlertTriangle,
   ArrowLeft,
@@ -38,6 +36,7 @@ import {
   getStatusBadgeClass,
   getCertaintyLabel,
   getCertaintyBadgeClass,
+  formatDeadlineDate,
 } from "@/lib/order-utils"
 import type { OrderSimulateResponse } from "@/types/order"
 import { ApiError } from "@/lib/api-client"
@@ -108,8 +107,7 @@ export default function OrderDetailPage() {
   }
 
   const formatDate = (dateStr?: string | null) => {
-    if (!dateStr) return <span className="text-muted-foreground">未設定</span>
-    return format(new Date(dateStr), "yyyy/MM/dd HH:mm", { locale: ja })
+    return formatDeadlineDate(dateStr) ?? <span className="text-muted-foreground">未設定</span>
   }
 
   if (isLoading) {

--- a/frontend/src/app/orders/new/page.tsx
+++ b/frontend/src/app/orders/new/page.tsx
@@ -25,7 +25,7 @@ import { ProductRoutingsDialog } from "@/components/product-routings-dialog"
 import { useSimulateOrder, useCreateOrder, useConfirmOrder } from "@/hooks/use-orders"
 import { useProducts } from "@/hooks/use-products"
 import { useCustomers } from "@/hooks/use-customers"
-import { getProductName, getCustomerName } from "@/lib/order-utils"
+import { getProductName, getCustomerName, formatDeadlineDate } from "@/lib/order-utils"
 import type { OrderSimulateResponse } from "@/types/order"
 import type { Product } from "@/types/product"
 
@@ -296,7 +296,7 @@ export default function NewOrderPage() {
                 <Label htmlFor="desired-deadline">希望納期（任意）</Label>
                 <Input
                   id="desired-deadline"
-                  type="datetime-local"
+                  type="date"
                   value={desiredDeadline}
                   onChange={(e) => setDesiredDeadline(e.target.value)}
                 />
@@ -362,9 +362,8 @@ export default function NewOrderPage() {
                   <div className="flex justify-between">
                     <dt className="text-muted-foreground">希望納期</dt>
                     <dd>
-                      {desiredDeadline
-                        ? format(new Date(desiredDeadline), "yyyy/MM/dd HH:mm", { locale: ja })
-                        : <span className="text-muted-foreground">未設定</span>}
+                      {formatDeadlineDate(desiredDeadline)
+                        ?? <span className="text-muted-foreground">未設定</span>}
                     </dd>
                   </div>
                   <div className="flex justify-between">

--- a/frontend/src/components/orders/bulk-simulate-confirm-dialog.tsx
+++ b/frontend/src/components/orders/bulk-simulate-confirm-dialog.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -18,7 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { getProductName } from "@/lib/order-utils"
+import { getProductName, formatDeadlineDate } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
 
@@ -64,9 +62,7 @@ export function BulkSimulateConfirmDialog({
                   <TableCell className="font-medium">{order.order_no}</TableCell>
                   <TableCell className="text-sm">{getProductName(order.product_id, products)}</TableCell>
                   <TableCell className="text-sm">
-                    {order.desired_deadline
-                      ? format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
-                      : "未設定"}
+                    {formatDeadlineDate(order.desired_deadline) ?? "未設定"}
                   </TableCell>
                 </TableRow>
               ))}

--- a/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
+++ b/frontend/src/components/orders/bulk-simulate-summary-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { formatDeadlineDate } from "@/lib/order-utils"
 import type { BulkSimulateResult } from "@/types/order"
 
 const PAGE_SIZE = 5
@@ -23,6 +24,7 @@ interface BulkSimulateSummaryDialogProps {
   onBulkConfirm?: (orderIds: number[]) => void
 }
 
+// 回答納期(calculated_deadline)はスケジューラが計算した実際の日時のため時刻付きで表示する
 function formatDate(iso: string) {
   return format(new Date(iso), "yyyy/MM/dd HH:mm", { locale: ja })
 }
@@ -107,7 +109,7 @@ export function BulkSimulateSummaryDialog({ results, onClose, onBulkConfirm }: B
                     <>
                       <p>
                         <span className="text-xs text-muted-foreground/70">希望　</span>
-                        {r.desiredDeadline ? formatDate(r.desiredDeadline) : "未設定"}
+                        {formatDeadlineDate(r.desiredDeadline) ?? "未設定"}
                       </p>
                       <p>
                         <span className="text-xs text-muted-foreground/70">回答　</span>

--- a/frontend/src/components/orders/delete-order-dialog.tsx
+++ b/frontend/src/components/orders/delete-order-dialog.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
 import { buttonVariants } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -13,7 +11,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { getProductName, getCustomerName } from "@/lib/order-utils"
+import { getProductName, getCustomerName, formatDeadlineDate } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
 import type { Customer } from "@/types/customer"
@@ -66,19 +64,11 @@ export function DeleteOrderDialog({
                   </div>
                   <div className="flex justify-between gap-4">
                     <span className="text-muted-foreground">希望納期</span>
-                    <span>
-                      {order.desired_deadline
-                        ? format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
-                        : "未設定"}
-                    </span>
+                    <span>{formatDeadlineDate(order.desired_deadline) ?? "未設定"}</span>
                   </div>
                   <div className="flex justify-between gap-4">
                     <span className="text-muted-foreground">確定納期</span>
-                    <span>
-                      {order.confirmed_deadline
-                        ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", { locale: ja })
-                        : "-"}
-                    </span>
+                    <span>{formatDeadlineDate(order.confirmed_deadline) ?? "-"}</span>
                   </div>
                 </div>
               )}

--- a/frontend/src/components/orders/edit-order-dialog.tsx
+++ b/frontend/src/components/orders/edit-order-dialog.tsx
@@ -16,6 +16,7 @@ import { Label } from "@/components/ui/label"
 import { ProductSelector } from "@/components/product-selector"
 import { CustomerSelector } from "@/components/customer-selector"
 import { useUpdateOrder } from "@/hooks/use-orders"
+import { toDateInputValue } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
 
 interface EditOrderDialogProps {
@@ -31,9 +32,7 @@ export function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogPr
   const [productId, setProductId] = useState(order?.product_id?.toString() ?? "")
   const [customerId, setCustomerId] = useState(order?.customer_id?.toString() ?? "")
   const [quantity, setQuantity] = useState(order?.quantity?.toString() ?? "")
-  const [desiredDeadline, setDesiredDeadline] = useState(
-    order?.desired_deadline ? order.desired_deadline.slice(0, 16) : ""
-  )
+  const [desiredDeadline, setDesiredDeadline] = useState(toDateInputValue(order?.desired_deadline))
   const [duplicateError, setDuplicateError] = useState("")
 
   if (!order) return null
@@ -129,7 +128,7 @@ export function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogPr
             <Label htmlFor="desired-deadline">希望納期</Label>
             <Input
               id="desired-deadline"
-              type="datetime-local"
+              type="date"
               value={desiredDeadline}
               onChange={(e) => setDesiredDeadline(e.target.value)}
             />

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -2,8 +2,6 @@
 
 import { AlertCircle, Loader2, Mail, MoreHorizontal } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { format } from "date-fns"
-import { ja } from "date-fns/locale"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -26,6 +24,7 @@ import {
   getStatusBadgeClass,
   getCertaintyLabel,
   getCertaintyBadgeClass,
+  formatDeadlineDate,
 } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
 import type { Product } from "@/types/product"
@@ -125,7 +124,7 @@ export function OrderTableRow({
         <TableCell className="text-right">{order.quantity}</TableCell>
         <TableCell>
           {order.desired_deadline ? (
-            format(new Date(order.desired_deadline), "yyyy/MM/dd HH:mm", { locale: ja })
+            formatDeadlineDate(order.desired_deadline)
           ) : (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -139,9 +138,7 @@ export function OrderTableRow({
           )}
         </TableCell>
         <TableCell>
-          {order.confirmed_deadline
-            ? format(new Date(order.confirmed_deadline), "yyyy/MM/dd", { locale: ja })
-            : "-"}
+          {formatDeadlineDate(order.confirmed_deadline) ?? "-"}
         </TableCell>
         <TableCell>
           <div className="flex flex-col items-start gap-1">

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -26,6 +26,24 @@ export function filterOrder(order: Order, statusFilter: StatusFilter): boolean {
   return true
 }
 
+/**
+ * 日付のみを表す文字列 (例: "2026-10-01" や "2026-10-01T00:00:00")
+ * をタイムゾーンの影響を受けずに "yyyy/MM/dd" 表示へ整形する。
+ * `new Date()` でパースすると環境のタイムゾーンによって日付がずれるため使用しない。
+ */
+export function formatDeadlineDate(dateStr: string | null | undefined): string | null {
+  if (!dateStr) return null
+  return dateStr.slice(0, 10).replace(/-/g, "/")
+}
+
+/**
+ * 日付のみを表す文字列を `<input type="date">` が要求する "YYYY-MM-DD" 形式に整形する。
+ */
+export function toDateInputValue(dateStr: string | null | undefined): string {
+  if (!dateStr) return ""
+  return dateStr.slice(0, 10)
+}
+
 export function compareOrders(a: Order, b: Order, sortKey: SortKey): number {
   if (sortKey === "created_at_desc" || sortKey === "created_at_asc") {
     if (!a.created_at && !b.created_at) return 0

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -7,8 +7,8 @@ export interface Order {
   product_id: number
   customer_id?: number
   quantity: number
-  desired_deadline?: string // ISO 8601形式
-  confirmed_deadline?: string // ISO 8601形式
+  desired_deadline?: string // 日付のみ (YYYY-MM-DD)、時刻情報は持たない
+  confirmed_deadline?: string // 日付のみ (YYYY-MM-DD)、時刻情報は持たない
   status: 'draft' | 'confirmed' | 'completed' | 'canceled'
   customer_certainty: 'confirmed' | 'forecast' | 'forecast_tentative' | null
   is_scheduled: boolean


### PR DESCRIPTION
## 概要
Closes #293

`orders.deadline_date`（API上は `desired_deadline`）・`confirmed_deadline` はいずれもDB上「日付のみ」(date型)だが、フロントエンドの複数箇所で `new Date(dateStr)` による時刻付きフォーマットや `type="datetime-local"` 入力として扱っていたため、以下の不具合が発生していた。

- 一覧・詳細・各種ダイアログで実際には存在しない時刻(例: 09:00)が表示される（`new Date("2026-10-01")` はUTC0時扱いのため、JST表示で+9時間される）
- `EditOrderDialog` の希望納期入力欄が、DB値を `datetime-local` が期待する形式に変換できず空欄になる

## 変更内容
- `frontend/src/lib/order-utils.ts` に日付専用の共通ユーティリティを追加
  - `formatDeadlineDate`: タイムゾーンの影響を受けない `yyyy/MM/dd` 表示用整形（文字列の先頭10文字をそのまま使用、`new Date()` を経由しない）
  - `toDateInputValue`: `<input type="date">` バインド用の `YYYY-MM-DD` 整形
- 表示箇所を上記ユーティリティに統一
  - `order-table-row.tsx`（一覧）
  - `orders/[id]/page.tsx`（詳細）
  - `bulk-simulate-confirm-dialog.tsx`
  - `delete-order-dialog.tsx`
  - `orders/new/page.tsx`（確定前サマリー）
- 入力欄を `type="datetime-local"` → `type="date"` に変更
  - `EditOrderDialog`
  - 新規注文作成ページ (`orders/new/page.tsx`)
- `types/order.ts` のコメントを実態（日付のみ）に合わせて修正

シミュレーション結果の `calculated_deadline`（スケジューラが計算した実時刻を持つ日時）は今回のスコープ外で、従来通り時刻付きで表示する。

バックエンド側は `deadline_date` を文字列としてそのまま透過しているだけで、`datetime-local` 形式・`date` 形式のいずれも許容していた（バリデーションなし）ため、コード変更は不要と確認した。

## テスト
- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd frontend && npm run lint`（既存の無関係なwarningのみ）
- [x] `cd backend && pytest __tests__/unit/ __tests__/api/`（全て成功）
- [x] 手動確認: 一覧・詳細・編集ダイアログ・削除確認・一括シミュレーション確認ダイアログ・新規注文作成の各画面で希望納期/確定納期が日付のみで正しく表示・編集できること