### PR TITLE
fix: 直接転送メールでヘッダー行が無くても顧客特定できるようにする (#298)

### DIFF
--- a/backend/__tests__/unit/services/test_customer_matching_service.py
+++ b/backend/__tests__/unit/services/test_customer_matching_service.py
@@ -2,7 +2,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from app.services.customer_matching_service import (
+    extract_body_email_candidates,
     extract_customer_name,
+    extract_effective_sender_email,
     extract_sender_email,
     extract_sender_email_candidates,
     resolve_or_create_customer,
@@ -58,6 +60,56 @@ class TestExtractSenderEmail:
             "Sent: ...\n"
         )
         assert extract_sender_email(body) == "original_sender@customer.example.com"
+
+
+@pytest.mark.unit
+class TestExtractBodyEmailCandidates:
+    # メーラーの転送機能を介さず直接転送された場合の本文例（Issue #298）。
+    # "From:"/"差出人:" ヘッダー行が存在しないため、署名欄のメールアドレスの
+    # みが手がかりになる。
+    _DIRECT_FORWARD_BODY = """\
+カブトギ工業
+兜木社長
+
+いつもお世話になっております。
+
+
+8月度(8/3分)の63Cの注文書を送付致します。
+ご対応の程お願い致します。
+
+---------------------------------------------------
+株式会社 飯野製作所
+購買課　　岡部宏美
+
+〒329-1574
+栃木県矢板市乙畑1855番地
+TEL：0287-48-2221
+FAX：0287-48-2223
+e-mail: hiromi_okabe@iinoseisakusho.co.jp<mailto:hiromi_okabe@iinoseisakusho.co.jp>
+---------------------------------------------------
+"""
+
+    def test_extracts_email_without_header_line(self):
+        assert extract_body_email_candidates(self._DIRECT_FORWARD_BODY) == [
+            "hiromi_okabe@iinoseisakusho.co.jp"
+        ]
+
+    def test_returns_empty_list_when_no_email_present(self):
+        assert extract_body_email_candidates("こんにちは、注文をお願いします。") == []
+
+
+@pytest.mark.unit
+class TestExtractEffectiveSenderEmail:
+    def test_prefers_header_email_when_present(self):
+        body = "From: taro@example.com\n本文\ncontact@signature.example.com\n"
+        assert extract_effective_sender_email(body) == "taro@example.com"
+
+    def test_falls_back_to_body_email_when_no_header(self):
+        body = "本文中に署名 contact@signature.example.com があるのみ"
+        assert extract_effective_sender_email(body) == "contact@signature.example.com"
+
+    def test_returns_none_when_no_email_anywhere(self):
+        assert extract_effective_sender_email("メールアドレスなし") is None
 
 
 @pytest.mark.unit
@@ -170,6 +222,47 @@ class TestResolveOrCreateCustomer:
         assert customer_id == 6
         assert created_draft is True
         inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["name"] == "株式会社 飯野製作所 岡部宏美"
+
+    def test_direct_forward_without_header_uses_body_signature_name_hint(self):
+        # Issue #298: 直接転送形式ではヘッダー行が本文化されないため、本文全体
+        # からのフォールバック抽出で署名ブロックの会社名を使えることを確認する。
+        mock_db = MagicMock()
+        mock_db.table().select().eq().in_().execute.return_value = MagicMock(data=[])
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[]
+        )
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 7}])
+        body = (
+            "カブトギ工業\n"
+            "兜木社長\n"
+            "\n"
+            "いつもお世話になっております。\n"
+            "\n"
+            "8月度(8/3分)の63Cの注文書を送付致します。\n"
+            "ご対応の程お願い致します。\n"
+            "\n"
+            "---------------------------------------------------\n"
+            "株式会社 飯野製作所\n"
+            "購買課　　岡部宏美\n"
+            "\n"
+            "〒329-1574\n"
+            "栃木県矢板市乙畑1855番地\n"
+            "TEL：0287-48-2221\n"
+            "FAX：0287-48-2223\n"
+            "e-mail: hiromi_okabe@iinoseisakusho.co.jp"
+            "<mailto:hiromi_okabe@iinoseisakusho.co.jp>\n"
+            "---------------------------------------------------\n"
+        )
+
+        customer_id, created_draft = resolve_or_create_customer(
+            mock_db, "tenant-1", body
+        )
+
+        assert customer_id == 7
+        assert created_draft is True
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["email"] == "hiromi_okabe@iinoseisakusho.co.jp"
         assert inserted_row["name"] == "株式会社 飯野製作所 岡部宏美"
 
     def test_ambiguous_candidate_intersection_falls_back_to_last_candidate(self):

--- a/backend/__tests__/unit/services/test_gmail_service.py
+++ b/backend/__tests__/unit/services/test_gmail_service.py
@@ -206,7 +206,7 @@ class TestProcessMessagePdfStaging:
                 ],
             ),
             patch(
-                "app.services.gmail_service.extract_sender_email",
+                "app.services.gmail_service.extract_effective_sender_email",
                 return_value="customer@example.com",
             ),
             patch(
@@ -262,7 +262,10 @@ class TestProcessMessagePdfStaging:
                     }
                 ],
             ),
