### PR TITLE
fix: PDF解析失敗時に下書き受注を起票し、不明な顧客名をJSTで表示する

### DIFF
--- a/backend/__tests__/unit/services/test_customer_matching_service.py
+++ b/backend/__tests__/unit/services/test_customer_matching_service.py
@@ -301,6 +301,20 @@ class TestResolveOrCreateCustomer:
         assert "email" not in inserted_row
         assert inserted_row["name"].startswith("不明な顧客 (")
 
+    def test_placeholder_name_uses_jst_not_utc(self):
+        """Gmail internalDate（UTC epoch millis）はJSTに変換した上で
+        プレースホルダー顧客名に埋め込むこと（表示がJSTのユーザー向けのため）。"""
+        mock_db = MagicMock()
+        mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 6}])
+
+        # 1751511600000ms = 2025-07-03 03:00 UTC = 2025-07-03 12:00 JST
+        resolve_or_create_customer(
+            mock_db, "tenant-1", "こんにちは、注文をお願いします。", "1751511600000"
+        )
+
+        inserted_row = mock_db.table().insert.call_args.args[0]
+        assert inserted_row["name"] == "不明な顧客 (2025-07-03 12:00)"
+
     def test_no_candidates_and_no_received_at_falls_back_to_now(self):
         mock_db = MagicMock()
         mock_db.table().insert().execute.return_value = MagicMock(data=[{"id": 4}])

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -34,10 +34,16 @@ class TestParsePendingOrderPdfs:
 
         assert result == {"processed": 0, "orders_created": 0, "errors": 0}
 
