### PR TITLE
fix: Dialog内のプルダウンでマウスホイールスクロールが効かない問題を修正

### DIFF
--- a/docs/features/order-management-ui-design.md
+++ b/docs/features/order-management-ui-design.md
@@ -207,6 +207,14 @@ URL クエリパラメータ `?status=` で管理（マスタ画面と同じパ�
 **希望納期・確定納期の日付/時刻の扱い (#293)**
 `desired_deadline`（DB上は `deadline_date`）・`confirmed_deadline` はいずれも「日付のみ」(`YYYY-MM-DD`) で、時刻情報を持たない。`new Date(dateStr)` でパースして `format` すると環境のタイムゾーンによって存在しない時刻が表示されてしまうため、`lib/order-utils.ts` の `formatDeadlineDate`（表示用、文字列の先頭10文字をそのまま整形）・`toDateInputValue`（`<input type="date">` バインド用）に処理を統一した。`EditOrderDialog` と新規注文作成ページの希望納期入力欄も `type="datetime-local"` から `type="date"` に変更している。`BulkSimulateSummaryDialog` の希望納期表示も同様に対応済み。なお、シミュレーション結果の `calculated_deadline` はスケジューラが計算した実際の日時（時刻を持つ）のため対象外。
 
+**Dialog 内プルダウンのマウスホイールスクロール不具合 (#319)**
+`Dialog`（`@radix-ui/react-dialog`）が modal 表示中に行うボディスクロールロック（`react-remove-scroll`）は、`Portal` 経由で `document.body` 直下に描画される要素へのホイールイベントもブロックしてしまう。このため `ProductSelector`（`Popover` + `Command`）・`CustomerSelector`（`Select`）を `Dialog` 内（`EditOrderDialog`・`SplitOrderDialog`）で使うと、一覧をマウスホイールでスクロールできない不具合があった（矢印キーでの操作は影響を受けないため気づきにくい）。
+対応として、共通コンポーネント側でスクロール対象要素に対しネイティブ（非 passive）の `wheel` イベントリスナーを登録し、`scrollTop` を直接更新することでロックを迂回している。
+- `frontend/src/components/ui/command.tsx` の `CommandList`
+- `frontend/src/components/ui/select.tsx` の `SelectContent`（内部の `SelectPrimitive.Viewport`）
+
+いずれも共通 UI コンポーネント側の対応のため、`Dialog` 内外を問わず両セレクタを使う画面すべてに適用される。
+
 ---
 
 ## バックエンド追加事項

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -55,13 +55,37 @@ CommandInput.displayName = CommandPrimitive.Input.displayName
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.List
-    ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  // Dialog内(react-remove-scrollのスクロールロック)にPortalで描画されると
+  // マウスホイールでのスクロールが無効化されるため、ネイティブのnon-passive
+  // wheelリスナーで手動スクロールして迂回する
+  React.useEffect(() => {
+    const node = listRef.current
+    if (!node) return
+
+    const handleWheel = (event: WheelEvent) => {
+      node.scrollTop += event.deltaY
+      event.preventDefault()
+    }
+
+    node.addEventListener("wheel", handleWheel, { passive: false })
+    return () => node.removeEventListener("wheel", handleWheel)
+  }, [])
+
+  return (
+    <CommandPrimitive.List
+      ref={(node) => {
+        listRef.current = node
+        if (typeof ref === "function") ref(node)
+        else if (ref) ref.current = node
+      }}
+      className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+      {...props}
+    />
+  )
+})
 CommandList.displayName = CommandPrimitive.List.displayName
 
 const CommandEmpty = React.forwardRef<

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -6,6 +6,7 @@ import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { useWheelScrollFallback } from "@/hooks/use-wheel-scroll-fallback"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -57,22 +58,7 @@ const CommandList = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
 >(({ className, ...props }, ref) => {
   const listRef = React.useRef<HTMLDivElement>(null)
-
-  // Dialog内(react-remove-scrollのスクロールロック)にPortalで描画されると
-  // マウスホイールでのスクロールが無効化されるため、ネイティブのnon-passive
-  // wheelリスナーで手動スクロールして迂回する
-  React.useEffect(() => {
-    const node = listRef.current
-    if (!node) return
-
-    const handleWheel = (event: WheelEvent) => {
-      node.scrollTop += event.deltaY
-      event.preventDefault()
-    }
-
-    node.addEventListener("wheel", handleWheel, { passive: false })
-    return () => node.removeEventListener("wheel", handleWheel)
-  }, [])
+  useWheelScrollFallback(listRef)
 
   return (
     <CommandPrimitive.List

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useWheelScrollFallback } from "@/hooks/use-wheel-scroll-fallback"
 
 const Select = SelectPrimitive.Root
 
@@ -37,22 +38,7 @@ const SelectContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = "popper", ...props }, ref) => {
   const viewportRef = React.useRef<HTMLDivElement>(null)
-
-  // Dialog内(react-remove-scrollのスクロールロック)にPortalで描画されると
-  // マウスホイールでのスクロールが無効化されるため、ネイティブのnon-passive
-  // wheelリスナーで手動スクロールして迂回する
-  React.useEffect(() => {
-    const node = viewportRef.current
-    if (!node) return
-
-    const handleWheel = (event: WheelEvent) => {
-      node.scrollTop += event.deltaY
-      event.preventDefault()
-    }
-
-    node.addEventListener("wheel", handleWheel, { passive: false })
-    return () => node.removeEventListener("wheel", handleWheel)
-  }, [])
+  useWheelScrollFallback(viewportRef)
 
   return (
     <SelectPrimitive.Portal>

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -35,31 +35,52 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectPrimitive.Viewport
+>(({ className, children, position = "popper", ...props }, ref) => {
+  const viewportRef = React.useRef<HTMLDivElement>(null)
+
+  // Dialog内(react-remove-scrollのスクロールロック)にPortalで描画されると
+  // マウスホイールでのスクロールが無効化されるため、ネイティブのnon-passive
+  // wheelリスナーで手動スクロールして迂回する
+  React.useEffect(() => {
+    const node = viewportRef.current
+    if (!node) return
+
+    const handleWheel = (event: WheelEvent) => {
+      node.scrollTop += event.deltaY
+      event.preventDefault()
+    }
+
+    node.addEventListener("wheel", handleWheel, { passive: false })
+    return () => node.removeEventListener("wheel", handleWheel)
+  }, [])
+
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          "p-1",
+          "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-))
+        <SelectPrimitive.Viewport
+          ref={viewportRef}
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+})
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
 const SelectLabel = React.forwardRef<

--- a/frontend/src/hooks/use-wheel-scroll-fallback.ts
+++ b/frontend/src/hooks/use-wheel-scroll-fallback.ts
@@ -1,0 +1,43 @@
+import * as React from "react"
+
+/**
+ * Dialog(react-remove-scrollのスクロールロック)にPortal経由で描画された
+ * 要素はマウスホイールでのスクロールが無効化されるため、ネイティブのnon-passive
+ * wheelリスナーで手動スクロールして迂回する。
+ *
+ * スクロール端に達していて実際にスクロールできない場合や ctrlKey 押下時
+ * (ブラウザのピンチズーム)は何もしない。これにより親要素へのスクロール
+ * チェーンやズーム操作を妨げない。
+ */
+export function useWheelScrollFallback<T extends HTMLElement>(
+  ref: React.RefObject<T | null>
+) {
+  React.useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) return
+
+      const lineHeight = 16
+      const delta =
+        event.deltaMode === 1
+          ? event.deltaY * lineHeight
+          : event.deltaMode === 2
+            ? event.deltaY * node.clientHeight
+            : event.deltaY
+
+      const { scrollTop, scrollHeight, clientHeight } = node
+      const atTop = scrollTop <= 0
+      const atBottom = scrollTop + clientHeight >= scrollHeight
+
+      if ((delta < 0 && atTop) || (delta > 0 && atBottom)) return
+
+      node.scrollTop += delta
+      event.preventDefault()
+    }
+
+    node.addEventListener("wheel", handleWheel, { passive: false })
+    return () => node.removeEventListener("wheel", handleWheel)
+  }, [ref])
+}


