### PR TITLE
注文編集モーダル(EditOrderDialog)にも参照元メールパネルを表示する

### DIFF
--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -551,6 +551,16 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
   入力できる。送信すると分割後の一覧ページに遷移する
 - `useSplitOrder`（`frontend/src/hooks/use-orders.ts`）が上記APIを呼び出し、
   成功時に注文一覧のキャッシュを無効化する
+- 参照元メール（件名・顧客・本文・添付ファイル一覧）を表示する左ペインは
+  `SourceEmailPanel`（`frontend/src/components/orders/source-email-panel.tsx`）
+  として共通コンポーネント化されており（Issue #317）、`SplitOrderDialog` に加えて
+  `EditOrderDialog`（`frontend/src/components/orders/edit-order-dialog.tsx`）からも
+  利用される。`EditOrderDialog` は `source_type === 'email'` かつ `source_raw` が
+  存在する注文を編集する場合のみ、モーダルを2ペインレイアウト
+  （`sm:max-w-[820px]`）に切り替えて左に本パネルを表示する。手動作成の注文では
+  従来通り単一カラムのフォームのみが表示される。件名/本文の分離ロジック
+  （`source_raw` 内の「件名: ...」行を正規表現で切り出す）は
+  `splitSubjectAndBody()`（`frontend/src/lib/order-utils.ts`）として共通化されている
 
 ---
 

--- a/frontend/src/components/orders/edit-order-dialog.tsx
+++ b/frontend/src/components/orders/edit-order-dialog.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { ProductSelector } from "@/components/product-selector"
 import { CustomerSelector } from "@/components/customer-selector"
+import { SourceEmailPanel } from "@/components/orders/source-email-panel"
 import { useUpdateOrder } from "@/hooks/use-orders"
 import { toDateInputValue } from "@/lib/order-utils"
 import type { Order } from "@/types/order"
@@ -37,6 +38,7 @@ export function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogPr
 
   if (!order) return null
 
+  const hasSourceEmail = order.source_type === "email" && !!order.source_raw
   const productChanged = productId !== (order.product_id?.toString() ?? "")
   const quantityChanged = quantity !== (order.quantity?.toString() ?? "")
   const showScheduleWarning = order.is_scheduled && (productChanged || quantityChanged)