-    def test_encrypted_pdf_marks_failed_and_creates_no_order(self):
+    def test_encrypted_pdf_creates_draft_order_with_known_info_only(self):
+        """PDFが暗号化等で解析不能な場合でも、既知の情報（顧客等）だけで
+        product_id・quantity・deadline_dateがNULLの下書きorderを起票し、
+        ユーザーによる手動修正の起点とすること（Issue #304）。"""
         mock_db = MagicMock()
         mock_db.table().select().is_().eq().execute.return_value = MagicMock(
             data=[self._staging_row()]
+        )
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 99, "action": "inserted"}]
         )
 
         with (
@@ -58,15 +64,28 @@ class TestParsePendingOrderPdfs:
             result = parse_pending_order_pdfs(mock_db)
 
         mock_extract_lines.assert_not_called()
-        assert result == {"processed": 1, "orders_created": 0, "errors": 0}
+        assert result == {"processed": 1, "orders_created": 1, "errors": 0}
 
+        rpc_params = mock_db.rpc.call_args_list[-1].args[1]
+        assert rpc_params["p_product_id"] is None
+        assert rpc_params["p_quantity"] is None
+        assert rpc_params["p_deadline_date"] is None
+        assert rpc_params["p_customer_id"] == 7
+        assert rpc_params["p_source_attachment_id"] == "att-1"
+
+        # ステージング行自体はorder紐付け済みとして "success" にする
         update_calls = mock_db.table().update.call_args_list
-        assert any(
-            c.args[0] == {"parse_status": "failed_encrypted"} for c in update_calls
-        )
+        assert any(c.args[0] == {"parse_status": "success"} for c in update_calls)
+
+        # 新規order紐付け用のorder_attachments行には解析失敗理由を引き継ぐ
+        attachment_insert = mock_db.table("order_attachments").insert.call_args.args[0]
+        assert attachment_insert["order_id"] == 99
+        assert attachment_insert["parse_status"] == "failed_encrypted"
 
         insert_calls = mock_db.table().insert.call_args_list
-        assert any(c.args[0]["notif_type"] == "failed_encrypted" for c in insert_calls)
+        assert any(
+            c.args[0].get("notif_type") == "failed_encrypted" for c in insert_calls
+        )
 
     def test_pdf_with_no_order_lines_falls_back_to_body_extraction(self):
         """PDFの内容が注文と無関係で明細が0件の場合、メール本文から抽出した

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -87,6 +87,32 @@ class TestParsePendingOrderPdfs:
             c.args[0].get("notif_type") == "failed_encrypted" for c in insert_calls
         )
 
+    def test_missing_customer_id_is_treated_as_error_not_silent_null(self):
+        """resolve_or_create_customer は常に customer_id を解決するはずなので、
+        ステージング行に customer_id が無いのは不整合。customer_id=NULL の
+        受注を静かに作らず、エラーとしてカウントされること（PRレビュー指摘対応）。"""
+        mock_db = MagicMock()
+        mock_db.table().select().is_().eq().execute.return_value = MagicMock(
+            data=[self._staging_row(customer_id=None)]
+        )
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.download_attachment",
+                return_value=b"%PDF-fake",
+            ),
+            patch(
+                "app.services.pdf_order_parsing_service.extract_text",
+                return_value=PdfTextResult(
+                    text=None, failure_reason="failed_encrypted"
+                ),
+            ),
+        ):
+            result = parse_pending_order_pdfs(mock_db)
+
+        assert result == {"processed": 0, "orders_created": 0, "errors": 1}
+        mock_db.rpc.assert_not_called()
+
     def test_pdf_with_no_order_lines_falls_back_to_body_extraction(self):
         """PDFの内容が注文と無関係で明細が0件の場合、メール本文から抽出した
         line_itemsを使ってorderが作成されること（Issue #278/#280）。"""

--- a/backend/app/services/customer_matching_service.py
+++ b/backend/app/services/customer_matching_service.py
@@ -1,8 +1,9 @@
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.utils.calendar import JST
 from app.utils.logger import get_logger
 from supabase import Client
 
@@ -128,11 +129,15 @@ def extract_customer_name(body: str, email: str) -> str | None:
 
 
 def _placeholder_customer_name(received_at: str | int | None) -> str:
-    """メールの受信日時（Gmail internalDate、epoch millis）から仮の顧客名を組み立てる。"""
-    dt = datetime.now()
+    """メールの受信日時（Gmail internalDate、epoch millis）から仮の顧客名を組み立てる。
+
+    実行ホストのタイムゾーンに関わらず、表示はJST（日本のユーザー向け）で
+    統一するため、UTCとして解釈した上でJSTへ変換する。
+    """
+    dt = datetime.now(JST)
     if received_at is not None:
         try:
-            dt = datetime.fromtimestamp(int(received_at) / 1000)
+            dt = datetime.fromtimestamp(int(received_at) / 1000, tz=UTC).astimezone(JST)
         except (ValueError, TypeError, OSError):
             pass
     return f"不明な顧客 ({dt.strftime('%Y-%m-%d %H:%M')})"

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -161,6 +161,22 @@ def _process_email_body(db: Client, row: dict[str, Any]) -> int:
     return created_count
 
 
+def _require_customer_id(staging_row: dict[str, Any], attachment_id: str) -> int:
+    """
+    staging_row.customer_id を取得する。resolve_or_create_customer は必ず
+    customer_id を解決する（顧客未特定時も"不明な顧客"下書きを作成する）ため、
+    ここで欠落している場合はステージング行自体の不整合（想定外の経路での
+    直接INSERT等）であり、customer_id=NULL の受注を静かに作らず早期に検知する。
+    """
+    customer_id = staging_row.get("customer_id")
+    if customer_id is None:
+        raise ValueError(
+            f"staging row {attachment_id} has no customer_id; "
+            "resolve_or_create_customer should have set it"
+        )
+    return cast(int, customer_id)
+
+
 def _process_unreadable_pdf(
     db: Client, staging_row: dict[str, Any], failure_reason: str
 ) -> int:
@@ -174,12 +190,13 @@ def _process_unreadable_pdf(
     """
     tenant_id = staging_row["tenant_id"]
     attachment_id = staging_row["id"]
+    customer_id = _require_customer_id(staging_row, attachment_id)
 
     rpc_result = db.rpc(
         "upsert_order_by_dedupe_key",
         {
             "p_tenant_id": tenant_id,
-            "p_customer_id": staging_row.get("customer_id"),
+            "p_customer_id": customer_id,
             "p_product_id": None,
             "p_quantity": None,
             "p_deadline_date": None,
@@ -300,6 +317,7 @@ def _process_line_item(
     """
     tenant_id = staging_row["tenant_id"]
     attachment_id = staging_row["id"]
+    customer_id = _require_customer_id(staging_row, attachment_id)
     product_number_raw = line.get("product_number_raw")
     product_name_raw = line.get("product_name_raw")
 
@@ -363,7 +381,7 @@ def _process_line_item(
         "upsert_order_by_dedupe_key",
         {
             "p_tenant_id": tenant_id,
-            "p_customer_id": staging_row.get("customer_id"),
+            "p_customer_id": customer_id,
             "p_product_id": product_id,
             "p_quantity": quantity,
             "p_deadline_date": deadline_date,

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -86,22 +86,11 @@ def _parse_one(db: Client, row: dict[str, Any]) -> int:
         text_result = extract_text(content)
 
         if text_result.failure_reason is not None:
-            db.table(table).update({"parse_status": text_result.failure_reason}).eq(
+            created_count = _process_unreadable_pdf(db, row, text_result.failure_reason)
+            db.table(table).update({"parse_status": "success"}).eq(
                 "id", attachment_id
             ).execute()
-            create_notification(
-                db,
-                row["tenant_id"],
-                text_result.failure_reason,
-                SupabaseTableName.ORDER_ATTACHMENTS.value,
-                attachment_id,
-                {},
-            )
-            logger.info(
-                f"pdf_order_parsing: attachment {attachment_id} "
-                f"marked {text_result.failure_reason}"
-            )
-            return 0
+            return created_count
 
         line_items = extract_order_lines(cast(str, text_result.text))
         logger.info(
@@ -170,6 +159,78 @@ def _process_email_body(db: Client, row: dict[str, Any]) -> int:
         f"created {created_count} orders"
     )
     return created_count
+
+
+def _process_unreadable_pdf(
+    db: Client, staging_row: dict[str, Any], failure_reason: str
+) -> int:
+    """
+    PDFのテキストが抽出できず明細抽出自体を行えない場合でも、判明している情報
+    （顧客等。顧客未特定時は"不明な顧客"下書きに解決済み）だけで product_id・
+    quantity・deadline_date が NULL の下書き order を1件起票し、ユーザーが手動で
+    内容を補完する起点とする。product_id・deadline_date が共に NULL の行は
+    upsert_order_by_dedupe_key が常に新規行としてINSERTするため、他の解析失敗
+    ケースと誤って統合されることはない。
+    """
+    tenant_id = staging_row["tenant_id"]
+    attachment_id = staging_row["id"]
+
+    rpc_result = db.rpc(
+        "upsert_order_by_dedupe_key",
+        {
+            "p_tenant_id": tenant_id,
+            "p_customer_id": staging_row.get("customer_id"),
+            "p_product_id": None,
+            "p_quantity": None,
+            "p_deadline_date": None,
+            "p_customer_certainty": "forecast_tentative",
+            "p_source_type": "email",
+            "p_source_raw": staging_row.get("source_raw"),
+            "p_extracted_product_name": None,
+            "p_source_attachment_id": attachment_id,
+        },
+    ).execute()
+    rpc_rows = cast(list[dict[str, Any]], rpc_result.data or [])
+    action = rpc_rows[0]["action"] if rpc_rows else None
+
+    if action not in _KNOWN_UPSERT_ACTIONS:
+        raise RuntimeError(
+            f"upsert_order_by_dedupe_key returned unexpected result "
+            f"for attachment {attachment_id}: rows={rpc_rows}"
+        )
+
+    log_id = _log_parse_event(db, tenant_id, attachment_id, failure_reason, {})
+    create_notification(
+        db,
+        tenant_id,
+        failure_reason,
+        SupabaseTableName.ORDER_PARSE_LOG.value,
+        log_id,
+        {},
+    )
+
+    if action != "inserted":
+        # NULL/NULLの下書きは常に新規挿入される想定だが、念のため他アクションが
+        # 返った場合は order を紐付けずログ・通知のみで終える。
+        return 0
+
+    order_id = rpc_rows[0]["order_id"]
+    db.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
+        {
+            "order_id": order_id,
+            "tenant_id": tenant_id,
+            "storage_path": staging_row.get("storage_path", ""),
+            "original_filename": staging_row.get("original_filename", ""),
+            "content_type": staging_row.get("content_type"),
+            "size_bytes": staging_row.get("size_bytes"),
+            "parse_status": failure_reason,
+        }
+    ).execute()
+    logger.info(
+        f"pdf_order_parsing: order {order_id} inserted as draft from "
+        f"unreadable attachment {attachment_id} ({failure_reason})"
+    )
+    return 1
 
 
 def _check_multi_order_suspected(

--- a/docs/features/customer-draft-auto-create.md
+++ b/docs/features/customer-draft-auto-create.md
@@ -60,8 +60,11 @@ def resolve_or_create_customer(
 - `email` があり新規作成する場合: `status='draft'` で作成する
 - `email` が無い場合: 常に新規の下書き顧客を作成する。`name` は
   `不明な顧客 (YYYY-MM-DD HH:MM)` 形式のプレースホルダーとし、`received_at`
-  （Gmailメッセージの `internalDate`、epoch millis）から算出する。取得できない・不正な値の場合は
-  処理実行時刻にフォールバックする
+  （Gmailメッセージの `internalDate`、epoch millis、UTC）から算出する。取得できない・不正な値の場合は
+  処理実行時刻にフォールバックする。実行ホストのタイムゾーンに関わらず表示はJSTで統一するため、
+  `received_at` はUTCとして解釈した上で `app.utils.calendar.JST` へ変換する
+  （変換前はUTCのままフォーマットしてしまい、日本のユーザーから見て9時間ずれて表示される
+  不具合があった）
 
 ### 呼び出し元 `gmail_service.py` の修正
 

--- a/docs/features/order-attachments.md
+++ b/docs/features/order-attachments.md
@@ -105,6 +105,11 @@ RLS違反になっていた（`GET /orders/{id}/attachments` はこれを servic
 `notifications` は横断的な「担当者への通知」専用の薄いテーブルとして別途書き込まれる
 （詳細は [notifications.md](notifications.md) 参照）。
 
+`failed_encrypted` / `failed_image` は Issue #304 より、判明している情報だけの下書き
+`orders` 行にも紐づけられるようになった（`order_id` が設定された `order_attachments` 行が
+追加作成される）。詳細は [pdf-order-parsing.md](pdf-order-parsing.md) の
+「PDF自体が読めない場合の下書き起票（Issue #304）」を参照。
+
 ---
 
 ## バックエンド処理フロー

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -37,8 +37,11 @@ Issue #267 で `customer_certainty` カラムを新設して是正した。
 ```
 1. order_attachments WHERE parse_status='pending' AND order_id IS NULL をポーリング
 2. Storage から PDF をダウンロードし、pdfplumber でテキスト抽出 (pdf_text_service.py)
-   - パスワード保護 (PPAP等) で開けない → parse_status='failed_encrypted'、orderは生成しない
-   - テキストが1文字も取れない (画像PDF等) → parse_status='failed_image'、orderは生成しない
+   - パスワード保護 (PPAP等) で開けない → `product_id`/`quantity`/`deadline_date` が
+     すべて `NULL` の下書き order を1件起票し、対応する `order_attachments` 行の
+     `parse_status='failed_encrypted'` とする（Issue #304、詳細後述）
+   - テキストが1文字も取れない (画像PDF等) → 同様に下書き order を1件起票し
+     `parse_status='failed_image'` とする（Issue #304）
 3. 抽出成功時、Claude tool-use (pdf_order_extraction_service.py) で明細行の配列を取得
    { product_name_raw, product_number_raw, quantity, delivery_date, certainty }
 4. 明細ごとに (pdf_order_parsing_service._process_line_item):
@@ -228,6 +231,32 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
 - `product_id=NULL` の明細に対して `_mark_superseded_orders`（旧内示レコードの
   無効化）は呼ばない。どの製品の内示を無効化すべきか判断できないため
 
+### PDF自体が読めない場合の下書き起票（Issue #304）
+
+暗号化PDF・画像PDF等でテキスト抽出自体に失敗した場合、以前は `order_attachments` の
+`parse_status` を更新し通知するだけで `orders` 行を一切作成せず処理を打ち切っていた。
+ユーザーが内容を確認・手動修正する起点が無くなってしまうため、Issue #296（製品未マッチ
+時の `product_id=NULL` 下書き起票）と同じ設計方針をテキスト抽出失敗ケースにも適用した。
+
+- `pdf_order_parsing_service._process_unreadable_pdf()` が、`product_id`・`quantity`・
+  `deadline_date` をすべて `NULL`、`customer_certainty='forecast_tentative'` として
+  `upsert_order_by_dedupe_key` RPCを呼び、下書き order を1件起票する
+- `customer_id` はステージング行作成時（`gmail_service.py` → `resolve_or_create_customer`）
+  に既に解決済みの値をそのまま使う。送信元メールアドレスから顧客を特定できない場合も
+  「不明な顧客 (YYYY-MM-DD HH:MM)」のプレースホルダー顧客が自動作成されているため、
+  `customer_id` が `NULL` になることはない（[customer-draft-auto-create.md](customer-draft-auto-create.md)）
+- `product_id` と `deadline_date` が共に `NULL` の場合、`upsert_order_by_dedupe_key` は
+  重複判定に使える情報が無いため常に新規行としてINSERTする（Issue #296で追加された分岐、
+  `20260712000000_add_orders_dedupe_key_unmatched_product.sql`）。そのため複数の
+  解析失敗PDFが同一顧客から届いても、既存の下書きと誤って統合されることはない
+- 生成した order に対応する `order_attachments` 行（`order_id` 設定済み）を追加INSERTし、
+  `parse_status` にはテキスト抽出失敗理由（`failed_encrypted`/`failed_image`）をそのまま
+  引き継ぐ。ステージング行自体（`order_id IS NULL` の元の行）は処理完了として
+  `parse_status='success'` に更新する（Claude抽出まで到達したかどうかに関わらず、
+  パース処理自体は正常完了とみなす既存方針を踏襲）
+- `order_parse_log`・`notifications` への記録は従来どおり行う（`reason`/`notif_type` に
+  `failed_encrypted`/`failed_image` を使用。新しい値の追加やCHECK制約変更は不要）
+
 #### 重複起票防止（dedupe）のNULL product_id対応
 
 `orders_dedupe_key`（`product_id` を含む）はNULLの非等価性により機能しないため、
@@ -396,6 +425,13 @@ Issue #296 での変更（製品未マッチ明細のNULL product_id下書き起
 - 注文一覧・削除確認・一括シミュレーション確認ダイアログの `getProductName`
   呼び出しに `extracted_product_name` を渡すよう更新
 
+Issue #304 での変更（PDF解析失敗時の下書き起票）:
+
+- `backend/app/services/pdf_order_parsing_service.py`: テキスト抽出失敗時に
+  `order_attachments.parse_status` 更新・通知のみで打ち切っていた分岐を、
+  `_process_unreadable_pdf()` による下書き order 起票に変更。
+  `_parse_one()` は失敗時も最終的にステージング行を `parse_status='success'` に更新する
+
 ---
 
 ## 環境変数
@@ -423,7 +459,9 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
       に正しくセットされる。`orders.status` は常に `draft` で作成される（Issue #267）
 - [x] 品番・品名の照合失敗時も `order_parse_log` に記録した上で
       `product_id=NULL` の下書きが起票され、明細がドロップされない（Issue #296）
-- [x] 暗号化PDF・画像PDF（テキスト抽出不可）でもクラッシュせず `parse_status` が適切に更新される
+- [x] 暗号化PDF・画像PDF（テキスト抽出不可）でもクラッシュせず、判明している情報
+      （顧客等）だけで下書き order が1件起票され、対応する `order_attachments` 行の
+      `parse_status` に失敗理由が引き継がれる（Issue #304）
 - [x] 重複明細（UNIQUE制約抵触）はスキップされ `order_parse_log` に記録される
 - [x] 生成された各orderから、対応する添付PDFが注文詳細画面からダウンロードできる
       （既存の `/orders/{order_id}/attachments` エンドポイントを変更なしで再利用）
@@ -461,6 +499,9 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
 - [x] `product_id=NULL` の明細について、同一
       `(tenant_id, customer_id, deadline_date, extracted_product_name)` の内容が
       再度パースされても重複下書きが増殖しない（Issue #296）
+- [x] 暗号化PDF・画像PDFで解析自体に失敗した場合も、顧客IDのみで
+      `product_id`/`quantity`/`deadline_date` が `NULL` の下書き order が起票される
+      （Issue #304）
 
 ### 手動分割UI（Issue #280 Phase3）
 


### PR DESCRIPTION
## Summary
- 暗号化PDF・画像PDF等でテキスト抽出に失敗した場合、従来は通知のみで `orders` 行が一切作成されず処理を打ち切っていたが、判明している情報（顧客等）だけで `product_id`/`quantity`/`deadline_date` が `NULL` の下書き受注を1件起票するように変更（Issue #296と同じ「always create, never drop」方針をテキスト抽出失敗ケースにも適用）
- 起票した下書きに対応する `order_attachments` 行を追加し、解析失敗理由（`failed_encrypted`/`failed_image`）を引き継ぐことで、ユーザーが添付PDFを確認しながら手動修正できる導線を確保
- 「不明な顧客」プレースホルダー顧客名に埋め込む受信日時が、実行ホストのタイムゾーン依存でUTCのまま表示されていた不具合を修正し、JSTで表示するよう修正

Closes #304

## Test plan
- [x] `pytest __tests__/unit/ __tests__/api/` パス
- [x] `ruff check` / `mypy` パス
- [x] PDF解析失敗時に下書き受注が起票され、`order_attachments` に解析失敗理由が引き継がれることを単体テストで検証
- [x] JST変換について具体的なタイムスタンプでのアサーションを単体テストに追加
- [x] `docs/features/pdf-order-parsing.md` / `order-attachments.md` / `customer-draft-auto-create.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)