### PR DESCRIPTION
## 概要

closes #319

`EditOrderDialog` / `SplitOrderDialog` 内の `ProductSelector`（Popover+Command）・`CustomerSelector`（Select）で、マウスホイールによる一覧スクロールが効かない不具合を修正。

## 原因

Radix Dialog の modal 表示中のボディスクロールロック（`react-remove-scroll`）が、`Portal` 経由で `document.body` 直下に描画される `PopoverContent`/`SelectContent` へのホイールイベントも「ダイアログ外へのスクロール」とみなしてブロックしていた。キーボード操作（矢印キー）はこのブロッカーの対象外のため影響を受けず、原因の切り分けが難しい不具合だった。

## 対応

Issue内の修正方針候補のうち「1. スクロール対象要素に `onWheel` ハンドラを追加し、手動で `scrollTop` を更新することでブロッカーを迂回する」を採用。ただし React の `onWheel` は passive リスナーとして登録され `preventDefault()` が効かないため、ネイティブの `addEventListener("wheel", handler, { passive: false })` で実装。

- `frontend/src/components/ui/command.tsx`: `CommandList` にネイティブ wheel リスナーを追加
- `frontend/src/components/ui/select.tsx`: `SelectContent` 内の `SelectPrimitive.Viewport` に同様のリスナーを追加

いずれも共通 UI コンポーネントへの対応のため、`Dialog` 内外を問わず両セレクタを使う画面すべてに適用される。

## 動作確認

- `CommandList`（Popover+Command）については、Dialog内に配置した検証用ページで実際に Playwright から `page.mouse.wheel()` を発行し、`scrollTop` が `0 → 300` に変化することを確認（修正前は `0` のまま変化なし、という Issue の再現条件と同じ検証方法）
- Dialog 本来の挙動（Esc キーでの close）に回帰がないことを確認
- `tsc --noEmit` / `eslint` にエラーなし

## Test plan

- [ ] `EditOrderDialog` を開き、製品プルダウンをマウスホイールでスクロールできることを確認
- [ ] `EditOrderDialog` を開き、顧客プルダウンをマウスホイールでスクロールできることを確認
- [ ] `SplitOrderDialog` でも同様に確認
- [ ] Dialog の背景クリックブロック・Escキーでの close に回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)