### PR TITLE
fix: GET /notificationsのN+1解消でRenderインスタンス再起動を防ぐ

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_notifications.py
+++ b/backend/__tests__/api/routers/transaction/test_notifications.py
@@ -31,8 +31,11 @@ class TestNotificationsRouter:
 
     @pytest.fixture(autouse=True)
     def override_dependency(self):
-        yield
         app.dependency_overrides = {}
+        try:
+            yield
+        finally:
+            app.dependency_overrides = {}
 
     def test_get_notifications_resolves_link_urls_without_n_plus_one(self):
         notification_rows = [

--- a/backend/__tests__/api/routers/transaction/test_notifications.py
+++ b/backend/__tests__/api/routers/transaction/test_notifications.py
@@ -1,0 +1,147 @@
+# __tests__/api/routers/transaction/test_notifications.py
+from unittest.mock import MagicMock
+
+import pytest
+from app.dependencies import get_supabase_admin_client, get_supabase_client
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _query_mock(data):
+    """`.table(...).select(...).eq(...)...execute()` のチェーンをモックする"""
+    query = MagicMock()
+    query.select.return_value = query
+    query.eq.return_value = query
+    query.in_.return_value = query
+    query.order.return_value = query
+    query.limit.return_value = query
+    query.is_.return_value = query
+    query.update.return_value = query
+    query.execute.return_value = MagicMock(data=data)
+    return query
+
+
+@pytest.mark.api
+class TestNotificationsRouter:
+    """notificationsルーターのユニットテスト（N+1回避の確認を含む）"""
+
+    @pytest.fixture(autouse=True)
+    def override_dependency(self):
+        yield
+        app.dependency_overrides = {}
+
+    def test_get_notifications_resolves_link_urls_without_n_plus_one(self):
+        notification_rows = [
+            {
+                "id": "n1",
+                "tenant_id": TENANT_ID,
+                "notif_type": "no_product_match",
+                "source_table": "order_parse_log",
+                "source_id": "log-1",
+                "detail": None,
+                "read_at": None,
+                "created_at": "2026-07-22T00:00:00+00:00",
+            },
+            {
+                "id": "n2",
+                "tenant_id": TENANT_ID,
+                "notif_type": "attachment_added",
+                "source_table": "order_attachments",
+                "source_id": "att-2",
+                "detail": None,
+                "read_at": None,
+                "created_at": "2026-07-22T00:01:00+00:00",
+            },
+            {
+                "id": "n3",
+                "tenant_id": TENANT_ID,
+                "notif_type": "non_order_email",
+                "source_table": "gmail_message",
+                "source_id": "gmail-3",
+                "detail": None,
+                "read_at": None,
+                "created_at": "2026-07-22T00:02:00+00:00",
+            },
+            {
+                "id": "n4",
+                "tenant_id": TENANT_ID,
+                "notif_type": "no_product_match",
+                "source_table": "order_parse_log",
+                "source_id": None,
+                "detail": None,
+                "read_at": None,
+                "created_at": "2026-07-22T00:03:00+00:00",
+            },
+        ]
+
+        mock_client = MagicMock()
+        mock_client.table.return_value = _query_mock(notification_rows)
+
+        mock_admin_client = MagicMock()
+
+        def table_side_effect(table_name):
+            if table_name == "order_parse_log":
+                return _query_mock([{"id": "log-1", "order_attachment_id": "att-1"}])
+            if table_name == "order_attachments":
+                return _query_mock(
+                    [
+                        {"id": "att-1", "storage_path": "tenant/att-1.pdf"},
+                        {"id": "att-2", "storage_path": "tenant/att-2.pdf"},
+                    ]
+                )
+            raise AssertionError(f"unexpected table: {table_name}")
+
+        mock_admin_client.table.side_effect = table_side_effect
+        mock_admin_client.storage.from_.return_value.create_signed_urls.return_value = [
+            {
+                "path": "tenant/att-1.pdf",
+                "signedURL": "https://example.com/signed/att-1.pdf",
+                "error": None,
+            },
+            {
+                "path": "tenant/att-2.pdf",
+                "signedURL": "https://example.com/signed/att-2.pdf",
+                "error": None,
+            },
+        ]
+
+        app.dependency_overrides[get_supabase_client] = lambda: mock_client
+        app.dependency_overrides[get_supabase_admin_client] = lambda: mock_admin_client
+
+        response = client.get(
+            "/notifications",
+            headers={"Authorization": "Bearer dummy", "x-tenant-id": TENANT_ID},
+        )
+
+        assert response.status_code == 200
+        body = {row["id"]: row for row in response.json()}
+        assert body["n1"]["link_url"] == "https://example.com/signed/att-1.pdf"
+        assert body["n2"]["link_url"] == "https://example.com/signed/att-2.pdf"
+        assert body["n3"]["link_url"] == "https://mail.google.com/mail/u/0/#all/gmail-3"
+        assert body["n4"]["link_url"] is None
+
+        # order_parse_log / order_attachments への問い合わせが通知件数分ではなく
+        # 1回ずつ（バッチ）にまとまっていること（N+1回避の確認）
+        parse_log_calls = [
+            c
+            for c in mock_admin_client.table.call_args_list
+            if c.args[0] == "order_parse_log"
+        ]
+        attachment_calls = [
+            c
+            for c in mock_admin_client.table.call_args_list
+            if c.args[0] == "order_attachments"
+        ]
+        assert len(parse_log_calls) == 1
+        assert len(attachment_calls) == 1
+
+        # 署名付きURL生成もまとめて1回のバッチ呼び出しであること
+        mock_admin_client.storage.from_.return_value.create_signed_urls.assert_called_once()
+        called_paths = mock_admin_client.storage.from_.return_value.create_signed_urls.call_args.kwargs[
+            "paths"
+        ]
+        assert set(called_paths) == {"tenant/att-1.pdf", "tenant/att-2.pdf"}

--- a/backend/__tests__/integration/test_notifications_rls.py
+++ b/backend/__tests__/integration/test_notifications_rls.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 
 import pytest
 from app.main import app
-from app.routers.transaction.notifications import _resolve_link_url
+from app.routers.transaction.notifications import _resolve_link_urls
 from fastapi.testclient import TestClient
 from postgrest.exceptions import APIError
 
@@ -248,10 +248,23 @@ class TestNotificationsRls:
         assert row["read_at"] is None
 
 
+def _resolve_single(admin_db, tenant_id, notif_type, source_table, source_id):
+    """_resolve_link_urls（バッチ版）を単一通知向けに呼び出すテスト用ヘルパー"""
+    notif_id = "test-notif-id"
+    row = {
+        "id": notif_id,
+        "notif_type": notif_type,
+        "source_table": source_table,
+        "source_id": source_id,
+    }
+    return _resolve_link_urls(admin_db, tenant_id, [row]).get(notif_id)
+
+
 @pytest.mark.integration
 class TestResolveLinkUrlIdorFix:
     """
-    GET /notifications の `_resolve_link_url` (commit 868a45f) の回帰テスト。
+    GET /notifications の `_resolve_link_urls`（バッチ化前は `_resolve_link_url`、
+    commit 868a45f でIDOR修正）の回帰テスト。
     admin_client(Service Role Key, RLSバイパス) を使うため、notifications 行
     自身の tenant_id を必ず条件に含めないと、source_id 経由で他テナントの
     order_parse_log / order_attachments を参照できてしまう。
@@ -260,7 +273,7 @@ class TestResolveLinkUrlIdorFix:
     def test_order_attachments_source_in_other_tenant_resolves_to_none(
         self, admin_db, notif_tenants
     ):
-        link_url = _resolve_link_url(
+        link_url = _resolve_single(
             admin_db,
             notif_tenants["own_id"],
             "no_product_match",
@@ -272,7 +285,7 @@ class TestResolveLinkUrlIdorFix:
     def test_order_parse_log_source_in_other_tenant_resolves_to_none(
         self, admin_db, notif_tenants
     ):
-        link_url = _resolve_link_url(
+        link_url = _resolve_single(
             admin_db,
             notif_tenants["own_id"],
             "no_product_match",
@@ -287,16 +300,16 @@ class TestResolveLinkUrlIdorFix:
         """
         自テナントの場合は正しく storage_path が見つかり、署名付きURL生成まで
         到達すること。実際の署名付きURL生成（Storage側の可用性）はこのIDOR修正
-        とは無関係なので create_signed_url はスタブ化し、DBクエリ側の挙動
-        （tenant_id条件つきの照合が正しくヒットすること）だけを検証する。
+        とは無関係なので create_signed_urls（バッチ版）はスタブ化し、DBクエリ側の
+        挙動（tenant_id条件つきの照合が正しくヒットすること）だけを検証する。
         """
         monkeypatch.setattr(
-            "app.routers.transaction.notifications.create_signed_url",
-            lambda _client,
-            storage_path,
-            **_kwargs: f"https://signed.example/{storage_path}",
+            "app.routers.transaction.notifications.create_signed_urls",
+            lambda _client, storage_paths, **_kwargs: {
+                path: f"https://signed.example/{path}" for path in storage_paths
+            },
         )
-        link_url = _resolve_link_url(
+        link_url = _resolve_single(
             admin_db,
             notif_tenants["own_id"],
             "no_product_match",
@@ -308,7 +321,7 @@ class TestResolveLinkUrlIdorFix:
 
     def test_non_order_email_builds_gmail_link_without_query(self, admin_db):
         """non_order_email はDBを引かずsource_idからGmailリンクを直接組み立てる"""
-        link_url = _resolve_link_url(
+        link_url = _resolve_single(
             admin_db,
             "irrelevant-tenant-id",
             "non_order_email",

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -11,7 +11,7 @@ from app.dependencies import (
 )
 from app.models.transaction.notification_schema import NotificationResponse
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
-from app.services.attachment_service import create_signed_url
+from app.services.attachment_service import create_signed_urls
 from app.utils.logger import get_logger
 from supabase import Client
 
@@ -30,15 +30,103 @@ _PARSE_LOG_NOTIF_TYPES = {
 }
 
 
-def _resolve_link_url(
+def _fetch_parse_log_attachment_ids(
+    admin_client: Client, tenant_id: str, parse_log_ids: set[str]
+) -> dict[str, str]:
+    """order_parse_log.id -> order_attachment_id の対応をまとめて取得する。"""
+    if not parse_log_ids:
+        return {}
+    log_result = (
+        admin_client.table(SupabaseTableName.ORDER_PARSE_LOG.value)
+        .select("id, order_attachment_id")
+        .in_("id", list(parse_log_ids))
+        .eq("tenant_id", tenant_id)
+        .execute()
+    )
+    return {
+        log_row["id"]: log_row["order_attachment_id"]
+        for log_row in cast(list[dict[str, Any]], log_result.data or [])
+        if log_row.get("order_attachment_id")
+    }
+
+
+def _fetch_attachment_storage_paths(
+    admin_client: Client, tenant_id: str, attachment_ids: set[str]
+) -> dict[str, str]:
+    """order_attachments.id -> storage_path の対応をまとめて取得する。"""
+    if not attachment_ids:
+        return {}
+    attachment_result = (
+        admin_client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
+        .select("id, storage_path")
+        .in_("id", list(attachment_ids))
+        .eq("tenant_id", tenant_id)
+        .execute()
+    )
+    return {
+        att_row["id"]: att_row["storage_path"]
+        for att_row in cast(list[dict[str, Any]], attachment_result.data or [])
+        if att_row.get("storage_path")
+    }
+
+
+def _collect_parse_log_ids(
+    rows: list[dict[str, Any]], link_urls: dict[str, str | None]
+) -> set[str]:
+    """order_parse_log 経由で attachment_id を解決すべき通知の source_id を集める。
+    non_order_email はこの場でリンクを確定させ link_urls に書き込む。"""
+    parse_log_ids: set[str] = set()
+    for row in rows:
+        source_id = row.get("source_id")
+        if source_id is None:
+            continue
+        if row["notif_type"] == "non_order_email":
+            link_urls[row["id"]] = f"https://mail.google.com/mail/u/0/#all/{source_id}"
+        elif (
+            row["source_table"] == "order_parse_log"
+            and row["notif_type"] in _PARSE_LOG_NOTIF_TYPES
+        ):
+            parse_log_ids.add(source_id)
+    return parse_log_ids
+
+
+def _collect_row_attachment_ids(
+    rows: list[dict[str, Any]],
+    link_urls: dict[str, str | None],
+    parse_log_to_attachment: dict[str, str],
+) -> dict[str, str]:
+    """通知id -> attachment_id の対応を組み立てる（既にリンク確定済みの行は除外）。"""
+    row_attachment_id: dict[str, str] = {}
+    for row in rows:
+        if row["id"] in link_urls:
+            continue
+        source_id = row.get("source_id")
+        if source_id is None:
+            continue
+        attachment_id: str | None = None
+        if row["source_table"] == "order_attachments":
+            attachment_id = source_id
+        elif (
+            row["source_table"] == "order_parse_log"
+            and row["notif_type"] in _PARSE_LOG_NOTIF_TYPES
+        ):
+            attachment_id = parse_log_to_attachment.get(source_id)
+        if attachment_id is not None:
+            row_attachment_id[row["id"]] = attachment_id
+    return row_attachment_id
+
+
+def _resolve_link_urls(
     admin_client: Client,
     tenant_id: str,
-    notif_type: str,
-    source_table: str,
-    source_id: str | None,
-) -> str | None:
+    rows: list[dict[str, Any]],
+) -> dict[str, str | None]:
     """
-    通知の遷移先URLを解決する。取得できない場合は None。
+    通知一覧の遷移先URLをまとめて解決する。notification id をキーとした辞書を返す。
+
+    以前は通知1件ごとに order_parse_log / order_attachments への問い合わせと
+    署名付きURL生成APIを呼び出しており、通知件数に比例してレスポンスが遅延していた
+    （N+1）。ここではまとめて .in_() で取得し、署名付きURLもバッチ生成する。
 
     admin_client（Service Role Key、RLSバイパス）を使うため、参照先クエリには
     必ず notifications 行自身の tenant_id を条件に含める。source_id は notifications
@@ -46,48 +134,35 @@ def _resolve_link_url(
     order_attachments 行を参照でき、他テナントの添付ファイルの署名付きURLが
     生成できてしまう（IDOR）。
     """
-    if source_id is None:
-        return None
+    link_urls: dict[str, str | None] = {}
 
-    if notif_type == "non_order_email":
-        return f"https://mail.google.com/mail/u/0/#all/{source_id}"
-
-    attachment_id: str | None = None
-    if source_table == "order_attachments":
-        attachment_id = source_id
-    elif source_table == "order_parse_log" and notif_type in _PARSE_LOG_NOTIF_TYPES:
-        log_result = (
-            admin_client.table(SupabaseTableName.ORDER_PARSE_LOG.value)
-            .select("order_attachment_id")
-            .eq("id", source_id)
-            .eq("tenant_id", tenant_id)
-            .limit(1)
-            .execute()
-        )
-        log_rows = cast(list[dict[str, Any]], log_result.data or [])
-        attachment_id = log_rows[0]["order_attachment_id"] if log_rows else None
-
-    if attachment_id is None:
-        return None
-
-    attachment_result = (
-        admin_client.table(SupabaseTableName.ORDER_ATTACHMENTS.value)
-        .select("storage_path")
-        .eq("id", attachment_id)
-        .eq("tenant_id", tenant_id)
-        .limit(1)
-        .execute()
+    parse_log_ids = _collect_parse_log_ids(rows, link_urls)
+    parse_log_to_attachment = _fetch_parse_log_attachment_ids(
+        admin_client, tenant_id, parse_log_ids
     )
-    attachment_rows = cast(list[dict[str, Any]], attachment_result.data or [])
-    storage_path = attachment_rows[0].get("storage_path") if attachment_rows else None
-    if not storage_path:
-        return None
 
-    try:
-        return create_signed_url(admin_client, storage_path)
-    except Exception:
-        logger.warning(f"Failed to generate signed URL for {storage_path}")
-        return None
+    row_attachment_id = _collect_row_attachment_ids(
+        rows, link_urls, parse_log_to_attachment
+    )
+    attachment_to_storage_path = _fetch_attachment_storage_paths(
+        admin_client, tenant_id, set(row_attachment_id.values())
+    )
+
+    signed_url_map: dict[str, str] = {}
+    storage_paths = sorted(set(attachment_to_storage_path.values()))
+    if storage_paths:
+        try:
+            signed_url_map = create_signed_urls(admin_client, storage_paths)
+        except Exception:
+            logger.warning(
+                f"Failed to generate signed URLs for {len(storage_paths)} paths"
+            )
+
+    for notif_id, attachment_id in row_attachment_id.items():
+        storage_path = attachment_to_storage_path.get(attachment_id)
+        link_urls[notif_id] = signed_url_map.get(storage_path) if storage_path else None
+
+    return link_urls
 
 
 @notifications_router.get("", response_model=list[NotificationResponse])
@@ -112,6 +187,7 @@ def get_notifications(
         .execute()
     )
     rows = cast(list[dict[str, Any]], result.data or [])
+    link_urls = _resolve_link_urls(admin_client, tenant_id, rows)
     return [
         NotificationResponse(
             id=str(row["id"]),
@@ -121,13 +197,7 @@ def get_notifications(
             detail=row.get("detail"),
             read_at=row.get("read_at"),
             created_at=str(row["created_at"]),
-            link_url=_resolve_link_url(
-                admin_client,
-                row["tenant_id"],
-                row["notif_type"],
-                row["source_table"],
-                row.get("source_id"),
-            ),
+            link_url=link_urls.get(row["id"]),
         )
         for row in rows
     ]

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -55,3 +55,23 @@ def create_signed_url(
         expires_in=expires_in,
     )
     return str(response["signedURL"])
+
+
+def create_signed_urls(
+    admin_client: Client,
+    storage_paths: list[str],
+    expires_in: int = 3600,
+) -> dict[str, str]:
+    """複数ファイルの署名付きURLをまとめて生成する（N+1回避用）。
+    storage_path をキーとした辞書を返す。生成に失敗したパスは含まれない。"""
+    if not storage_paths:
+        return {}
+    responses = admin_client.storage.from_(_BUCKET).create_signed_urls(
+        paths=storage_paths,
+        expires_in=expires_in,
+    )
+    return {
+        response["path"]: response["signedURL"]
+        for response in responses
+        if response.get("path") and not response.get("error")
+    }

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -105,6 +105,23 @@ RLSの `is_tenant_member(tenant_id)` は所属する全テナントの行を許�
 `x-tenant-id` ヘッダーの tenant_id で明示的に絞り込む（`PATCH /notifications/read`
 と同じ絞り込みに揃えている）。
 
+#### `link_url` 解決のバッチ化（Issue #302）
+
+当初の実装は `link_url` を通知1件ごとに解決しており、`order_parse_log` /
+`order_attachments` への問い合わせと署名付きURL生成APIを通知件数分だけ同期的に
+呼び出すN+1になっていた（通知が多いテナントで `GET /notifications` が15〜30秒かかり、
+単一ワーカー構成のRenderインスタンスがヘルスチェック不応答で再起動する事象につながった）。
+
+`_resolve_link_urls()`（`notifications.py`）で以下のようにバッチ化した。
+
+1. `order_parse_log` を参照すべき通知の `source_id` を集約し `.in_()` で1回だけ取得
+2. `order_attachments` を参照すべき `attachment_id` を集約し `.in_()` で1回だけ取得
+3. 署名付きURLは `attachment_service.create_signed_urls()`（storage3の
+   `create_signed_urls` バッチAPI）で `storage_path` をまとめて1回だけ生成
+
+テナント絞り込み（IDOR対策）は個別解決版と同様、各バッチクエリに
+`.eq("tenant_id", tenant_id)` を必ず含めている。
+
 ---
 
 ## フロントエンド設計


### PR DESCRIPTION
## Summary
- `GET /notifications` の `link_url` 解決が通知1件ごとに `order_parse_log` / `order_attachments` への問い合わせと署名付きURL生成を同期的に繰り返すN+1になっており、通知件数分だけレスポンスが遅延していた（Renderログで15〜30秒/リクエストを確認）
- 単一ワーカー構成のためこの長時間リクエストがプロセスを占有し、ヘルスチェック不応答によるインスタンス再起動につながっていた
- `_resolve_link_urls()` として `.in_()` によるバッチ取得と `create_signed_urls()`（storage3のバッチAPI）によるバッチ署名に置き換え、問い合わせ回数を通知件数に依存しない定数回に削減

## Test plan
- [x] `backend/__tests__/api/routers/transaction/test_notifications.py` を新規追加し、`order_parse_log` / `order_attachments` への問い合わせおよび署名付きURL生成がそれぞれ1回にまとまっていること（N+1が発生しないこと）を検証
- [x] `pytest __tests__/unit/ __tests__/api/` 全件パス
- [x] `ruff check` / `mypy` エラーなし
- [x] `docs/features/notifications.md` を更新

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)