-            patch("app.services.gmail_service.extract_sender_email", return_value=None),
+            patch(
+                "app.services.gmail_service.extract_effective_sender_email",
+                return_value=None,
+            ),
             patch(
                 "app.services.gmail_service.resolve_or_create_customer",
                 return_value=(7, True),
@@ -317,7 +320,7 @@ class TestProcessMessagePdfStaging:
                 return_value=[],
             ),
             patch(
-                "app.services.gmail_service.extract_sender_email",
+                "app.services.gmail_service.extract_effective_sender_email",
                 return_value="spam@example.com",
             ),
             patch(

--- a/backend/app/services/customer_matching_service.py
+++ b/backend/app/services/customer_matching_service.py
@@ -15,6 +15,13 @@ _FORWARDED_EMAIL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# メールアドレス全般にマッチする正規表現（ヘッダー行に依存しないフォールバック抽出用）。
+# 「直接転送」形式などヘッダー行自体が本文に残らない場合、署名欄のメールアドレスを
+# 直接検出する。
+_ANY_EMAIL_RE = re.compile(
+    r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+)
+
 # 日本のビジネスメール署名でよく使われる罫線区切り（"---" 等）
 _SIGNATURE_SEPARATOR_RE = re.compile(r"^[-=_ー―−‐]{5,}$")
 _COMPANY_KEYWORDS_RE = re.compile(r"(株式会社|有限会社|合同会社|合資会社|㈱|㈲)")
@@ -42,6 +49,35 @@ def extract_sender_email(body: str) -> str | None:
     # 候補が複数ある場合、一番奥（最初にメールを書いた本人）が実際の顧客であることが
     # 多いため、最後に出現したものを採用する。
     candidates = extract_sender_email_candidates(body)
+    return candidates[-1] if candidates else None
+
+
+def extract_body_email_candidates(body: str) -> list[str]:
+    """本文全体に出現するメールアドレスを出現順・重複排除で返す。
+
+    メーラーの「転送」機能を介さず直接転送された場合など、"From:"/"差出人:" と
+    いったヘッダー行自体が本文にテキスト化されないケースがある。その場合の
+    フォールバックとして、署名欄などに書かれたメールアドレスを直接検出する。
+    """
+    seen: set[str] = set()
+    candidates: list[str] = []
+    for m in _ANY_EMAIL_RE.finditer(body):
+        email = m.group(0)
+        if email not in seen:
+            seen.add(email)
+            candidates.append(email)
+    return candidates
+
+
+def extract_effective_sender_email(body: str) -> str | None:
+    """ヘッダー行から抽出を試み、見つからなければ本文全体から抽出する。
+
+    `resolve_or_create_customer` が実際に顧客特定に使う候補と同じ優先順位
+    （ヘッダー行 → 本文全体）で解決した結果を、通知payload等の表示用に返す。
+    """
+    candidates = extract_sender_email_candidates(body) or extract_body_email_candidates(
+        body
+    )
     return candidates[-1] if candidates else None
 
 
@@ -167,11 +203,15 @@ def resolve_or_create_customer(
       候補集合のうち「最後に出現したもの」1件に絞り込み、メールアドレス単体の
       検索/下書き作成にフォールバックする（0件の場合のみ署名ブロックから
       customer_name を抽出し、下書きのnameに使う）
+    - "From:"/"差出人:" ヘッダー行が本文に存在しない場合（直接転送等）は、
+      本文全体からメールアドレスを検出するフォールバックを使う
 
     Returns: (customer_id, 新規に下書き作成したかどうか)
     """
     table = SupabaseTableName.CUSTOMERS.value
     candidates = extract_sender_email_candidates(body)
+    if not candidates:
+        candidates = extract_body_email_candidates(body)
 
     if candidates:
         result = (

--- a/backend/app/services/gmail_service.py
+++ b/backend/app/services/gmail_service.py
@@ -9,7 +9,7 @@ from googleapiclient.discovery import build
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.services.attachment_service import upload_staged_attachment
 from app.services.customer_matching_service import (
-    extract_sender_email,
+    extract_effective_sender_email,
     resolve_or_create_customer,
 )
 from app.services.notification_service import create_notification
@@ -206,7 +206,7 @@ def _process_message(
         staged_attachment = pdf_attachment or (attachments[0] if attachments else None)
 
         # 5. 顧客マッチング（メールの受注可否に関わらず、ソース単位で1回解決する）
-        sender_email = extract_sender_email(body)
+        sender_email = extract_effective_sender_email(body)
         customer_id, created_draft = resolve_or_create_customer(
             db, tenant_id, body, msg.get("internalDate")
         )

--- a/docs/features/customer-draft-auto-create.md
+++ b/docs/features/customer-draft-auto-create.md
@@ -164,6 +164,53 @@ def resolve_or_create_customer(
 
 ---
 
+## ヘッダー行が本文化されない「直接転送」への対応（Issue #298）
+
+Issue #265 の前提「ユーザが intake 用 Gmail アドレスへ**転送する**」は、メーラーの転送機能
+（`Forward`）を使うことを想定しており、その場合 `From:`/`差出人:` ヘッダー行がテキストとして
+本文に残る。運用調整により、宛先を差し替えて直接転送する「直接転送」形式に変更したところ、
+このヘッダー行自体が本文に含まれなくなり、`extract_sender_email_candidates` が常に空集合を
+返すようになった。結果、署名ブロックからの会社名抽出（`extract_customer_name`）も一切起動
+されず、`不明な顧客 (YYYY-MM-DD HH:MM)` の下書きになってしまっていた。
+
+### 修正内容 (`customer_matching_service.py`)
+
+- `extract_body_email_candidates(body)` を追加。ヘッダー行の有無に関わらず、本文全体から
+  メールアドレス（`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`）を出現順・重複排除で
+  抽出する
+- `resolve_or_create_customer` は `extract_sender_email_candidates(body)`（ヘッダー行ベース）
+  が空集合の場合のみ、`extract_body_email_candidates(body)` にフォールバックする。以降の
+  積集合判定・`extract_customer_name` による署名ブロック抽出ロジックは変更なし（抽出元の
+  候補集合が変わるだけ）
+- `extract_effective_sender_email(body)` を追加し、`resolve_or_create_customer` と同じ優先順位
+  （ヘッダー行 → 本文全体）で解決したメールアドレスを返す。`gmail_service.py` の
+  `customer_draft_created` 通知payload用の `sender_email` はこちらに置き換えた
+  （従来の `extract_sender_email` はヘッダー行のみを見るため、直接転送メールでは常に `None`
+  になり通知内容が不正確だった）
+
+### 前提の更新
+
+- ヘッダー行（`From:`/`差出人:`）は「あれば優先して使う」候補源の一つに格下げし、
+  必須の前提ではなくなった。本文中に署名ブロック（罫線区切り＋会社名キーワード＋
+  メールアドレス）が含まれていれば、転送方式に関わらず顧客特定できる
+- 本文中に複数の署名ブロックが存在する場合（例: 転送元の担当者の署名＋実際の顧客の署名）は、
+  従来のヘッダー候補と同様「最後に出現したメールアドレス」を採用する。これは実例
+  （社内担当者宛の文面が先頭、顧客の署名ブロックが末尾）で正しく動作することを確認済みだが、
+  本文の構成によっては先頭のブロックが実際の顧客になるケースもありうるため、
+  誤マッチ時に手動修正できる下書き運用（本ドキュメント本体の仕組み）に引き続き依存する
+
+### 受け入れ条件
+
+- [x] `From:`/`差出人:` ヘッダー行が本文中に存在しない「直接転送」形式のメールでも、
+      署名ブロックから顧客名（会社名）を抽出できること
+- [x] 既存のヘッダーあり転送メールの挙動（Issue #265）が変わらないこと
+- [x] 既存のテストをパスし、新規ロジックのユニットテストを追加すること
+      (`__tests__/unit/services/test_customer_matching_service.py`,
+      `__tests__/unit/services/test_gmail_service.py`)
+- [x] 型・Lint エラーが出ていないこと
+
+---
+
 ## フロントエンド設計
 
 - `frontend/src/types/customer.ts`: `Customer.status: "active" | "draft"` を追加
@@ -222,3 +269,4 @@ def resolve_or_create_customer(
 - Issue #262: `customer_id=NULL` によるbigint型エラー（本Issueで新規発生分はほぼ解消見込み）
 - Issue #259, #168: 関連Issue
 - Issue #265: 転送メールの顧客メールアドレス/顧客名抽出が正しく行われない不具合の修正
+- Issue #298: 直接転送メールでヘッダー行が本文化されず顧客特定に失敗する不具合の修正


### PR DESCRIPTION
## Summary
- `From:`/`差出人:` ヘッダー行が本文化されない「直接転送」形式のメールでは、`extract_sender_email_candidates` が常に空集合を返し、署名ブロックからの会社名抽出（`extract_customer_name`）も一切起動されず「不明な顧客」の下書きが作成されていた問題を修正
- ヘッダー行ベースの候補が0件の場合のみ、本文全体からメールアドレスを検出する `extract_body_email_candidates` にフォールバックするようにした（既存のヘッダーあり転送メールの挙動・積集合判定ロジックは変更なし）
- 通知payload用に `extract_sender_email`（ヘッダー専用）を使っていた `gmail_service.py` を、同じ優先順位でフォールバックする `extract_effective_sender_email` に置き換え

## Test plan
- [x] `pytest backend/__tests__/unit/services/test_customer_matching_service.py` — Issueに記載の実例（カブトギ工業／株式会社 飯野製作所）を含む新規テストがパス
- [x] `pytest backend/__tests__/unit/services/test_gmail_service.py` — モック対象の関数名変更に追随
- [x] `pytest backend/__tests__/unit/ backend/__tests__/api/` — 既存の `test_scheduler.py` の1件のみ失敗（本PRと無関係、mainブランチでも同様に失敗することを確認済み）
- [x] `ruff check` / `ruff format` / `mypy` すべてパス（pre-commitフックで確認）
- [x] `docs/features/customer-draft-auto-create.md` を更新

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)