### PR TITLE
fix: 顧客マスタのテーブル列幅を固定して崩れを解消

### DIFF
--- a/frontend/src/app/master/customers/page.tsx
+++ b/frontend/src/app/master/customers/page.tsx
@@ -185,16 +185,16 @@ export default function CustomersPage() {
         <div className="text-center py-10">読み込み中...</div>
       ) : (
         <div className="rounded-md border">
-          <Table>
+          <Table className="table-fixed">
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[100px]">ID</TableHead>
-                <TableHead>顧客名</TableHead>
-                <TableHead>通称</TableHead>
-                <TableHead>代表者名</TableHead>
-                <TableHead>電話番号</TableHead>
-                <TableHead>Email</TableHead>
-                <TableHead className="w-[120px] text-right">操作</TableHead>
+                <TableHead className="w-[70px] whitespace-nowrap">ID</TableHead>
+                <TableHead className="w-[220px]">顧客名</TableHead>
+                <TableHead className="w-[140px] whitespace-nowrap">通称</TableHead>
+                <TableHead className="w-[140px] whitespace-nowrap">代表者名</TableHead>
+                <TableHead className="w-[140px] whitespace-nowrap">電話番号</TableHead>
+                <TableHead className="w-[220px]">Email</TableHead>
+                <TableHead className="w-[100px] whitespace-nowrap text-right">操作</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -204,16 +204,18 @@ export default function CustomersPage() {
                     <TableCell className="font-medium">{customer.id}</TableCell>
                     <TableCell>
                       <div className="flex items-center gap-2">
-                        {customer.name}
+                        <span className="truncate">{customer.name}</span>
                         {customer.status === "draft" && (
-                          <Badge variant="secondary">下書き</Badge>
+                          <Badge variant="secondary" className="shrink-0 whitespace-nowrap">
+                            下書き
+                          </Badge>
                         )}
                       </div>
                     </TableCell>
-                    <TableCell>{customer.alias || "-"}</TableCell>
-                    <TableCell>{customer.representative_name || "-"}</TableCell>
-                    <TableCell>{customer.phone_number || "-"}</TableCell>
-                    <TableCell>{customer.email || "-"}</TableCell>
+                    <TableCell className="truncate">{customer.alias || "-"}</TableCell>
+                    <TableCell className="truncate">{customer.representative_name || "-"}</TableCell>
+                    <TableCell className="whitespace-nowrap">{customer.phone_number || "-"}</TableCell>
+                    <TableCell className="truncate">{customer.email || "-"}</TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
                         <Button


### PR DESCRIPTION
## Summary
- 顧客マスタ画面 (`/master/customers`) のテーブルで列幅が自動計算により極端に狭くなり、日本語が1文字ずつ縦に折り返される表示崩れを修正
- `table-fixed` と各列の明示的な幅指定を追加
- 折り返し不要な列 (ID・通称・代表者名・電話番号・操作) に `whitespace-nowrap` を追加
- 長くなりうる列 (顧客名・Email) は `truncate` で省略表示に変更

Closes #307

## Test plan
- [x] `npx tsc --noEmit` で型エラーがないことを確認
- [x] 同一Tailwindクラス構成のスタンドアロンHTMLでレイアウト崩れが解消することをスクリーンショットで確認
- [x] ローカルSupabase(Docker)起動環境で実データによる最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)