### PR TITLE
fix: 顧客削除時の外部キー制約エラーを409として理由付きで返す

### DIFF
--- a/backend/__tests__/api/routers/master/test_customers_router.py
+++ b/backend/__tests__/api/routers/master/test_customers_router.py
@@ -148,3 +148,18 @@ class TestCustomerRouter:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Not found"
+
+    def test_delete_customer_conflict(self, mock_repo):
+        """DELETE /{id}: 他のデータから参照されている場合の409エラーテスト"""
+        customer_id = 1
+        mock_repo.delete.side_effect = ValueError(
+            "他のデータから参照されているため削除できません"
+        )
+
+        response = client.delete(f"/customers/{customer_id}")
+
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "他のデータから参照されているため削除できません"
+        )

--- a/backend/__tests__/unit/repositories/supabase/common/test_base_repo.py
+++ b/backend/__tests__/unit/repositories/supabase/common/test_base_repo.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from app.repositories.supa_infra.common import BaseRepository
+from postgrest.exceptions import APIError
 
 
 @pytest.mark.unit
@@ -97,3 +98,29 @@ class TestBaseRepository:
 
         # --- 実行, 検証 ---
         assert base_repo.delete(999) is False
+
+    def test_delete_foreign_key_violation(self, base_repo, mock_client):
+        """外部キー制約違反時、分かりやすいValueErrorに変換されるテスト"""
+
+        # --- モックのセットアップ ---
+        (
+            mock_client.table.return_value.delete.return_value.eq.return_value.execute
+        ).side_effect = APIError({"code": "23503", "message": "foreign key violation"})
+
+        # --- 実行, 検証 ---
+        with pytest.raises(
+            ValueError, match="他のデータから参照されているため削除できません"
+        ):
+            base_repo.delete(1)
+
+    def test_delete_other_api_error_reraised(self, base_repo, mock_client):
+        """外部キー制約違反以外のAPIErrorはそのまま再送出されるテスト"""
+
+        # --- モックのセットアップ ---
+        (
+            mock_client.table.return_value.delete.return_value.eq.return_value.execute
+        ).side_effect = APIError({"code": "99999", "message": "unexpected error"})
+
+        # --- 実行, 検証 ---
+        with pytest.raises(APIError):
+            base_repo.delete(1)

--- a/backend/app/repositories/supa_infra/common/base_repo.py
+++ b/backend/app/repositories/supa_infra/common/base_repo.py
@@ -79,13 +79,22 @@ class BaseRepository(Generic[T]):
     def delete(self, id: int) -> bool:
         """削除 (Delete)"""
         logger.info(f"Deleting record {id} from {self.table_name}")
-        # count="exact" で削除された行数を確認できる
-        # postgrest-pyの型定義ではCountMethod enumが要求されるが、文字列でも動作するためignoreする
-        res = (
-            self.client.table(self.table_name)
-            .delete(count="exact")  # type: ignore
-            .eq("id", id)
-            .execute()
-        )
+        try:
+            # count="exact" で削除された行数を確認できる
+            # postgrest-pyの型定義ではCountMethod enumが要求されるが、文字列でも動作するためignoreする
+            res = (
+                self.client.table(self.table_name)
+                .delete(count="exact")  # type: ignore
+                .eq("id", id)
+                .execute()
+            )
+        except APIError as e:
+            # 外部キー制約違反の場合は分かりやすいエラーメッセージを投げる
+            if e.code == "23503":  # foreign_key_violation
+                raise ValueError(
+                    "他のデータから参照されているため削除できません"
+                ) from e
+            # その他のAPIエラーはそのまま再送出
+            raise
         # countが1以上なら削除成功とみなす
         return res.count is not None and res.count > 0

--- a/backend/app/routers/master/customers.py
+++ b/backend/app/routers/master/customers.py
@@ -58,7 +58,10 @@ def delete_customer(
 ):
     """顧客を削除"""
     logger.info(f"Deleting customer {customer_id}")
