### PR TITLE
fix: test_schedule_respects_calendar_logic のflakyな時刻依存を解消する (#300)

### DIFF
--- a/backend/__tests__/unit/test_scheduler.py
+++ b/backend/__tests__/unit/test_scheduler.py
@@ -280,10 +280,22 @@ class TestScheduleOrder:
             {"equipment_id": 1}
         ]
 
-        # 設備の最終終了時刻を今日の 16:00 (JST) に設定
-        # 2時間の作業を開始すると18:00になるため、2つのスケジュールに分割されるべき
-        now = datetime.now(tz=JST)
-        mock_schedule_repo.get_last_end_time.return_value = now.replace(
+        # 設備の最終終了時刻を「平日の16:00 (JST)」に設定する。
+        # 2時間の作業を開始すると18:00になるため、2つのスケジュールに分割されるべき。
+        #
+        # 実行時刻の datetime.now(tz=JST) は使わず、固定の平日日付
+        # （2099-01-05は月曜日）を基準にする。理由は2つ:
+        # 1. schedule_order は start_time 省略時に datetime.now(JST)
+        #    （テスト実行時刻そのもの）にフォールバックする。get_last_end_time
+        #    （今日16:00固定）より後ろの時刻に実行されると
+        #    max(last_end, current_process_start) が current_process_start 側を
+        #    採用してしまい、実行タイミング次第で結果が変わっていた
+        # 2. デフォルトのカレンダー設定は土日を休日扱いするため、
+        #    「今日」が土日にあたるテスト実行日には last_end 自体が休日となり、
+        #    分割されずに翌営業日1件だけの結果になっていた
+        # 固定の平日日付・時刻を使うことで、いつテストを実行しても結果が変わらない。
+        base_date = datetime(2099, 1, 5, tzinfo=JST)  # 月曜日
+        mock_schedule_repo.get_last_end_time.return_value = base_date.replace(
             hour=16, minute=0, second=0, microsecond=0
         )
         mock_schedule_repo.create.return_value = None
@@ -296,6 +308,7 @@ class TestScheduleOrder:
             product_repo=mock_product_repo,
             schedule_repo=mock_schedule_repo,
             tenant_id="test-tenant-id",
+            start_time=base_date.replace(hour=8, minute=0, second=0, microsecond=0),
         )
 
         # 検証：2つのスケジュールに分割される


### PR DESCRIPTION
## Summary
- `test_schedule_respects_calendar_logic` が現在時刻（および実行日の曜日）に依存する flaky test だった問題を修正
- 原因は2つ:
  1. `schedule_order` の呼び出しで `start_time` を省略していたため、内部で `datetime.now(JST)`（テスト実行時刻そのもの）にフォールバックしていた。モックした `get_last_end_time`（今日16:00固定）よりテスト実行時刻が後だと `max(last_end, current_process_start)` が現在時刻側を採用し、想定と異なる結果になっていた
  2. デフォルトのカレンダー設定は土日を休日扱いするため、テスト実行日が土日にあたると `get_last_end_time` の「今日16:00」自体が休日になり、翌営業日1件のみの結果になっていた（実際にPR #299のCIはこのケース: 実行日が土曜日）
- 固定の平日日付（2099-01-05、月曜日）を基準にし、`start_time` も明示的に渡すことで、実行タイミングに関わらず常に同じ結果になるようにした

## Test plan
- [x] `pytest backend/__tests__/unit/test_scheduler.py` — 全件パス
- [x] `pytest backend/__tests__/unit/ backend/__tests__/api/` — 全件パス
- [x] `ruff check` / `ruff format` / `mypy` すべてパス（pre-commitフックで確認）

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)