### PR TITLE
[Feature]: ロール拡張(president/iso_officer/order_handler/platform_admin の導入)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,21 @@ cd backend && ruff check . && mypy .
 - **ガントチャート**: `frontend/src/gantt/` のカスタム実装を使用。`gantt-task-react` は削除済みのため参照しない
 - **データ取得**: TanStack Query (`useQuery` / `useMutation`) で統一。`useEffect` でのフェッチ禁止
 - **型安全**: Backend の Pydantic スキーマと Frontend の TypeScript interface を一致させること
+- **メンバーロール**: `organization_members.role` は `president`（社長）/ `iso_officer`（ISO担当）/ `order_handler`（受注担当）/ `platform_admin`（プラットフォーム管理者）の四値（Issue #323）。旧 `admin`/`member` は廃止済み。メンバー管理系エンドポイントは `president`/`platform_admin` に開放し、承認操作（工程確定 `is_confirmed` 等）は `platform_admin` を含めず `president` 限定とする方針。詳細は [docs/features/member-roles.md](docs/features/member-roles.md) 参照
+
+## 本番 Supabase への接続（マイグレーション適用・一時的なSQL実行）
+
+- このプロジェクトの本番DBは **direct connection (`db.<ref>.supabase.co`) が名前解決できない**（IPv4アドオン未設定等の理由と推測）。`supabase db push --linked` は Management API 経由で一時ログインロールを作成する際に `permission denied to alter role` で失敗することがある
+- 代わりに **セッションプーラー経由の `--db-url`** を使うこと。リージョンは `ap-northeast-1`（Tokyo）で、`aws-0-...` ではなく `aws-1-ap-northeast-1.pooler.supabase.com` が有効だった（`aws-0` は `tenant/user not found` で失敗）
+  ```bash
+  # プロジェクトref・パスワードは backend/.env の SUPABASE_PROJECT_ID / SUPABASE_DB_PASSWORD を利用
+  # パスワードは percent-encode が必要
+  supabase db push --db-url "postgresql://postgres.<project-ref>:<url-encoded-password>@aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres"
+
+  # 一時的なSQL実行（本番データの確認・単発の手動UPDATE等）
+  supabase db query --db-url "postgresql://postgres.<project-ref>:<url-encoded-password>@aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres" "SELECT ..."
+  ```
+- 本番への `db push` / 直接SQL実行は不可逆な操作のため、必ず `--dry-run`（push の場合）や `SELECT` での事前確認を行い、ユーザーの明示的な承認を得てから実行すること
 
 ## Git ワークフロー
 

--- a/backend/__tests__/api/routers/master/test_process_routings.py
+++ b/backend/__tests__/api/routers/master/test_process_routings.py
@@ -22,8 +22,13 @@ class TestProcessRoutingRouter:
         mock = MagicMock()
         return mock
 
+    @pytest.fixture
+    def mock_client(self):
+        """Supabaseクライアントのモックを作成するフィクスチャ"""
+        return MagicMock()
+
     @pytest.fixture(autouse=True)
-    def override_dependency(self, mock_repo):
+    def override_dependency(self, mock_repo, mock_client):
         """
         テスト実行中だけ get_product_repo / get_current_user_id を差し替える。
         PATCH は is_confirmed 更新時にロールチェックのため get_current_user_id
@@ -31,7 +36,7 @@ class TestProcessRoutingRouter:
         """
         app.dependency_overrides[get_product_repo] = lambda: mock_repo
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
-        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
+        app.dependency_overrides[get_supabase_client] = lambda: mock_client
         yield
         app.dependency_overrides = {}
 
@@ -102,6 +107,46 @@ class TestProcessRoutingRouter:
         called_id, called_data = mock_repo.update_routing.call_args[0]
         assert called_id == routing_id
         assert called_data == payload
+
+    def test_update_process_routing_is_confirmed_forbidden_for_non_president(
+        self, headers, mock_repo, mock_client
+    ):
+        """PATCH /{id}: is_confirmed 変更は president 以外だと403"""
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "role": "order_handler"
+        }
+        routing_id = 1
+        payload = {"is_confirmed": True}
+
+        response = client.patch(
+            f"/process-routings/{routing_id}", json=payload, headers=headers
+        )
+
+        assert response.status_code == 403
+        mock_repo.update_routing.assert_not_called()
+
+    def test_update_process_routing_is_confirmed_allowed_for_president(
+        self, headers, mock_repo, mock_client
+    ):
+        """PATCH /{id}: is_confirmed 変更は president なら成功"""
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "role": "president"
+        }
+        routing_id = 1
+        payload = {"is_confirmed": True}
+        updated_data = {"id": routing_id, "is_confirmed": True}
+        mock_repo.update_routing.return_value = updated_data
+
+        response = client.patch(
+            f"/process-routings/{routing_id}", json=payload, headers=headers
+        )
+
+        assert response.status_code == 200
+        mock_repo.update_routing.assert_called_once()
+        called_id, called_data = mock_repo.update_routing.call_args[0]
+        assert called_id == routing_id
+        assert called_data["is_confirmed"] is True
+        assert called_data["confirmed_by"] == "test-user-id"
 
     def test_delete_process_routing_success(self, headers, mock_repo):
         """DELETE /{id}: 削除成功時のテスト"""

--- a/backend/__tests__/api/routers/master/test_products_router.py
+++ b/backend/__tests__/api/routers/master/test_products_router.py
@@ -3,7 +3,7 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from app.dependencies import get_product_repo
+from app.dependencies import get_current_user_id, get_product_repo, get_supabase_client
 
 # テスト対象のAPIインスタンス
 from app.main import app
@@ -11,6 +11,13 @@ from fastapi.testclient import TestClient
 
 # テストクライアントの作成
 client = TestClient(app)
+
+
+def _set_role(mock_client: MagicMock, role: str) -> None:
+    """organization_members からのロール取得チェーンのモックを設定する。"""
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+        "role": role
+    }
 
 
 @pytest.mark.api
@@ -23,13 +30,21 @@ class TestProductRouter:
         mock = MagicMock()
         return mock
 
+    @pytest.fixture
+    def mock_client(self):
+        """Supabaseクライアントのモックを作成するフィクスチャ"""
+        return MagicMock()
+
     @pytest.fixture(autouse=True)
-    def override_dependency(self, mock_repo):
+    def override_dependency(self, mock_repo, mock_client):
         """
-        テスト実行中だけ get_product_repo を mock_repo に差し替える。
-        autouse=True なので、このクラスの全テストで自動的に適用される。
+        テスト実行中だけ get_product_repo / get_current_user_id / get_supabase_client を差し替える。
+        PATCH は is_active 更新時にロールチェックのため get_current_user_id
+        (実体はSupabase認証) を要求するため、テストでは固定IDに差し替える。
         """
         app.dependency_overrides[get_product_repo] = lambda: mock_repo
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: mock_client
         yield
         # テスト終了後に元に戻す（重要）
         app.dependency_overrides = {}
@@ -100,7 +115,7 @@ class TestProductRouter:
         call_args = mock_repo.create.call_args[0][0]
         assert call_args["name"] == "New Product"
 