-    success = repo.delete(customer_id)
+    try:
+        success = repo.delete(customer_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from None
     if not success:
         raise HTTPException(status_code=404, detail="Not found")
     return {"status": "deleted"}

--- a/docs/features/customer-delete-error-handling.md
+++ b/docs/features/customer-delete-error-handling.md
@@ -1,0 +1,60 @@
+# 顧客削除時の外部キー制約エラーハンドリング（Issue #312）
+
+顧客マスタで受注/添付データから参照されている顧客を削除しようとすると、外部キー制約違反が
+FastAPI/フロントエンドで握りつぶされ、常に汎用的な「顧客の削除に失敗しました」トーストしか
+表示されず、原因が分からない問題を解消する。
+
+---
+
+## 背景
+
+メール受注取り込みで自動作成される下書き顧客（[customer-draft-auto-create.md](customer-draft-auto-create.md)
+参照）は、作成直後に `order_attachments.customer_id` から参照されるステージング行を必ず伴う。
+`customers.id` を参照する外部キー（`orders.customer_id`, `order_attachments.customer_id`、
+いずれも `ON DELETE` 句なし）があるため、これらの顧客を削除しようとすると Postgres が
+`23503 foreign_key_violation` を返すが、従来は以下の理由でユーザーに原因が伝わらなかった。
+
+- `BaseRepository.delete`（`base_repo.py`）に例外処理がなく、`APIError` がそのまま伝播し
+  FastAPI が汎用的な 500 を返す
+- `delete_customer` ルーターにも `try/except` がない
+- フロントエンドの `handleDelete`（`page.tsx`）が `catch` 内で実際のエラー内容を見ず、
+  固定文言のトーストのみを表示していた
+
+## 修正内容
+
+### バックエンド
+
+- `BaseRepository.delete`（`backend/app/repositories/supa_infra/common/base_repo.py`）で
+  `postgrest.exceptions.APIError` を捕捉し、`code == "23503"`（外部キー制約違反）の場合は
+  `ValueError("他のデータから参照されているため削除できません")` に変換する。
+  それ以外の `APIError` はそのまま再送出する（`create` の一意制約違反ハンドリングと同じパターン）
+- `delete_customer`（`backend/app/routers/master/customers.py`）で `ValueError` を捕捉し、
+  `HTTPException(status_code=409, detail=str(e))` を返す
+
+### フロントエンド
+
+- `frontend/src/app/master/customers/page.tsx` の `handleDelete` で、`error` が `ApiError`
+  かつ `data.detail` が文字列の場合はそれをトーストメッセージとして表示し、それ以外は
+  従来通り汎用メッセージ「顧客の削除に失敗しました」を表示する
+
+## スコープ外
+
+- 下書き顧客に紐づく `order_attachments`（ステージング行）がある場合の削除可否自体の仕様変更
+  （カスケード削除や `customer_id` の NULL 化など）は本Issueのスコープ外とし、現状通り
+  「関連データがある場合は削除をブロックし、理由を表示する」動作とする
+
+## 受け入れ条件
+
+- [x] 関連データ（受注/添付）が存在する顧客を削除しようとした際、具体的な理由を含む
+      エラーメッセージ（「他のデータから参照されているため削除できません」）が表示されること
+- [x] 関連データが存在しない顧客は正常に削除できること
+- [x] 既存のテストをパスし、新しいエラーハンドリングを検証するテストを追加すること
+      (`__tests__/unit/repositories/supabase/common/test_base_repo.py`,
+      `__tests__/api/routers/master/test_customers_router.py`)
+- [x] 型・Lint エラーが出ていないこと
+
+## 関連
+
+- [customer-draft-auto-create.md](customer-draft-auto-create.md): 下書き顧客が
+  `order_attachments` から参照される経緯
+- Issue #312: 顧客マスタで関連データを持つ顧客を削除できず理由も表示されない

--- a/frontend/src/app/master/customers/page.tsx
+++ b/frontend/src/app/master/customers/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { Plus, Pencil, Trash2 } from "lucide-react"
 import { toast } from "sonner"
+import { ApiError } from "@/lib/api-client"
 import {
   useCustomers,
   useCreateCustomer,
@@ -151,7 +152,11 @@ export default function CustomersPage() {
       setIsDeleteDialogOpen(false)
       setSelectedCustomer(null)
     } catch (error) {
-      toast.error("顧客の削除に失敗しました")
+      const message =
+        error instanceof ApiError && typeof error.data.detail === "string"
+          ? error.data.detail
+          : "顧客の削除に失敗しました"
+      toast.error(message)
       console.error(error)
     }
   }


### PR DESCRIPTION
## Summary
- 関連データ（`orders`/`order_attachments`）から参照されている顧客を削除しようとすると、外部キー制約違反（`23503`）がハンドリングされず汎用500エラーになり、フロントも固定文言のトーストしか表示していなかった
- `BaseRepository.delete` でFK違反を検知し `ValueError` に変換、ルーターで409＋具体的なメッセージを返すようにした
- フロントの `handleDelete` でバックエンドから返る理由をトースト表示するようにした

## Test plan
- [x] `pytest __tests__/unit __tests__/api` 全パス（新規テスト含む）
- [x] `ruff check` / `mypy` パス
- [x] `tsc --noEmit` / `npm run lint` パス（新規warning無し）
- [x] `docs/features/customer-delete-error-handling.md` を追加

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)