@@ -79,63 +81,84 @@ export function EditOrderDialog({ order, open, onOpenChange }: EditOrderDialogPr
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
-        <DialogHeader>
+      <DialogContent
+        className={
+          hasSourceEmail
+            ? "flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[820px]"
+            : "sm:max-w-[480px]"
+        }
+      >
+        <DialogHeader className={hasSourceEmail ? "px-6 pb-4 pt-6" : undefined}>
           <DialogTitle>注文の編集</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          {showScheduleWarning && (
-            <div className="flex items-start gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                スケジュールが無効になります。保存後に再シミュレーションが必要です。
-              </span>
-            </div>
+        <div className={hasSourceEmail ? "flex min-h-0 flex-1 border-t" : undefined}>
+          {hasSourceEmail && (
+            <SourceEmailPanel
+              order={order}
+              className="w-[300px] shrink-0 space-y-4 overflow-y-auto border-r bg-muted/30 p-5"
+            />
           )}
 
-          <div className="space-y-2">
-            <Label htmlFor="order-no">注文番号（任意）</Label>
-            <Input
-              id="order-no"
-              value={orderNo}
-              onChange={(e) => {
-                setOrderNo(e.target.value)
-                setDuplicateError("")
-              }}
-            />
-            {duplicateError && (
-              <p className="text-sm text-destructive">{duplicateError}</p>
+          <div
+            className={
+              hasSourceEmail
+                ? "flex-1 space-y-4 overflow-y-auto p-5"
+                : "space-y-4 py-2"
+            }
+          >
+            {showScheduleWarning && (
+              <div className="flex items-start gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>
+                  スケジュールが無効になります。保存後に再シミュレーションが必要です。
+                </span>
+              </div>
             )}
-          </div>
 
-          <ProductSelector value={productId} onValueChange={setProductId} />
+            <div className="space-y-2">
+              <Label htmlFor="order-no">注文番号（任意）</Label>
+              <Input
+                id="order-no"
+                value={orderNo}
+                onChange={(e) => {
+                  setOrderNo(e.target.value)
+                  setDuplicateError("")
+                }}
+              />
+              {duplicateError && (
+                <p className="text-sm text-destructive">{duplicateError}</p>
+              )}
+            </div>
 
-          <CustomerSelector value={customerId} onValueChange={setCustomerId} />
+            <ProductSelector value={productId} onValueChange={setProductId} />
 
-          <div className="space-y-2">
-            <Label htmlFor="quantity">数量 *</Label>
-            <Input
-              id="quantity"
-              type="number"
-              min={1}
-              value={quantity}
-              onChange={(e) => setQuantity(e.target.value)}
-            />
-          </div>
+            <CustomerSelector value={customerId} onValueChange={setCustomerId} />
 
-          <div className="space-y-2">
-            <Label htmlFor="desired-deadline">希望納期</Label>
-            <Input
-              id="desired-deadline"
-              type="date"
-              value={desiredDeadline}
-              onChange={(e) => setDesiredDeadline(e.target.value)}
-            />
+            <div className="space-y-2">
+              <Label htmlFor="quantity">数量 *</Label>
+              <Input
+                id="quantity"
+                type="number"
+                min={1}
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="desired-deadline">希望納期</Label>
+              <Input
+                id="desired-deadline"
+                type="date"
+                value={desiredDeadline}
+                onChange={(e) => setDesiredDeadline(e.target.value)}
+              />
+            </div>
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={hasSourceEmail ? "border-t px-6 py-4" : undefined}>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             キャンセル
           </Button>

--- a/frontend/src/components/orders/source-email-panel.tsx
+++ b/frontend/src/components/orders/source-email-panel.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { AlertTriangle, Download, Mail, Paperclip } from "lucide-react"
+import { useOrderAttachments } from "@/hooks/use-orders"
+import { useCustomers } from "@/hooks/use-customers"
+import { getCustomerName, splitSubjectAndBody } from "@/lib/order-utils"
+import type { Order } from "@/types/order"
+
+interface SourceEmailPanelProps {
+  order: Order
+  className?: string
+}
+
+/**
+ * メール起点の注文について、件名・本文・添付ファイル一覧を表示するパネル。
+ * EditOrderDialog / SplitOrderDialog から共通利用する。
+ */
+export function SourceEmailPanel({ order, className }: SourceEmailPanelProps) {
+  const { data: attachments } = useOrderAttachments(order.id)
+  const { data: customers } = useCustomers()
+  const { subject, body } = splitSubjectAndBody(order.source_raw)
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-1.5 text-sm font-medium">
+        <Mail className="h-4 w-4" />
+        参照元メール
+      </div>
+
+      {subject && (
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">件名</p>
+          <p className="text-sm font-medium break-words">{subject}</p>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <p className="text-xs text-muted-foreground">顧客</p>
+        <p className="text-sm font-medium">
+          {order.customer_id ? (
+            getCustomerName(order.customer_id, customers)
+          ) : (
+            <span className="text-muted-foreground">未設定</span>
+          )}
+        </p>
+      </div>
+
+      {body && (
+        <div className="rounded-md border bg-background p-3">
+          <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
+            {body}
+          </pre>
+        </div>
+      )}
+
+      <div className="space-y-1.5 border-t pt-3">
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Paperclip className="h-3.5 w-3.5" />
+          添付ファイル
+        </p>
+        {attachments && attachments.length > 0 ? (
+          <ul className="space-y-1.5">
+            {attachments.map((att) => (
+              <li key={att.id} className="text-xs">
+                {att.parse_status === "failed_no_attachment" ? (
+                  <span className="text-muted-foreground">添付ファイルなし</span>
+                ) : att.parse_status === "failed_encrypted" ||
+                  att.parse_status === "failed_image" ? (
+                  <span className="flex items-center gap-1 text-amber-600">
+                    <AlertTriangle className="h-3 w-3 shrink-0" />
+                    自動読み取り不可
+                    {att.signed_url && (
+                      <a
+                        href={att.signed_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1 underline text-primary"
+                      >
+                        {att.original_filename}
+                      </a>
+                    )}
+                  </span>
+                ) : (
+                  <a
+                    href={att.signed_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-primary underline"
+                  >
+                    <Download className="h-3 w-3 shrink-0" />
+                    {att.original_filename}
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-xs text-muted-foreground">添付ファイルなし</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/orders/source-email-panel.tsx
+++ b/frontend/src/components/orders/source-email-panel.tsx
@@ -16,8 +16,8 @@ interface SourceEmailPanelProps {
  * EditOrderDialog / SplitOrderDialog から共通利用する。
  */
 export function SourceEmailPanel({ order, className }: SourceEmailPanelProps) {
-  const { data: attachments } = useOrderAttachments(order.id)
-  const { data: customers } = useCustomers()
+  const { data: attachments, isLoading: attachmentsLoading } = useOrderAttachments(order.id)
+  const { data: customers, isLoading: customersLoading } = useCustomers()
   const { subject, body } = splitSubjectAndBody(order.source_raw)
 
   return (
@@ -37,7 +37,9 @@ export function SourceEmailPanel({ order, className }: SourceEmailPanelProps) {
       <div className="space-y-1">
         <p className="text-xs text-muted-foreground">顧客</p>
         <p className="text-sm font-medium">
-          {order.customer_id ? (
+          {customersLoading ? (
+            <span className="text-muted-foreground">読み込み中...</span>
+          ) : order.customer_id ? (
             getCustomerName(order.customer_id, customers)
           ) : (
             <span className="text-muted-foreground">未設定</span>
@@ -58,7 +60,9 @@ export function SourceEmailPanel({ order, className }: SourceEmailPanelProps) {
           <Paperclip className="h-3.5 w-3.5" />
           添付ファイル
         </p>
-        {attachments && attachments.length > 0 ? (
+        {attachmentsLoading ? (
+          <p className="text-xs text-muted-foreground">読み込み中...</p>
+        ) : attachments && attachments.length > 0 ? (
           <ul className="space-y-1.5">
             {attachments.map((att) => (
               <li key={att.id} className="text-xs">

--- a/frontend/src/components/orders/split-order-dialog.tsx
+++ b/frontend/src/components/orders/split-order-dialog.tsx
@@ -1,14 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import {
-  AlertTriangle,
-  Download,
-  Mail,
-  Paperclip,
-  Plus,
-  Trash2,
-} from "lucide-react"
+import { Plus, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -23,26 +16,9 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { ProductSelector } from "@/components/product-selector"
 import { CustomerSelector } from "@/components/customer-selector"
-import { useSplitOrder, useOrderAttachments } from "@/hooks/use-orders"
-import { useCustomers } from "@/hooks/use-customers"
-import { getCustomerName } from "@/lib/order-utils"
+import { SourceEmailPanel } from "@/components/orders/source-email-panel"
+import { useSplitOrder } from "@/hooks/use-orders"
 import type { Order } from "@/types/order"
-
-/**
- * source_raw の先頭に含まれる「件名: ...」行を件名として切り出し、
- * 残りを本文として返す。件名行が見つからない場合は全体を本文として扱う。
- */
-function splitSubjectAndBody(sourceRaw?: string | null): {
-  subject?: string
-  body?: string
-} {
-  if (!sourceRaw) return {}
-  const match = sourceRaw.match(/^件名[:：]\s*(.*)$/m)
-  if (!match || match.index == null) return { body: sourceRaw }
-  const subject = match[1].trim()
-  const body = sourceRaw.slice(match.index + match[0].length).replace(/^\s+/, "")
-  return { subject: subject || undefined, body: body || undefined }
-}
 
 interface SplitOrderDialogProps {
   order: Order | null
@@ -76,10 +52,6 @@ export function SplitOrderDialog({
   const splitOrder = useSplitOrder()
   const [items, setItems] = useState<SplitLineItemForm[]>([])
   const [error, setError] = useState("")
-
-  const { data: attachments } = useOrderAttachments(order?.id ?? 0)
-  const { data: customers } = useCustomers()
-  const { subject, body } = splitSubjectAndBody(order?.source_raw)
 
   // ダイアログを開いた時点の注文内容を初期値として2行を用意する
   useEffect(() => {
@@ -170,84 +142,10 @@ export function SplitOrderDialog({
 
         <div className="flex min-h-0 flex-1 border-t">
           {/* 左: 参照元メール（分割単位を判断するための情報） */}
-          <div className="w-[300px] shrink-0 space-y-4 overflow-y-auto border-r bg-muted/30 p-5">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
-              <Mail className="h-4 w-4" />
-              参照元メール
-            </div>
-
-            {subject && (
-              <div className="space-y-1">
-                <p className="text-xs text-muted-foreground">件名</p>
-                <p className="text-sm font-medium break-words">{subject}</p>
-              </div>
-            )}
-
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">顧客</p>
-              <p className="text-sm font-medium">
-                {order.customer_id ? (
-                  getCustomerName(order.customer_id, customers)
-                ) : (
-                  <span className="text-muted-foreground">未設定</span>
-                )}
-              </p>
-            </div>
-
-            {body && (
-              <div className="rounded-md border bg-background p-3">
-                <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-xs text-muted-foreground">
-                  {body}
-                </pre>
-              </div>
-            )}
-
-            <div className="space-y-1.5 border-t pt-3">
-              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Paperclip className="h-3.5 w-3.5" />
-                添付ファイル
-              </p>
-              {attachments && attachments.length > 0 ? (
-                <ul className="space-y-1.5">
-                  {attachments.map((att) => (
-                    <li key={att.id} className="text-xs">
-                      {att.parse_status === "failed_no_attachment" ? (
-                        <span className="text-muted-foreground">添付ファイルなし</span>
-                      ) : att.parse_status === "failed_encrypted" ||
-                        att.parse_status === "failed_image" ? (
-                        <span className="flex items-center gap-1 text-amber-600">
-                          <AlertTriangle className="h-3 w-3 shrink-0" />
-                          自動読み取り不可
-                          {att.signed_url && (
-                            <a
-                              href={att.signed_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="ml-1 underline text-primary"
-                            >
-                              {att.original_filename}
-                            </a>
-                          )}
-                        </span>
-                      ) : (
-                        <a
-                          href={att.signed_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-1 text-primary underline"
-                        >
-                          <Download className="h-3 w-3 shrink-0" />
-                          {att.original_filename}
-                        </a>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-xs text-muted-foreground">添付ファイルなし</p>
-              )}
-            </div>
-          </div>
+          <SourceEmailPanel
+            order={order}
+            className="w-[300px] shrink-0 space-y-4 overflow-y-auto border-r bg-muted/30 p-5"
+          />
 
           {/* 右: 分割フォーム */}
           <div className="flex-1 space-y-4 overflow-y-auto p-5">

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -139,8 +139,9 @@ export function getCertaintyBadgeClass(
 }
 
 /**
- * source_raw の先頭に含まれる「件名: ...」行を件名として切り出し、
- * 残りを本文として返す。件名行が見つからない場合は全体を本文として扱う。
+ * source_raw 中の最初に見つかった「件名: ...」行(先頭とは限らない)を件名として
+ * 切り出し、その行より後ろを本文として返す。件名行が見つからない場合は全体を
+ * 本文として扱う。
  */
 export function splitSubjectAndBody(sourceRaw?: string | null): {
   subject?: string

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -137,3 +137,19 @@ export function getCertaintyBadgeClass(
   }
   return classes[certainty] ?? ""
 }
+
+/**
+ * source_raw の先頭に含まれる「件名: ...」行を件名として切り出し、
+ * 残りを本文として返す。件名行が見つからない場合は全体を本文として扱う。
+ */
+export function splitSubjectAndBody(sourceRaw?: string | null): {
+  subject?: string
+  body?: string
+} {
+  if (!sourceRaw) return {}
+  const match = sourceRaw.match(/^件名[:：]\s*(.*)$/m)
+  if (!match || match.index == null) return { body: sourceRaw }
+  const subject = match[1].trim()
+  const body = sourceRaw.slice(match.index + match[0].length).replace(/^\s+/, "")
+  return { subject: subject || undefined, body: body || undefined }
+}


### PR DESCRIPTION
## Summary

Issue #280 / PR #290 で `SplitOrderDialog` に実装された「参照元メールパネル」(件名・顧客・本文・添付ファイル一覧)を、注文編集モーダル (`EditOrderDialog`) でも表示できるようにする (Issue #317)。

- `SourceEmailPanel`(`frontend/src/components/orders/source-email-panel.tsx`)を新設し、`SplitOrderDialog` の左ペインJSXを共通コンポーネントとして切り出した
- `splitSubjectAndBody()`(件名/本文分離ロジック)は `frontend/src/lib/order-utils.ts` に移設し、両ダイアログから共通利用
- `EditOrderDialog`: 編集対象の注文が `source_type === 'email'` かつ `source_raw` を持つ場合のみ、モーダルを2ペインレイアウト(`sm:max-w-[820px]`)に切り替え、左に `SourceEmailPanel` を表示する。手動作成の注文では従来通り単一カラムのフォームのみ表示
- `SplitOrderDialog` は新コンポーネントを利用するようリファクタ(表示・挙動に変更なし)
- `docs/features/pdf-order-parsing.md` を更新
- バックエンドAPIの変更は不要(既存の `GET /orders/{order_id}` / `GET /orders/{order_id}/attachments` で必要な情報が取得可能なため)

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npx eslint` (変更ファイル) パス
- [x] `npm run build` パス
- [ ] ローカルSupabase (Docker) が起動していない環境のため、ブラウザでの実動作確認は未実施。レビュー時にメール起点の下書き注文編集モーダルの表示、および分割ダイアログの回帰有無を確認してください

## 関連Issue
Closes #317