-    def test_update_product(self, mock_repo):
+    def test_update_product(self, headers, mock_repo):
         """PATCH /{id}: 更新のテスト"""
         product_id = 1
         payload = {"name": "Updated Name"}
@@ -112,7 +127,9 @@ class TestProductRouter:
 
         mock_repo.update.return_value = updated_data
 
-        response = client.patch(f"/products/{product_id}", json=payload)
+        response = client.patch(
+            f"/products/{product_id}", json=payload, headers=headers
+        )
 
         assert response.status_code == 200
         assert response.json() == updated_data
@@ -123,8 +140,9 @@ class TestProductRouter:
         assert called_id == product_id
         assert called_data == payload
 
-    def test_toggle_product_is_active(self, mock_repo):
-        """PATCH /{id}: is_active フラグの有効/無効切り替えテスト"""
+    def test_toggle_product_is_active(self, headers, mock_repo, mock_client):
+        """PATCH /{id}: is_active フラグの有効/無効切り替えテスト（president は許可）"""
+        _set_role(mock_client, "president")
         product_id = 1
         # 無効化するケース
         payload = {"is_active": False}
@@ -137,7 +155,9 @@ class TestProductRouter:
 
         mock_repo.update.return_value = updated_data
 
-        response = client.patch(f"/products/{product_id}", json=payload)
+        response = client.patch(
+            f"/products/{product_id}", json=payload, headers=headers
+        )
 
         assert response.status_code == 200
         assert response.json()["is_active"] is False
@@ -146,6 +166,35 @@ class TestProductRouter:
         called_id, called_data = mock_repo.update.call_args[0]
         assert called_id == product_id
         assert called_data == {"is_active": False}
+
+    def test_toggle_product_is_active_allowed_for_platform_admin(
+        self, headers, mock_repo, mock_client
+    ):
+        """PATCH /{id}: is_active の切り替えは platform_admin も許可"""
+        _set_role(mock_client, "platform_admin")
+        product_id = 1
+        updated_data = {"id": product_id, "is_active": False}
+        mock_repo.update.return_value = updated_data
+
+        response = client.patch(
+            f"/products/{product_id}", json={"is_active": False}, headers=headers
+        )
+
+        assert response.status_code == 200
+
+    def test_toggle_product_is_active_forbidden_for_order_handler(
+        self, headers, mock_repo, mock_client
+    ):
+        """PATCH /{id}: is_active の切り替えは president/platform_admin 以外は403"""
+        _set_role(mock_client, "order_handler")
+        product_id = 1
+
+        response = client.patch(
+            f"/products/{product_id}", json={"is_active": False}, headers=headers
+        )
+
+        assert response.status_code == 403
+        mock_repo.update.assert_not_called()
 
     def test_delete_product_success(self, mock_repo):
         """DELETE /{id}: 削除成功時のテスト"""

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -1,0 +1,93 @@
+# __tests__/api/routers/tenant/test_members.py
+from unittest.mock import MagicMock
+
+import pytest
+from app.dependencies import (
+    get_current_user_id,
+    get_supabase_admin_client,
+    get_supabase_client,
+)
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def _set_role(mock_client: MagicMock, role: str | None) -> None:
+    """organization_members からのロール取得チェーンのモックを設定する。"""
+    data = {"role": role} if role is not None else None
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = data
+
+
+@pytest.mark.api
+class TestMembersRouter:
+    """tenant/members ルーターの権限境界のテスト"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_admin_client(self):
+        return MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def override_dependency(self, mock_client, mock_admin_client):
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: mock_client
+        app.dependency_overrides[get_supabase_admin_client] = lambda: mock_admin_client
+        yield
+        app.dependency_overrides = {}
+
+    def test_list_members_forbidden_for_order_handler(self, headers, mock_client):
+        """GET /: president 以外は403"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.get("/tenant/members", headers=headers)
+
+        assert response.status_code == 403
+
+    def test_list_members_forbidden_for_iso_officer(self, headers, mock_client):
+        """GET /: iso_officer も閲覧・編集権限は無いため403"""
+        _set_role(mock_client, "iso_officer")
+
+        response = client.get("/tenant/members", headers=headers)
+
+        assert response.status_code == 403
+
+    def test_list_members_allowed_for_president(
+        self, headers, mock_client, mock_admin_client
+    ):
+        """GET /: president は一覧を取得できる"""
+        _set_role(mock_client, "president")
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
+
+        response = client.get("/tenant/members", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_member_forbidden_for_order_handler(self, headers, mock_client):
+        """POST /: president 以外は403"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.post(
+            "/tenant/members",
+            json={
+                "email": "new@example.com",
+                "password": "password123",
+                "full_name": "New User",
+                "role": "order_handler",
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 403
+
+    def test_delete_member_forbidden_for_order_handler(self, headers, mock_client):
+        """DELETE /{user_id}: president 以外は403"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.delete("/tenant/members/other-user-id", headers=headers)
+
+        assert response.status_code == 403

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -91,3 +91,60 @@ class TestMembersRouter:
         response = client.delete("/tenant/members/other-user-id", headers=headers)
 
         assert response.status_code == 403
+
+    def test_list_members_allowed_for_platform_admin(
+        self, headers, mock_client, mock_admin_client
+    ):
+        """GET /: platform_admin もメンバー一覧を取得できる"""
+        _set_role(mock_client, "platform_admin")
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
+
+        response = client.get("/tenant/members", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_member_allowed_for_platform_admin(
+        self, headers, mock_client, mock_admin_client
+    ):
+        """POST /: platform_admin もメンバーを追加できる"""
+        _set_role(mock_client, "platform_admin")
+        mock_admin_client.auth.admin.create_user.return_value.user.id = "new-user-id"
+
+        response = client.post(
+            "/tenant/members",
+            json={
+                "email": "new@example.com",
+                "password": "password123",
+                "full_name": "New User",
+                "role": "order_handler",
+            },
+            headers=headers,
+        )
+
+        assert response.status_code == 201
+
+    def test_update_member_self_demotion_blocked_for_platform_admin(
+        self, headers, mock_client
+    ):
+        """PATCH /{user_id}: platform_admin が自分自身のロールを変更しようとすると400"""
+        _set_role(mock_client, "platform_admin")
+
+        response = client.patch(
+            "/tenant/members/test-user-id",
+            json={"role": "order_handler"},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+
+    def test_delete_member_forbidden_when_last_platform_admin(
+        self, headers, mock_client
+    ):
+        """DELETE /{user_id}: テナントに platform_admin が1人しかいない場合は削除できない"""
+        _set_role(mock_client, "platform_admin")
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value.count = 1
+
+        response = client.delete("/tenant/members/other-user-id", headers=headers)
+
+        assert response.status_code == 400

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -40,7 +40,7 @@ class TestMembersRouter:
         app.dependency_overrides = {}
 
     def test_list_members_forbidden_for_order_handler(self, headers, mock_client):
-        """GET /: president 以外は403"""
+        """GET /: president / platform_admin 以外は403"""
         _set_role(mock_client, "order_handler")
 
         response = client.get("/tenant/members", headers=headers)
@@ -68,7 +68,7 @@ class TestMembersRouter:
         assert response.json() == []
 
     def test_create_member_forbidden_for_order_handler(self, headers, mock_client):
-        """POST /: president 以外は403"""
+        """POST /: president / platform_admin 以外は403"""
         _set_role(mock_client, "order_handler")
 
         response = client.post(
@@ -85,7 +85,7 @@ class TestMembersRouter:
         assert response.status_code == 403
 
     def test_delete_member_forbidden_for_order_handler(self, headers, mock_client):
-        """DELETE /{user_id}: president 以外は403"""
+        """DELETE /{user_id}: president / platform_admin 以外は403"""
         _set_role(mock_client, "order_handler")
 
         response = client.delete("/tenant/members/other-user-id", headers=headers)

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -123,7 +123,7 @@ def get_current_user_role(tenant_id: str, user_id: str, client: Client) -> str:
     """organization_members から現在ユーザーのロールを取得する。
 
     Returns:
-        "admin" または "member"
+        "president" / "iso_officer" / "order_handler" のいずれか
 
     Raises:
         HTTPException 403: テナントメンバーでない場合

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -123,7 +123,7 @@ def get_current_user_role(tenant_id: str, user_id: str, client: Client) -> str:
     """organization_members から現在ユーザーのロールを取得する。
 
     Returns:
-        "president" / "iso_officer" / "order_handler" のいずれか
+        "president" / "iso_officer" / "order_handler" / "platform_admin" のいずれか
 
     Raises:
         HTTPException 403: テナントメンバーでない場合

--- a/backend/app/models/tenant/member_schemas.py
+++ b/backend/app/models/tenant/member_schemas.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field
 
-MemberRole = Literal["president", "iso_officer", "order_handler"]
+MemberRole = Literal["president", "iso_officer", "order_handler", "platform_admin"]
 
 
 class MemberCreateSchema(BaseModel):

--- a/backend/app/models/tenant/member_schemas.py
+++ b/backend/app/models/tenant/member_schemas.py
@@ -2,6 +2,8 @@ from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field
 
+MemberRole = Literal["president", "iso_officer", "order_handler"]
+
 
 class MemberCreateSchema(BaseModel):
     """メンバー追加リクエストのスキーマ"""
@@ -9,14 +11,14 @@ class MemberCreateSchema(BaseModel):
     email: EmailStr = Field(description="メールアドレス")
     password: str = Field(min_length=8, description="初期パスワード")
     full_name: str = Field(description="氏名")
-    role: Literal["admin", "member"] = Field(default="member", description="権限")
+    role: MemberRole = Field(default="order_handler", description="権限")
 
 
 class MemberUpdateSchema(BaseModel):
     """メンバー更新リクエストのスキーマ"""
 
     full_name: str | None = Field(default=None, description="氏名")
-    role: Literal["admin", "member"] | None = Field(default=None, description="権限")
+    role: MemberRole | None = Field(default=None, description="権限")
 
 
 class MemberResponse(BaseModel):

--- a/backend/app/routers/master/process_routings.py
+++ b/backend/app/routers/master/process_routings.py
@@ -87,14 +87,14 @@ def update_process_routing(
     client: Client = Depends(get_supabase_client),
     repo: ProductRepository = Depends(get_product_repo),
 ):
-    """工程順序を更新。is_confirmed の変更は admin のみ可能"""
+    """工程順序を更新。is_confirmed の変更は president のみ可能"""
     logger.info(f"Updating process routing {routing_id}")
 
     update_dict = routing_data.model_dump(exclude_unset=True)
 
     if "is_confirmed" in update_dict:
         role = get_current_user_role(tenant_id, user_id, client)
-        if role != "admin":
+        if role != "president":
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="工程の確定・確定取消は管理者のみ操作できます",

--- a/backend/app/routers/master/products.py
+++ b/backend/app/routers/master/products.py
@@ -1,10 +1,17 @@
 # routers/master/products.py
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.dependencies import get_current_tenant_id, get_product_repo
+from app.dependencies import (
+    get_current_tenant_id,
+    get_current_user_id,
+    get_current_user_role,
+    get_product_repo,
+    get_supabase_client,
+)
 from app.models.master import ProductCreateSchema, ProductUpdateSchema
 from app.repositories.supa_infra.master.product_repo import ProductRepository
 from app.utils.logger import get_logger
+from supabase import Client  # type: ignore
 
 product_router = APIRouter(prefix="/products", tags=["Master (Products)"])
 
@@ -40,11 +47,25 @@ def get_product(product_id: int, repo: ProductRepository = Depends(get_product_r
 def update_product(
     product_id: int,
     product_data: ProductUpdateSchema,
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
     repo: ProductRepository = Depends(get_product_repo),
 ):
-    """製品を更新"""
+    """製品を更新。is_active の変更は president / platform_admin のみ可能"""
     logger.info(f"Updating product {product_id}")
-    return repo.update(product_id, product_data.model_dump(exclude_unset=True))
+
+    update_dict = product_data.model_dump(exclude_unset=True)
+
+    if "is_active" in update_dict:
+        role = get_current_user_role(tenant_id, user_id, client)
+        if role not in ("president", "platform_admin"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="製品の有効/無効の切り替えは president または platform_admin のみ操作できます",
+            )
+
+    return repo.update(product_id, update_dict)
 
 
 @product_router.delete("/{product_id}")

--- a/backend/app/routers/tenant/members.py
+++ b/backend/app/routers/tenant/members.py
@@ -17,15 +17,18 @@ member_router = APIRouter(prefix="/tenant/members", tags=["Tenant (Members)"])
 logger = get_logger(__name__)
 
 
-def _require_president(
+# メンバー管理(一覧閲覧・追加・変更・削除)を行える権限を持つロール。
+# platform_admin は閲覧全般・メンバー管理・設定サポートを担うが、承認操作は含めない
+# （承認系エンドポイントでは対象外とすること）。
+_MEMBER_ADMIN_ROLES = ("president", "platform_admin")
+
+
+def _require_member_admin(
     current_user_id: str,
     tenant_id: str,
     client: Client,
 ) -> None:
-    """現在のユーザーが対象テナントの president であることを検証する。
-
-    メンバー管理(メンバー一覧の閲覧・追加・変更・削除)は president 限定の操作。
-    """
+    """現在のユーザーが対象テナントでメンバー管理権限を持つことを検証する。"""
     res = (
         client.table("organization_members")
         .select("role")
@@ -34,10 +37,13 @@ def _require_president(
         .single()
         .execute()
     )
-    if not res.data or cast(dict[str, Any], res.data).get("role") != "president":
+    if (
+        not res.data
+        or cast(dict[str, Any], res.data).get("role") not in _MEMBER_ADMIN_ROLES
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="この操作には president 権限が必要です",
+            detail="この操作には president または platform_admin 権限が必要です",
         )
 
 
@@ -48,8 +54,8 @@ def list_members(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """テナントのメンバー一覧を取得する（president のみ）"""
-    _require_president(current_user_id, tenant_id, client)
+    """テナントのメンバー一覧を取得する（president / platform_admin のみ）"""
+    _require_member_admin(current_user_id, tenant_id, client)
 
     members_res = (
         admin_client.table("organization_members")
@@ -97,8 +103,8 @@ def create_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """新規メンバーをアカウント発行して追加する（president のみ）"""
-    _require_president(current_user_id, tenant_id, client)
+    """新規メンバーをアカウント発行して追加する（president / platform_admin のみ）"""
+    _require_member_admin(current_user_id, tenant_id, client)
 
     # Supabase Admin API でユーザーを作成
     try:
@@ -161,19 +167,8 @@ def update_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """メンバーの氏名・権限を変更する（president のみ）"""
-    _require_president(current_user_id, tenant_id, client)
-
-    # 自分自身の president 権限降格を禁止
-    if (
-        user_id == current_user_id
-        and data.role is not None
-        and data.role != "president"
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="自分自身の権限を降格させることはできません",
-        )
+    """メンバーの氏名・権限を変更する（president / platform_admin のみ）"""
+    _require_member_admin(current_user_id, tenant_id, client)
 
     # 対象ユーザーが同テナントに所属しているか確認
     member_res = (
@@ -188,24 +183,37 @@ def update_member(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="メンバーが見つかりません"
         )
+    current_role = cast(dict[str, Any], member_res.data).get("role")
 
-    # role 変更の場合、president が0人になることを防ぐ
+    # 自分自身のメンバー管理権限(president/platform_admin)の降格を禁止
+    if (
+        user_id == current_user_id
+        and data.role is not None
+        and current_role in _MEMBER_ADMIN_ROLES
+        and data.role != current_role
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="自分自身の権限を降格させることはできません",
+        )
+
+    # role 変更の場合、president/platform_admin がそれぞれ0人になることを防ぐ
     if (
         data.role is not None
-        and data.role != "president"
-        and cast(dict[str, Any], member_res.data).get("role") == "president"
+        and data.role != current_role
+        and current_role in _MEMBER_ADMIN_ROLES
     ):
-        president_count_res = (
+        role_count_res = (
             client.table("organization_members")
             .select("user_id", count="exact")  # type: ignore[arg-type]
             .eq("tenant_id", tenant_id)
-            .eq("role", "president")
+            .eq("role", current_role)
             .execute()
         )
-        if (president_count_res.count or 0) <= 1:
+        if (role_count_res.count or 0) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="テナントに president が0人になるような変更はできません",
+                detail=f"テナントに {current_role} が0人になるような変更はできません",
             )
 
     updates: dict[str, Any] = {}
@@ -250,8 +258,8 @@ def delete_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """メンバーをテナントから削除する（president のみ、自分自身は削除不可）"""
-    _require_president(current_user_id, tenant_id, client)
+    """メンバーをテナントから削除する（president / platform_admin のみ、自分自身は削除不可）"""
+    _require_member_admin(current_user_id, tenant_id, client)
 
     if user_id == current_user_id:
         raise HTTPException(
@@ -273,19 +281,20 @@ def delete_member(
             status_code=status.HTTP_404_NOT_FOUND, detail="メンバーが見つかりません"
         )
 
-    # president を削除する場合、president が0人になることを防ぐ
-    if cast(dict[str, Any], member_res.data).get("role") == "president":
-        president_count_res = (
+    # president/platform_admin を削除する場合、それぞれが0人になることを防ぐ
+    current_role = cast(dict[str, Any], member_res.data).get("role")
+    if current_role in _MEMBER_ADMIN_ROLES:
+        role_count_res = (
             client.table("organization_members")
             .select("user_id", count="exact")  # type: ignore[arg-type]
             .eq("tenant_id", tenant_id)
-            .eq("role", "president")
+            .eq("role", current_role)
             .execute()
         )
-        if (president_count_res.count or 0) <= 1:
+        if (role_count_res.count or 0) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="テナントに president が0人になるような削除はできません",
+                detail=f"テナントに {current_role} が0人になるような削除はできません",
             )
 
     # organization_members から削除（テナント紐付けを解除）

--- a/backend/app/routers/tenant/members.py
+++ b/backend/app/routers/tenant/members.py
@@ -17,12 +17,15 @@ member_router = APIRouter(prefix="/tenant/members", tags=["Tenant (Members)"])
 logger = get_logger(__name__)
 
 
-def _require_admin(
+def _require_president(
     current_user_id: str,
     tenant_id: str,
     client: Client,
 ) -> None:
-    """現在のユーザーが対象テナントの admin であることを検証する。"""
+    """現在のユーザーが対象テナントの president であることを検証する。
+
+    メンバー管理(メンバー一覧の閲覧・追加・変更・削除)は president 限定の操作。
+    """
     res = (
         client.table("organization_members")
         .select("role")
@@ -31,10 +34,10 @@ def _require_admin(
         .single()
         .execute()
     )
-    if not res.data or cast(dict[str, Any], res.data).get("role") != "admin":
+    if not res.data or cast(dict[str, Any], res.data).get("role") != "president":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="この操作には admin 権限が必要です",
+            detail="この操作には president 権限が必要です",
         )
 
 
@@ -45,8 +48,8 @@ def list_members(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """テナントのメンバー一覧を取得する（admin のみ）"""
-    _require_admin(current_user_id, tenant_id, client)
+    """テナントのメンバー一覧を取得する（president のみ）"""
+    _require_president(current_user_id, tenant_id, client)
 
     members_res = (
         admin_client.table("organization_members")
@@ -94,8 +97,8 @@ def create_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """新規メンバーをアカウント発行して追加する（admin のみ）"""
-    _require_admin(current_user_id, tenant_id, client)
+    """新規メンバーをアカウント発行して追加する（president のみ）"""
+    _require_president(current_user_id, tenant_id, client)
 
     # Supabase Admin API でユーザーを作成
     try:
@@ -158,11 +161,15 @@ def update_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """メンバーの氏名・権限を変更する（admin のみ）"""
-    _require_admin(current_user_id, tenant_id, client)
+    """メンバーの氏名・権限を変更する（president のみ）"""
+    _require_president(current_user_id, tenant_id, client)
 
-    # 自分自身の権限降格を禁止
-    if user_id == current_user_id and data.role == "member":
+    # 自分自身の president 権限降格を禁止
+    if (
+        user_id == current_user_id
+        and data.role is not None
+        and data.role != "president"
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="自分自身の権限を降格させることはできません",
@@ -182,22 +189,23 @@ def update_member(
             status_code=status.HTTP_404_NOT_FOUND, detail="メンバーが見つかりません"
         )
 
-    # role 変更の場合、admin が0人になることを防ぐ
+    # role 変更の場合、president が0人になることを防ぐ
     if (
-        data.role == "member"
-        and cast(dict[str, Any], member_res.data).get("role") == "admin"
+        data.role is not None
+        and data.role != "president"
+        and cast(dict[str, Any], member_res.data).get("role") == "president"
     ):
-        admin_count_res = (
+        president_count_res = (
             client.table("organization_members")
             .select("user_id", count="exact")  # type: ignore[arg-type]
             .eq("tenant_id", tenant_id)
-            .eq("role", "admin")
+            .eq("role", "president")
             .execute()
         )
-        if (admin_count_res.count or 0) <= 1:
+        if (president_count_res.count or 0) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="テナントに admin が0人になるような変更はできません",
+                detail="テナントに president が0人になるような変更はできません",
             )
 
     updates: dict[str, Any] = {}
@@ -242,8 +250,8 @@ def delete_member(
     client: Client = Depends(get_supabase_client),
     admin_client: Client = Depends(get_supabase_admin_client),
 ):
-    """メンバーをテナントから削除する（admin のみ、自分自身は削除不可）"""
-    _require_admin(current_user_id, tenant_id, client)
+    """メンバーをテナントから削除する（president のみ、自分自身は削除不可）"""
+    _require_president(current_user_id, tenant_id, client)
 
     if user_id == current_user_id:
         raise HTTPException(
@@ -265,19 +273,19 @@ def delete_member(
             status_code=status.HTTP_404_NOT_FOUND, detail="メンバーが見つかりません"
         )
 
-    # admin を削除する場合、admin が0人になることを防ぐ
-    if cast(dict[str, Any], member_res.data).get("role") == "admin":
-        admin_count_res = (
+    # president を削除する場合、president が0人になることを防ぐ
+    if cast(dict[str, Any], member_res.data).get("role") == "president":
+        president_count_res = (
             client.table("organization_members")
             .select("user_id", count="exact")  # type: ignore[arg-type]
             .eq("tenant_id", tenant_id)
-            .eq("role", "admin")
+            .eq("role", "president")
             .execute()
         )
-        if (admin_count_res.count or 0) <= 1:
+        if (president_count_res.count or 0) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="テナントに admin が0人になるような削除はできません",
+                detail="テナントに president が0人になるような削除はできません",
             )
 
     # organization_members から削除（テナント紐付けを解除）

--- a/docs/features/member-roles.md
+++ b/docs/features/member-roles.md
@@ -1,0 +1,62 @@
+# メンバーロールの三値拡張（president/iso_officer/order_handler）
+
+Issue #323 で実装。受注確認・承認ワークフロー（#322）の権限基盤として、`organization_members.role` を
+`admin`/`member` の二値から `president` / `iso_officer` / `order_handler` の三値に拡張した。
+
+## ロール定義
+
+| ロール | 想定業務 | 権限 |
+|---|---|---|
+| `president`（社長） | 受注承認・却下、メンバー管理、工程マスタ編集 | 旧 `admin` 権限一式 + 監査ログ閲覧 |
+| `iso_officer`（ISO担当） | 承認プロセスの監査証跡の閲覧・出力 | 閲覧・出力のみ（編集・承認・メンバー管理は不可） |
+| `order_handler`（受注担当） | 下書き注文の表記揺れ修正、承認依頼の送信 | 上記操作のみ（承認・メンバー管理は不可） |
+
+`iso_officer` の監査ログ閲覧・出力機能自体は本Issueのスコープ外（#322 以降で実装予定）。本Issueでは
+ロール値の追加と、既存の `admin` 限定操作の権限判定の付け替えまでを行う。
+
+## 既存データの移行方針
+
+`supabase/migrations/20260810000000_expand_member_roles.sql` にて機械的に読み替える:
+
+- `admin` → `president`（受注承認・メンバー管理などの既存 admin 権限一式をそのまま引き継ぐため）
+- `member` → `order_handler`（表記揺れ修正・承認依頼送信という現行の一般メンバー運用に相当するため）
+
+同マイグレーションで `organization_members.role` に `CHECK (role IN ('president','iso_officer','order_handler'))`
+制約を追加し、カラムのデフォルト値も `order_handler` に変更。サインアップ時のトリガー関数
+（`handle_new_user`）が最初のメンバーに付与するロールも `president` に変更した。
+
+## Backend
+
+### 権限チェック
+
+- `backend/app/dependencies.py` の `get_current_user_role()`: 返り値の想定を三値に更新（ロジックは変更なし）
+- `backend/app/routers/tenant/members.py`: `_require_admin` を `_require_president` にリネーム。メンバー管理系エンドポイント
+  （一覧取得・追加・更新・削除）はすべて `president` 限定のまま。「テナントに president が0人になる変更/削除を禁止」する
+  ガード（旧: admin 0人ガード）も同様に読み替え
+- `backend/app/routers/master/process_routings.py`: `PATCH /process-routings/{id}` で `is_confirmed` を変更できるのは
+  `president` のみ（旧: `admin`）
+
+### スキーマ
+
+`backend/app/models/tenant/member_schemas.py` に `MemberRole = Literal["president", "iso_officer", "order_handler"]` を追加し、
+`MemberCreateSchema` / `MemberUpdateSchema` の `role` フィールドの型として使用。新規メンバーのデフォルトロールは `order_handler`。
+
+### テスト
+
+- `backend/__tests__/api/routers/tenant/test_members.py`（新規）: `order_handler` / `iso_officer` がメンバー管理系
+  エンドポイントで403になること、`president` は許可されることを検証
+- `backend/__tests__/api/routers/master/test_process_routings.py`: `is_confirmed` 変更が `president` 以外で403、
+  `president` で成功することを検証するテストを追加
+
+## Frontend
+
+- `frontend/src/types/member.ts`: `MemberRole` を三値に変更
+- `frontend/src/app/settings/members/page.tsx`: ロール選択肢・バッジ表示を三値に対応（社長=default、ISO担当=outline、
+  受注担当=secondary のバッジ variant）。新規追加時のデフォルトロールは `order_handler`
+- `frontend/src/app/master/products/page.tsx`, `frontend/src/components/product-routings-dialog.tsx`:
+  `isAdmin` 判定を `currentMember?.role === "president"` に変更（工程確定操作・製品の有効/無効化操作の表示制御）
+
+## スコープ外（今後のIssueで対応）
+
+- `iso_officer` 向けの監査ログ・承認履歴閲覧UI/APIの実装
+- 受注承認・却下ワークフロー本体（#322）

--- a/docs/features/member-roles.md
+++ b/docs/features/member-roles.md
@@ -1,7 +1,7 @@
-# メンバーロールの三値拡張（president/iso_officer/order_handler）
+# メンバーロールの四値拡張（president/iso_officer/order_handler/platform_admin）
 
 Issue #323 で実装。受注確認・承認ワークフロー（#322）の権限基盤として、`organization_members.role` を
-`admin`/`member` の二値から `president` / `iso_officer` / `order_handler` の三値に拡張した。
+`admin`/`member` の二値から `president` / `iso_officer` / `order_handler` / `platform_admin` の四値に拡張した。
 
 ## ロール定義
 
@@ -10,9 +10,14 @@ Issue #323 で実装。受注確認・承認ワークフロー（#322）の権�
 | `president`（社長） | 受注承認・却下、メンバー管理、工程マスタ編集 | 旧 `admin` 権限一式 + 監査ログ閲覧 |
 | `iso_officer`（ISO担当） | 承認プロセスの監査証跡の閲覧・出力 | 閲覧・出力のみ（編集・承認・メンバー管理は不可） |
 | `order_handler`（受注担当） | 下書き注文の表記揺れ修正、承認依頼の送信 | 上記操作のみ（承認・メンバー管理は不可） |
+| `platform_admin`（プラットフォーム管理者） | 閲覧全般、メンバー管理、設定サポート | 承認操作（受注承認・工程確定等）は含めない |
 
 `iso_officer` の監査ログ閲覧・出力機能自体は本Issueのスコープ外（#322 以降で実装予定）。本Issueでは
 ロール値の追加と、既存の `admin` 限定操作の権限判定の付け替えまでを行う。
+
+`platform_admin` はプラットフォーム運営側がテナントの設定・メンバー管理をサポートするためのロール。
+メンバー管理系エンドポイント（`tenant/members.py`）は `president` と同等の権限を持つが、承認操作
+（工程確定 `is_confirmed` トグル等）には含めない。
 
 ## 既存データの移行方針
 
@@ -25,36 +30,49 @@ Issue #323 で実装。受注確認・承認ワークフロー（#322）の権�
 制約を追加し、カラムのデフォルト値も `order_handler` に変更。サインアップ時のトリガー関数
 （`handle_new_user`）が最初のメンバーに付与するロールも `president` に変更した。
 
+続く `supabase/migrations/20260810000001_add_platform_admin_role.sql` で CHECK 制約に `platform_admin` を追加。
+`platform_admin` は既存データの機械移行対象ではなく、必要なテナントに手動で付与する想定。
+
 ## Backend
 
 ### 権限チェック
 
-- `backend/app/dependencies.py` の `get_current_user_role()`: 返り値の想定を三値に更新（ロジックは変更なし）
-- `backend/app/routers/tenant/members.py`: `_require_admin` を `_require_president` にリネーム。メンバー管理系エンドポイント
-  （一覧取得・追加・更新・削除）はすべて `president` 限定のまま。「テナントに president が0人になる変更/削除を禁止」する
-  ガード（旧: admin 0人ガード）も同様に読み替え
+- `backend/app/dependencies.py` の `get_current_user_role()`: 返り値の想定を四値に更新（ロジックは変更なし）
+- `backend/app/routers/tenant/members.py`: `_require_admin` を `_require_member_admin` にリネームし、
+  `president` または `platform_admin` を許可するよう変更（`_MEMBER_ADMIN_ROLES` 定数）。メンバー管理系
+  エンドポイント（一覧取得・追加・更新・削除）はこの2ロールに開放
+  - 「自分自身のメンバー管理権限（president/platform_admin）を降格できない」ガードは、呼び出しユーザー
+    自身が現在持つロールを基準に判定するよう一般化（例: platform_admin が自分のロールを order_handler に
+    変更しようとすると400）
+  - 「テナントに該当ロールが0人になる変更/削除を禁止」するガードも president/platform_admin それぞれ独立に
+    適用（例: platform_admin が1人しかいないテナントでその platform_admin を削除しようとすると400）
 - `backend/app/routers/master/process_routings.py`: `PATCH /process-routings/{id}` で `is_confirmed` を変更できるのは
-  `president` のみ（旧: `admin`）
+  `president` のみ（`platform_admin` は対象外 — 承認操作は含めない方針のため）
 
 ### スキーマ
 
-`backend/app/models/tenant/member_schemas.py` に `MemberRole = Literal["president", "iso_officer", "order_handler"]` を追加し、
+`backend/app/models/tenant/member_schemas.py` に
+`MemberRole = Literal["president", "iso_officer", "order_handler", "platform_admin"]` を定義し、
 `MemberCreateSchema` / `MemberUpdateSchema` の `role` フィールドの型として使用。新規メンバーのデフォルトロールは `order_handler`。
 
 ### テスト
 
-- `backend/__tests__/api/routers/tenant/test_members.py`（新規）: `order_handler` / `iso_officer` がメンバー管理系
-  エンドポイントで403になること、`president` は許可されることを検証
+- `backend/__tests__/api/routers/tenant/test_members.py`: `order_handler` / `iso_officer` がメンバー管理系
+  エンドポイントで403になること、`president` / `platform_admin` は許可されることを検証。platform_admin の
+  自己降格禁止・最後の1人削除禁止のガードも検証
 - `backend/__tests__/api/routers/master/test_process_routings.py`: `is_confirmed` 変更が `president` 以外で403、
   `president` で成功することを検証するテストを追加
 
 ## Frontend
 
-- `frontend/src/types/member.ts`: `MemberRole` を三値に変更
-- `frontend/src/app/settings/members/page.tsx`: ロール選択肢・バッジ表示を三値に対応（社長=default、ISO担当=outline、
-  受注担当=secondary のバッジ variant）。新規追加時のデフォルトロールは `order_handler`
-- `frontend/src/app/master/products/page.tsx`, `frontend/src/components/product-routings-dialog.tsx`:
-  `isAdmin` 判定を `currentMember?.role === "president"` に変更（工程確定操作・製品の有効/無効化操作の表示制御）
+- `frontend/src/types/member.ts`: `MemberRole` を四値に変更
+- `frontend/src/app/settings/members/page.tsx`: ロール選択肢・バッジ表示を四値に対応（社長=default、
+  ISO担当=outline、受注担当=secondary、プラットフォーム管理者=outline のバッジ variant）。新規追加時の
+  デフォルトロールは `order_handler`
+- `frontend/src/app/master/products/page.tsx`: `isAdmin` 判定を `role === "president" || role === "platform_admin"`
+  に変更（製品の有効/無効化操作の表示制御。設定サポート業務に該当するため platform_admin にも開放）
+- `frontend/src/components/product-routings-dialog.tsx`: `isAdmin` 判定は `role === "president"` のまま
+  （工程確定 `is_confirmed` トグルの表示制御。バックエンドの承認操作制限と一致させ、platform_admin には開放しない）
 
 ## スコープ外（今後のIssueで対応）
 

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -4,7 +4,10 @@ Issue #197 / #199 / #200 で実装。
 
 ## 概要
 
-工程ルーティング（`process_routings`）に確定フラグを追加し、`admin` ロールのみが確定操作を行えるよう制限する機能。
+工程ルーティング（`process_routings`）に確定フラグを追加し、`president` ロールのみが確定操作を行えるよう制限する機能。
+
+> [!NOTE]
+> Issue #323 でロールを `admin`/`member` の二値から `president`/`iso_officer`/`order_handler` の三値に拡張したのに伴い、確定操作の権限判定は `admin` → `president` に読み替えられている（[member-roles.md](member-roles.md) 参照）。
 
 ## DB スキーマ変更
 
@@ -26,7 +29,7 @@ Issue #197 / #199 / #200 で実装。
 
 `PATCH /process-routings/{id}` で `is_confirmed` を含むリクエストの場合:
 - 呼び出し元ユーザーのロールを確認
-- `admin` でなければ HTTP 403 を返す
+- `president` でなければ HTTP 403 を返す
 - `is_confirmed=true` の場合、`confirmed_by` と `confirmed_at` を自動セット
 - `is_confirmed=false`（取消）の場合、両フィールドを NULL にリセット
 
@@ -39,8 +42,8 @@ Issue #197 / #199 / #200 で実装。
 ### UI（`product-routings-dialog.tsx`）
 
 - 工程リストに「確定」列を追加
-  - `admin` ユーザー: チェックボックス形式のトグルボタンを表示。クリックで確定/取消
-  - `member` ユーザー: 鍵アイコン（`Lock`）を表示し操作不可
+  - `president` ユーザー: チェックボックス形式のトグルボタンを表示。クリックで確定/取消
+  - それ以外のロール: 鍵アイコン（`Lock`）を表示し操作不可
 - 確定済み工程の工程名に緑色バッジ（「確定済み」）を表示
 - 確定取消時は AlertDialog で「確定を取り消しますか？」確認ダイアログを表示
 - `useCurrentMember()` フックでロールを判定

--- a/docs/features/process-routing-confirmation.md
+++ b/docs/features/process-routing-confirmation.md
@@ -7,7 +7,7 @@ Issue #197 / #199 / #200 で実装。
 工程ルーティング（`process_routings`）に確定フラグを追加し、`president` ロールのみが確定操作を行えるよう制限する機能。
 
 > [!NOTE]
-> Issue #323 でロールを `admin`/`member` の二値から `president`/`iso_officer`/`order_handler` の三値に拡張したのに伴い、確定操作の権限判定は `admin` → `president` に読み替えられている（[member-roles.md](member-roles.md) 参照）。
+> Issue #323 でロールを `admin`/`member` の二値から `president`/`iso_officer`/`order_handler`/`platform_admin` の四値に拡張したのに伴い、確定操作の権限判定は `admin` → `president` に読み替えられている（`platform_admin` は承認操作を含まないため対象外。[member-roles.md](member-roles.md) 参照）。
 
 ## DB スキーマ変更
 

--- a/frontend/src/app/master/products/page.tsx
+++ b/frontend/src/app/master/products/page.tsx
@@ -83,7 +83,8 @@ export default function ProductsPage() {
 
   const { data: products, isLoading, error } = useProducts()
   const { data: currentMember } = useCurrentMember()
-  const isAdmin = currentMember?.role === "president"
+  const isAdmin =
+    currentMember?.role === "president" || currentMember?.role === "platform_admin"
 
   const createMutation = useCreateProduct()
   const updateMutation = useUpdateProduct()

--- a/frontend/src/app/master/products/page.tsx
+++ b/frontend/src/app/master/products/page.tsx
@@ -83,7 +83,7 @@ export default function ProductsPage() {
 
   const { data: products, isLoading, error } = useProducts()
   const { data: currentMember } = useCurrentMember()
-  const isAdmin = currentMember?.role === "admin"
+  const isAdmin = currentMember?.role === "president"
 
   const createMutation = useCreateProduct()
   const updateMutation = useUpdateProduct()

--- a/frontend/src/app/settings/members/page.tsx
+++ b/frontend/src/app/settings/members/page.tsx
@@ -52,12 +52,14 @@ const ROLE_LABELS: Record<MemberRole, string> = {
   president: "社長",
   iso_officer: "ISO担当",
   order_handler: "受注担当",
+  platform_admin: "プラットフォーム管理者",
 }
 
 const ROLE_BADGE_VARIANTS: Record<MemberRole, "default" | "secondary" | "outline"> = {
   president: "default",
   iso_officer: "outline",
   order_handler: "secondary",
+  platform_admin: "outline",
 }
 
 /**
@@ -355,6 +357,7 @@ export default function MembersPage() {
                     <SelectItem value="order_handler">受注担当</SelectItem>
                     <SelectItem value="iso_officer">ISO担当</SelectItem>
                     <SelectItem value="president">社長</SelectItem>
+                    <SelectItem value="platform_admin">プラットフォーム管理者</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -435,6 +438,7 @@ export default function MembersPage() {
                   <SelectItem value="order_handler">受注担当</SelectItem>
                   <SelectItem value="iso_officer">ISO担当</SelectItem>
                   <SelectItem value="president">社長</SelectItem>
+                  <SelectItem value="platform_admin">プラットフォーム管理者</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/app/settings/members/page.tsx
+++ b/frontend/src/app/settings/members/page.tsx
@@ -48,6 +48,18 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 
+const ROLE_LABELS: Record<MemberRole, string> = {
+  president: "社長",
+  iso_officer: "ISO担当",
+  order_handler: "受注担当",
+}
+
+const ROLE_BADGE_VARIANTS: Record<MemberRole, "default" | "secondary" | "outline"> = {
+  president: "default",
+  iso_officer: "outline",
+  order_handler: "secondary",
+}
+
 /**
  * パスワードをセキュアにランダム生成するユーティリティ
  * 英字大小・数字・記号を含む12文字
@@ -93,12 +105,12 @@ export default function MembersPage() {
   // 追加フォームの状態
   const [newEmail, setNewEmail] = useState("")
   const [newFullName, setNewFullName] = useState("")
-  const [newRole, setNewRole] = useState<MemberRole>("member")
+  const [newRole, setNewRole] = useState<MemberRole>("order_handler")
   const [newPassword, setNewPassword] = useState("")
 
   // 編集フォームの状態
   const [editFullName, setEditFullName] = useState("")
-  const [editRole, setEditRole] = useState<MemberRole>("member")
+  const [editRole, setEditRole] = useState<MemberRole>("order_handler")
 
   const { data: members, isLoading, error } = useTenantMembers()
   const createMutation = useCreateTenantMember()
@@ -109,7 +121,7 @@ export default function MembersPage() {
   const handleOpenCreateDialog = () => {
     setNewEmail("")
     setNewFullName("")
-    setNewRole("member")
+    setNewRole("order_handler")
     setNewPassword(generatePassword())
     setCreatedPassword(null)
     setIsCreateDialogOpen(true)
@@ -231,10 +243,8 @@ export default function MembersPage() {
                     <TableCell>{member.full_name ?? "—"}</TableCell>
                     <TableCell>{member.email}</TableCell>
                     <TableCell>
-                      <Badge
-                        variant={member.role === "admin" ? "default" : "secondary"}
-                      >
-                        {member.role === "admin" ? "管理者" : "メンバー"}
+                      <Badge variant={ROLE_BADGE_VARIANTS[member.role]}>
+                        {ROLE_LABELS[member.role]}
                       </Badge>
                     </TableCell>
                     <TableCell className="text-right">
@@ -342,8 +352,9 @@ export default function MembersPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="member">メンバー</SelectItem>
-                    <SelectItem value="admin">管理者</SelectItem>
+                    <SelectItem value="order_handler">受注担当</SelectItem>
+                    <SelectItem value="iso_officer">ISO担当</SelectItem>
+                    <SelectItem value="president">社長</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -421,8 +432,9 @@ export default function MembersPage() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="member">メンバー</SelectItem>
-                  <SelectItem value="admin">管理者</SelectItem>
+                  <SelectItem value="order_handler">受注担当</SelectItem>
+                  <SelectItem value="iso_officer">ISO担当</SelectItem>
+                  <SelectItem value="president">社長</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/components/product-routings-dialog.tsx
+++ b/frontend/src/components/product-routings-dialog.tsx
@@ -120,7 +120,7 @@ export function ProductRoutingsDialog({
   const { data: equipmentGroups, isLoading: isLoadingGroups } = useEquipmentGroups()
   const { data: currentMember } = useCurrentMember()
 
-  const isAdmin = currentMember?.role === "admin"
+  const isAdmin = currentMember?.role === "president"
 
   // ミューテーション
   const updateMutation = useUpdateProcessRouting()

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,4 +1,8 @@
-export type MemberRole = "president" | "iso_officer" | "order_handler"
+export type MemberRole =
+  | "president"
+  | "iso_officer"
+  | "order_handler"
+  | "platform_admin"
 
 export interface TenantMember {
   user_id: string

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -1,4 +1,4 @@
-export type MemberRole = "admin" | "member"
+export type MemberRole = "president" | "iso_officer" | "order_handler"
 
 export interface TenantMember {
   user_id: string

--- a/supabase/migrations/20260810000000_expand_member_roles.sql
+++ b/supabase/migrations/20260810000000_expand_member_roles.sql
@@ -1,0 +1,50 @@
+-- ==========================================
+-- ロール拡張: admin/member の二値から
+-- president / iso_officer / order_handler の三値へ移行
+--
+-- 移行方針:
+--   admin  -> president     (受注承認・メンバー管理・工程マスタ編集などの既存 admin 権限一式を引き継ぐ)
+--   member -> order_handler (下書き注文の表記揺れ修正・承認依頼送信を担当する現行運用に相当)
+-- ==========================================
+
+-- 既存データの移行
+update organization_members set role = 'president' where role = 'admin';
+update organization_members set role = 'order_handler' where role = 'member';
+
+-- 新ロール値のみを許可する CHECK 制約を追加
+alter table organization_members
+  add constraint organization_members_role_check
+  check (role in ('president', 'iso_officer', 'order_handler'));
+
+-- 新規メンバーのデフォルトロールを order_handler に変更
+alter table organization_members
+  alter column role set default 'order_handler';
+
+-- サインアップ時に作成される最初のメンバーは president（テナントの代表者）とする
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = ''
+as $$
+declare
+  new_tenant_id uuid;
+  tenant_name text;
+begin
+  tenant_name := new.raw_user_meta_data->>'tenant_name';
+
+  if tenant_name is not null and tenant_name <> '' then
+    begin
+      insert into public.tenants (name)
+      values (tenant_name)
+      returning id into new_tenant_id;
+
+      insert into public.organization_members (user_id, tenant_id, role)
+      values (new.id, new_tenant_id, 'president');
+    exception when others then
+      raise exception 'テナント作成に失敗しました: %', sqlerrm;
+    end;
+  end if;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260810000001_add_platform_admin_role.sql
+++ b/supabase/migrations/20260810000001_add_platform_admin_role.sql
@@ -1,0 +1,13 @@
+-- ==========================================
+-- platform_admin ロールの追加
+--
+-- 閲覧全般・メンバー管理・設定サポート等を担うプラットフォーム運営側の
+-- サポートロール。ただし承認操作（受注承認・工程確定等）は含めない。
+-- ==========================================
+
+alter table organization_members
+  drop constraint organization_members_role_check;
+
+alter table organization_members
+  add constraint organization_members_role_check
+  check (role in ('president', 'iso_officer', 'order_handler', 'platform_admin'));


### PR DESCRIPTION
## 概要
Closes #323

受注確認・承認ワークフロー導入（#322）の基盤として、既存の `admin`/`member` 二値ロールを `president`（社長） / `iso_officer`（ISO担当） / `order_handler`（受注担当） / `platform_admin`（プラットフォーム管理者）の四ロールに拡張しました。

## 変更内容

### DB
- `supabase/migrations/20260810000000_expand_member_roles.sql`
  - 既存ロールの移行: `admin` → `president`、`member` → `order_handler`（機械的に読み替え）
  - `organization_members.role` に `CHECK (role IN ('president','iso_officer','order_handler'))` を追加
  - デフォルトロールを `order_handler` に変更
  - サインアップトリガー（`handle_new_user`）が最初のメンバーに付与するロールを `president` に変更
- `supabase/migrations/20260810000001_add_platform_admin_role.sql`
  - CHECK 制約に `platform_admin` を追加

### Backend
- `app/models/tenant/member_schemas.py`: `MemberRole` 型を四値 (`president`/`iso_officer`/`order_handler`/`platform_admin`) に変更
- `app/routers/tenant/members.py`: `_require_admin` → `_require_member_admin` にリネームし、`president` または `platform_admin` を許可する `_MEMBER_ADMIN_ROLES` で判定。メンバー管理系エンドポイント（一覧・追加・更新・削除）をこの2ロールに開放
  - 「自分自身のメンバー管理権限を降格できない」「テナントに該当ロールが0人になる変更/削除を禁止」の各ガードを、president/platform_admin それぞれに独立して適用するよう一般化
- `app/routers/master/process_routings.py`: `is_confirmed`（工程確定）の変更を `president` 限定に変更（旧: `admin`）。`platform_admin` は承認操作を含まない方針のため対象外
- `app/routers/master/products.py`: `is_active`（有効/無効）の変更を `president`/`platform_admin` 限定に変更（旧: 誰でも可）。フロントエンドの表示制御のみで実際のAPIには制限が無かったため、レビュー指摘を受けてバックエンド側でも強制するよう追加
- `app/dependencies.py`: `get_current_user_role()` のdocstring更新

### Frontend
- `types/member.ts`: `MemberRole` を四値に変更
- `app/settings/members/page.tsx`: ロール選択肢・バッジ表示を四値対応（社長/ISO担当/受注担当/プラットフォーム管理者）
- `app/master/products/page.tsx`: `isAdmin` 判定を `role === "president" || role === "platform_admin"` に変更
- `components/product-routings-dialog.tsx`: `isAdmin` 判定を `role === "president"` のまま維持（工程確定は承認操作のため platform_admin には開放しない）

### テスト
- `__tests__/api/routers/tenant/test_members.py`（新規）: `order_handler`/`iso_officer` がメンバー管理系エンドポイントで403、`president`/`platform_admin` は許可されることを検証。platform_admin の自己降格禁止・最後の1人削除禁止のガードも検証
- `__tests__/api/routers/master/test_process_routings.py`: `is_confirmed` 変更の権限境界（president以外403、president成功）を検証
- `__tests__/api/routers/master/test_products_router.py`: `is_active` 変更の権限境界（president/platform_admin以外403、両ロールで成功）を検証

### ドキュメント
- `docs/features/member-roles.md`（新規）: ロール定義・移行方針・変更箇所をまとめたドキュメント
- `docs/features/process-routing-confirmation.md`: `admin`/`member` の記述を `president` に更新

## スコープ外
- `iso_officer` 向けの監査ログ・承認履歴閲覧UI/API（今後のIssueで対応）
- 受注承認・却下ワークフロー本体（#322）

## Test plan
- [x] `pytest __tests__/unit __tests__/api` — 374件全通過
- [x] `ruff check` / `mypy` — 変更ファイルに新規指摘なし
- [x] `npx tsc --noEmit` — フロントエンド型チェック通過
- [x] ローカル Supabase 環境でマイグレーション適用を確認（CHECK制約・デフォルト値・サインアップトリガーの動作を確認済み）