### PR TITLE
feat: 受注ステータス軸に pending_approval を追加 (Issue #324)

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -302,7 +302,7 @@ class TestOrderRouter:
             "product_id": 100,
             "quantity": 10,
             "order_number": "ORD-001",
-            "status": "draft",
+            "status": "pending_approval",
         }
 
         # Mockの設定
@@ -361,6 +361,23 @@ class TestOrderRouter:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Order not found"
+
+    def test_confirm_order_invalid_transition_from_draft(self, headers, mock_repo):
+        """POST /{order_id}/confirm: draftから直接confirmedへの遷移は拒否される (Issue #324)"""
+        order_id = 1
+        order_data = {
+            "id": order_id,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "draft",
+        }
+        mock_repo.get_by_id.return_value = order_data
+
+        response = client.post(f"/orders/{order_id}/confirm", headers=headers)
+
+        assert response.status_code == 400
+        mock_repo.update.assert_not_called()
 
     def test_split_order_not_found(self, headers, mock_repo):
         """POST /{order_id}/split: 注文が存在しない場合の404エラーテスト"""

--- a/backend/__tests__/unit/services/test_order_status_service.py
+++ b/backend/__tests__/unit/services/test_order_status_service.py
@@ -1,0 +1,45 @@
+# __tests__/unit/services/test_order_status_service.py
+import pytest
+from app.services.order_status_service import (
+    InvalidOrderStatusTransitionError,
+    validate_order_status_transition,
+)
+
+
+@pytest.mark.unit
+class TestOrderStatusService:
+    """orders.status 遷移バリデーションのユニットテスト (Issue #324)"""
+
+    @pytest.mark.parametrize(
+        ("current_status", "new_status"),
+        [
+            ("draft", "pending_approval"),
+            ("pending_approval", "confirmed"),
+            ("pending_approval", "draft"),
+            ("confirmed", "completed"),
+            ("confirmed", "canceled"),
+        ],
+    )
+    def test_allowed_transitions(self, current_status, new_status):
+        """順方向遷移および差し戻し(pending_approval->draft)は許可される"""
+        validate_order_status_transition(current_status, new_status)
+
+    @pytest.mark.parametrize(
+        ("current_status", "new_status"),
+        [
+            ("draft", "confirmed"),
+            ("draft", "completed"),
+            ("draft", "canceled"),
+            ("pending_approval", "completed"),
+            ("pending_approval", "canceled"),
+            ("confirmed", "pending_approval"),
+            ("confirmed", "draft"),
+            ("completed", "confirmed"),
+            ("canceled", "draft"),
+            (None, "confirmed"),
+        ],
+    )
+    def test_disallowed_transitions(self, current_status, new_status):
+        """不正な遷移(逆行・飛び越し・未知の状態からの遷移)は拒否される"""
+        with pytest.raises(InvalidOrderStatusTransitionError):
+            validate_order_status_transition(current_status, new_status)

--- a/backend/__tests__/unit/test_scheduler.py
+++ b/backend/__tests__/unit/test_scheduler.py
@@ -177,17 +177,20 @@ class TestScheduleOrder:
 
         # 設備1は遠い未来まで使用中、設備2は近い未来まで使用中
         # 設備2の方が早く開始できるべき
-        now = datetime.now(tz=JST)
+        # 実行時刻の壁時計に依存すると、テスト実行が16:00〜17:00近辺に
+        # 重なった場合に日またぎでセグメントが分割され失敗するため、
+        # 基準時刻は固定の平日午前（火曜9:00）を start_time として明示的に渡す。
+        fixed_now = datetime(2026, 1, 6, 9, 0, 0, tzinfo=JST)  # 火曜日 9:00
 
         def get_last_end_time_side_effect(equipment_id: int):
             if equipment_id == 1:
-                return now.replace(
+                return fixed_now.replace(
                     hour=16, minute=0, second=0, microsecond=0
-                )  # 今日の16:00まで使用中
+                )  # 当日16:00まで使用中
             elif equipment_id == 2:
-                return now.replace(
+                return fixed_now.replace(
                     hour=10, minute=0, second=0, microsecond=0
-                )  # 今日の10:00まで使用中（より早く空く）
+                )  # 当日10:00まで使用中（より早く空く）
 
         mock_schedule_repo.get_last_end_time.side_effect = get_last_end_time_side_effect
         mock_schedule_repo.create.return_value = None
@@ -201,13 +204,14 @@ class TestScheduleOrder:
             product_repo=mock_product_repo,
             schedule_repo=mock_schedule_repo,
             tenant_id="test-tenant-id",
+            start_time=fixed_now,
         )
 
-        # 検証：より早く空く設備2が選ばれるべき
-        # ただし、今日が土日の場合は月曜日になるため、厳密な検証は難しい
-        # ここでは、スケジュールが作成されたことを確認
+        # 検証：より早く空く設備2(10:00開始、11:00終了)が選ばれ、
+        # 稼働時間内に収まるため1セグメントで完了するはず
         assert len(result) == 1
         assert result[0]["order_id"] == 3
+        assert result[0]["equipment_id"] == 2
 
     def test_schedule_with_no_routings(self) -> None:
         """工程が存在しない場合、RoutingUnconfirmedErrorを投げる"""

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -31,6 +31,10 @@ from app.repositories.supa_infra.transaction.order_repo import OrderRepository
 from app.repositories.supa_infra.transaction.schedule_repo import ScheduleRepository
 from app.scheduler_logic import RoutingUnconfirmedError, schedule_order
 from app.services.attachment_service import create_signed_url
+from app.services.order_status_service import (
+    InvalidOrderStatusTransitionError,
+    validate_order_status_transition,
+)
 from app.services.simulation_service import build_simulate_response
 from app.utils.logger import get_logger
 from supabase import Client
@@ -441,6 +445,11 @@ def confirm_order(
         raise HTTPException(status_code=404, detail="Order not found")
     if order.get("product_id") is None:
         raise HTTPException(status_code=422, detail={"error": "product_unmatched"})
+
+    try:
+        validate_order_status_transition(order.get("status"), "confirmed")
+    except InvalidOrderStatusTransitionError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None
 
     try:
         # 1. 実際に保存 (dry_run=False)

--- a/backend/app/services/order_status_service.py
+++ b/backend/app/services/order_status_service.py
@@ -1,0 +1,39 @@
+# services/order_status_service.py
+"""orders.status の遷移バリデーション (Issue #324)。
+
+draft -> pending_approval -> confirmed -> completed / canceled の順方向のみを
+許可する。差し戻し pending_approval -> draft のみ例外的に許可する
+（実際の却下APIは別Issueで実装）。
+"""
+
+ORDER_STATUS_TRANSITIONS: dict[str, set[str]] = {
+    "draft": {"pending_approval"},
+    "pending_approval": {"draft", "confirmed"},
+    "confirmed": {"completed", "canceled"},
+    "completed": set(),
+    "canceled": set(),
+}
+
+
+class InvalidOrderStatusTransitionError(ValueError):
+    """許可されていない orders.status 遷移が要求された場合に送出する"""
+
+    def __init__(self, current_status: str | None, new_status: str):
+        self.current_status = current_status
+        self.new_status = new_status
+        super().__init__(
+            f"ステータスを {current_status!r} から {new_status!r} へ変更することはできません"
+        )
+
+
+def validate_order_status_transition(
+    current_status: str | None, new_status: str
+) -> None:
+    """current_status から new_status への遷移が許可されているか検証する。
+
+    Raises:
+        InvalidOrderStatusTransitionError: 許可されていない遷移の場合
+    """
+    allowed = ORDER_STATUS_TRANSITIONS.get(current_status or "", set())
+    if new_status not in allowed:
+        raise InvalidOrderStatusTransitionError(current_status, new_status)

--- a/docs/features/order-status-workflow.md
+++ b/docs/features/order-status-workflow.md
@@ -1,0 +1,50 @@
+# 受注ステータス遷移 (Issue #324)
+
+## 概要
+
+受注確認・承認ワークフロー（Issue #322）の土台として、`orders.status` に承認待ち状態
+`pending_approval` を追加し、順方向のみのステータス遷移バリデーションを実装した。
+
+## 背景
+
+過去に顧客側の確度（`forecast`/`forecast_tentative`）を `status` に混在させ、後に
+`customer_certainty` カラムへ分離し直した経緯がある
+（[20260705000000_separate_customer_certainty_from_status.sql](../../supabase/migrations/20260705000000_separate_customer_certainty_from_status.sql)、Issue #267）。
+本Issueでは「受注担当者の修正完了から社長承認まで」の状態を、`customer_certainty` の
+どちらの軸にも混在させず、独立した `status` の一段階として追加する。
+
+## ステータス遷移
+
+```
+draft ──────────▶ pending_approval ──────────▶ confirmed ──┬──▶ completed
+                        │                                    └──▶ canceled
+                        └──(差し戻し)──▶ draft
+```
+
+| 状態 | 意味 |
+|---|---|
+| `draft` | 下書き（メール自動作成 or 手動作成） |
+| `pending_approval` | 受注担当者による修正完了、社長承認待ち |
+| `confirmed` | 社長による承認済み（`POST /orders/{id}/confirm` 実行済み） |
+| `completed` | 完了 |
+| `canceled` | キャンセル |
+
+順方向遷移のみを許可し、差し戻し `pending_approval → draft` のみ例外的に許可する
+（実際の却下APIは別Issueで実装予定）。バリデーションは
+[order_status_service.py](../../backend/app/services/order_status_service.py) の
+`validate_order_status_transition()` が担い、`POST /orders/{id}/confirm`
+（[orders.py](../../backend/app/routers/transaction/orders.py)）はこれを経由して
+`pending_approval → confirmed` の遷移のみを許可するよう変更した
+（それ以前は無条件にステータスを上書きしていた）。
+
+## 自動処理（メール/PDF取込）との整合
+
+`upsert_order_by_dedupe_key`（[20260810000002_add_pending_approval_order_status.sql](../../supabase/migrations/20260810000002_add_pending_approval_order_status.sql)）
+は、既存の `confirmed`/`completed`/`canceled` 保護に加えて `pending_approval` 状態の
+受注も自動処理から保護し、誤って上書き・降格させないようにしている。
+
+## 承認申請API・却下API（本Issueのスコープ外）
+
+`draft → pending_approval`（承認申請）、`pending_approval → draft`（却下・差し戻し）を
+実行するAPIエンドポイント自体は別Issue（Issue #322 の後続）で実装する。本Issueでは
+`orders.status` の値追加と遷移バリデーションの土台のみを提供する。

--- a/frontend/src/lib/order-utils.ts
+++ b/frontend/src/lib/order-utils.ts
@@ -91,6 +91,7 @@ export function getCustomerName(customerId: number | undefined, customers?: Cust
 export function getStatusLabel(status: Order["status"]): string {
   const statusLabels: Record<Order["status"], string> = {
     draft: "下書き",
+    pending_approval: "承認待ち",
     confirmed: "確定",
     completed: "完了",
     canceled: "キャンセル",
@@ -103,10 +104,11 @@ export function getStatusLabel(status: Order["status"]): string {
  */
 export function getStatusBadgeClass(status: Order["status"]): string {
   const classes: Record<Order["status"], string> = {
-    draft:      "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
-    confirmed:  "bg-green-100 text-green-800 hover:bg-green-100",
-    completed:  "bg-blue-100 text-blue-800 hover:bg-blue-100",
-    canceled:   "bg-gray-100 text-gray-500 hover:bg-gray-100",
+    draft:             "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
+    pending_approval:  "bg-orange-100 text-orange-800 hover:bg-orange-100",
+    confirmed:         "bg-green-100 text-green-800 hover:bg-green-100",
+    completed:         "bg-blue-100 text-blue-800 hover:bg-blue-100",
+    canceled:          "bg-gray-100 text-gray-500 hover:bg-gray-100",
   }
   return classes[status] ?? ""
 }

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -10,7 +10,7 @@ export interface Order {
   quantity: number
   desired_deadline?: string // 日付のみ (YYYY-MM-DD)、時刻情報は持たない
   confirmed_deadline?: string // 日付のみ (YYYY-MM-DD)、時刻情報は持たない
-  status: 'draft' | 'confirmed' | 'completed' | 'canceled'
+  status: 'draft' | 'pending_approval' | 'confirmed' | 'completed' | 'canceled'
   customer_certainty: 'confirmed' | 'forecast' | 'forecast_tentative' | null
   is_scheduled: boolean
   has_no_routings?: boolean

--- a/supabase/migrations/20260810000002_add_pending_approval_order_status.sql
+++ b/supabase/migrations/20260810000002_add_pending_approval_order_status.sql
@@ -26,57 +26,116 @@ COMMENT ON COLUMN orders.status IS
 -- ==========================================
 -- upsert_order_by_dedupe_key: pending_approval も自動処理からの保護対象に追加
 --
--- 既存の confirmed/completed/canceled 保護に pending_approval を追加する。
--- 承認待ちの受注をメール/PDF自動処理が誤って上書き・降格させないようにする。
+-- 20260712000000_add_orders_dedupe_key_unmatched_product.sql 時点の最新定義
+-- （p_source_attachment_id 引数・product_id IS NULL 分岐を含む）をベースに、
+-- confirmed/completed/canceled の保護対象へ pending_approval を追加するのみの
+-- 差分を適用する。承認待ちの受注をメール/PDF自動処理が誤って上書き・降格
+-- させないようにする。
 -- ==========================================
 CREATE OR REPLACE FUNCTION upsert_order_by_dedupe_key(
-  p_tenant_id             uuid,
-  p_customer_id           bigint,
-  p_product_id            bigint,
-  p_quantity              int,
-  p_deadline_date         date,
-  p_customer_certainty    text,
-  p_source_type           text,
-  p_source_raw            text,
-  p_extracted_product_name text
+  p_tenant_id              uuid,
+  p_customer_id            bigint,
+  p_product_id             bigint,
+  p_quantity               int,
+  p_deadline_date          date,
+  p_customer_certainty     text,
+  p_source_type            text,
+  p_source_raw             text,
+  p_extracted_product_name text,
+  p_source_attachment_id   uuid DEFAULT NULL
 )
 RETURNS TABLE (order_id bigint, action text)
 LANGUAGE plpgsql
 SECURITY INVOKER
 AS $$
 DECLARE
-  v_existing        orders%ROWTYPE;
-  v_new_id          bigint;
+  v_existing          orders%ROWTYPE;
+  v_new_id            bigint;
   v_existing_priority int;
   v_new_priority      int;
+  v_extracted_name    text := NULLIF(TRIM(p_extracted_product_name), '');
 BEGIN
-  -- 先にINSERTを試み、UNIQUE制約(orders_dedupe_key)の競合でしか
-  -- 「既存あり」を判定しない。SELECTしてから未存在ならINSERTする順序だと、
-  -- 同一dedupeキーへの並行呼び出しが両方SELECTでNOT FOUNDと判定してしまい、
-  -- 片方が23505で例外終了する競合が起こり得るため。
-  INSERT INTO orders (
-    tenant_id, customer_id, product_id, quantity, deadline_date,
-    status, customer_certainty, source_type, source_raw, extracted_product_name
-  )
-  VALUES (
-    p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
-    'draft', p_customer_certainty, p_source_type, p_source_raw, p_extracted_product_name
-  )
-  ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
-  RETURNING orders.id INTO v_new_id;
+  IF p_product_id IS NULL THEN
+    IF v_extracted_name IS NULL OR p_deadline_date IS NULL THEN
+      -- 重複判定に使える情報（品名・納期）が不足しているため、常に新規行として
+      -- 挿入する（取りこぼしを許容する。Issue #296 未解決の問題として明記済み）。
+      INSERT INTO orders (
+        tenant_id, customer_id, product_id, quantity, deadline_date,
+        status, customer_certainty, source_type, source_raw, extracted_product_name,
+        source_attachment_id
+      )
+      VALUES (
+        p_tenant_id, p_customer_id, NULL, p_quantity, p_deadline_date,
+        'draft', p_customer_certainty, p_source_type, p_source_raw, v_extracted_name,
+        p_source_attachment_id
+      )
+      RETURNING orders.id INTO v_new_id;
 
-  IF v_new_id IS NOT NULL THEN
-    RETURN QUERY SELECT v_new_id, 'inserted'::text;
-    RETURN;
+      RETURN QUERY SELECT v_new_id, 'inserted'::text;
+      RETURN;
+    END IF;
+
+    INSERT INTO orders (
+      tenant_id, customer_id, product_id, quantity, deadline_date,
+      status, customer_certainty, source_type, source_raw, extracted_product_name,
+      source_attachment_id
+    )
+    VALUES (
+      p_tenant_id, p_customer_id, NULL, p_quantity, p_deadline_date,
+      'draft', p_customer_certainty, p_source_type, p_source_raw, v_extracted_name,
+      p_source_attachment_id
+    )
+    ON CONFLICT (tenant_id, customer_id, deadline_date, extracted_product_name)
+      WHERE product_id IS NULL
+        AND deadline_date IS NOT NULL
+        AND extracted_product_name IS NOT NULL
+      DO NOTHING
+    RETURNING orders.id INTO v_new_id;
+
+    IF v_new_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_new_id, 'inserted'::text;
+      RETURN;
+    END IF;
+
+    SELECT * INTO v_existing
+    FROM orders
+    WHERE tenant_id = p_tenant_id
+      AND customer_id = p_customer_id
+      AND product_id IS NULL
+      AND deadline_date = p_deadline_date
+      AND extracted_product_name = v_extracted_name
+    FOR UPDATE;
+  ELSE
+    -- 先にINSERTを試み、UNIQUE制約(orders_dedupe_key)の競合でしか
+    -- 「既存あり」を判定しない。SELECTしてから未存在ならINSERTする順序だと、
+    -- 同一dedupeキーへの並行呼び出しが両方SELECTでNOT FOUNDと判定してしまい、
+    -- 片方が23505で例外終了する競合が起こり得るため。
+    INSERT INTO orders (
+      tenant_id, customer_id, product_id, quantity, deadline_date,
+      status, customer_certainty, source_type, source_raw, extracted_product_name,
+      source_attachment_id
+    )
+    VALUES (
+      p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
+      'draft', p_customer_certainty, p_source_type, p_source_raw, v_extracted_name,
+      p_source_attachment_id
+    )
+    ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
+    RETURNING orders.id INTO v_new_id;
+
+    IF v_new_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_new_id, 'inserted'::text;
+      RETURN;
+    END IF;
+
+    SELECT * INTO v_existing
+    FROM orders
+    WHERE tenant_id = p_tenant_id
+      AND customer_id = p_customer_id
+      AND product_id = p_product_id
+      AND deadline_date = p_deadline_date
+    FOR UPDATE;
   END IF;
-
-  SELECT * INTO v_existing
-  FROM orders
-  WHERE tenant_id = p_tenant_id
-    AND customer_id = p_customer_id
-    AND product_id = p_product_id
-    AND deadline_date = p_deadline_date
-  FOR UPDATE;
 
   -- pending_approval/confirmed/completed/canceled (受注担当者が承認申請した、
   -- またはユーザーが確定・完了させた、もしくはキャンセルした注文)
@@ -96,9 +155,6 @@ BEGIN
   -- ここから先は既存行が draft かつ source_type != 'manual'
   -- (メール/PDF起票の確認待ちdraft) のケース。
   -- customer_certainty の優先順位（数値が大きいほど確度が高い）で判定する。
-  -- 既存行の customer_certainty が NULL（本文のみのメール起票等、確度情報を
-  -- 持たないdraft）の場合は最も低い優先度(-1)として扱い、PDF取込による
-  -- 確度付け・更新を妨げないようにする。
   v_existing_priority := CASE v_existing.customer_certainty
     WHEN 'forecast_tentative' THEN 0
     WHEN 'forecast'           THEN 1
@@ -112,8 +168,6 @@ BEGIN
     ELSE NULL
   END;
 
-  -- p_customer_certainty がCHECK制約の許容値以外だった場合
-  -- (呼び出し元での正規化漏れ等) は更新せずコンフリクト扱いにする
   IF v_new_priority IS NULL
      OR v_new_priority < v_existing_priority THEN
     RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
@@ -130,7 +184,7 @@ BEGIN
       quantity                = p_quantity,
       source_type             = p_source_type,
       source_raw              = p_source_raw,
-      extracted_product_name  = p_extracted_product_name
+      extracted_product_name  = v_extracted_name
   WHERE id = v_existing.id;
 
   RETURN QUERY SELECT v_existing.id, 'updated'::text;

--- a/supabase/migrations/20260810000002_add_pending_approval_order_status.sql
+++ b/supabase/migrations/20260810000002_add_pending_approval_order_status.sql
@@ -1,0 +1,138 @@
+-- ==========================================
+-- orders.status に pending_approval を追加 (Issue #324)
+--
+-- 受注確認・承認ワークフロー (#322) のための土台。受注担当者による表記揺れ
+-- 修正完了から社長承認までの「承認待ち」状態を、customer_certainty とは
+-- 独立した status の一段階として表現する。
+--
+-- status は draft -> pending_approval -> confirmed -> completed / canceled の
+-- 順方向にのみ遷移する（差し戻し pending_approval -> draft のみ例外的に許可）。
+-- 遷移バリデーション自体は backend/app/services/order_status_service.py で行う。
+-- ==========================================
+
+ALTER TABLE orders DROP CONSTRAINT orders_status_check;
+ALTER TABLE orders ADD CONSTRAINT orders_status_check
+  CHECK (status IN ('draft', 'pending_approval', 'confirmed', 'completed', 'canceled'));
+
+COMMENT ON COLUMN orders.status IS
+  'ProductPlannerのワークフローステータス: draft(下書き), '
+  'pending_approval(受注担当者の修正完了・社長承認待ち), '
+  'confirmed(確定/スケジュール済), completed(完了), canceled(キャンセル)。'
+  'draft -> pending_approval -> confirmed -> completed/canceled の順方向にのみ'
+  '遷移する（差し戻し pending_approval -> draft のみ例外）。confirmed へは'
+  'ユーザーの確定操作(/orders/{id}/confirm)でのみ遷移する。顧客側の確度は'
+  'customer_certainty を参照。';
+
+-- ==========================================
+-- upsert_order_by_dedupe_key: pending_approval も自動処理からの保護対象に追加
+--
+-- 既存の confirmed/completed/canceled 保護に pending_approval を追加する。
+-- 承認待ちの受注をメール/PDF自動処理が誤って上書き・降格させないようにする。
+-- ==========================================
+CREATE OR REPLACE FUNCTION upsert_order_by_dedupe_key(
+  p_tenant_id             uuid,
+  p_customer_id           bigint,
+  p_product_id            bigint,
+  p_quantity              int,
+  p_deadline_date         date,
+  p_customer_certainty    text,
+  p_source_type           text,
+  p_source_raw            text,
+  p_extracted_product_name text
+)
+RETURNS TABLE (order_id bigint, action text)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_existing        orders%ROWTYPE;
+  v_new_id          bigint;
+  v_existing_priority int;
+  v_new_priority      int;
+BEGIN
+  -- 先にINSERTを試み、UNIQUE制約(orders_dedupe_key)の競合でしか
+  -- 「既存あり」を判定しない。SELECTしてから未存在ならINSERTする順序だと、
+  -- 同一dedupeキーへの並行呼び出しが両方SELECTでNOT FOUNDと判定してしまい、
+  -- 片方が23505で例外終了する競合が起こり得るため。
+  INSERT INTO orders (
+    tenant_id, customer_id, product_id, quantity, deadline_date,
+    status, customer_certainty, source_type, source_raw, extracted_product_name
+  )
+  VALUES (
+    p_tenant_id, p_customer_id, p_product_id, p_quantity, p_deadline_date,
+    'draft', p_customer_certainty, p_source_type, p_source_raw, p_extracted_product_name
+  )
+  ON CONFLICT ON CONSTRAINT orders_dedupe_key DO NOTHING
+  RETURNING orders.id INTO v_new_id;
+
+  IF v_new_id IS NOT NULL THEN
+    RETURN QUERY SELECT v_new_id, 'inserted'::text;
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_existing
+  FROM orders
+  WHERE tenant_id = p_tenant_id
+    AND customer_id = p_customer_id
+    AND product_id = p_product_id
+    AND deadline_date = p_deadline_date
+  FOR UPDATE;
+
+  -- pending_approval/confirmed/completed/canceled (受注担当者が承認申請した、
+  -- またはユーザーが確定・完了させた、もしくはキャンセルした注文)
+  -- はPDF自動処理から完全に保護し、常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status IN ('pending_approval', 'confirmed', 'completed', 'canceled') THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  -- status='draft' かつ source_type='manual' (手動下書き) は自動更新の対象外。
+  -- 常にコンフリクトとしてログのみ記録する。
+  IF v_existing.status = 'draft' AND v_existing.source_type = 'manual' THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_draft_conflict'::text;
+    RETURN;
+  END IF;
+
+  -- ここから先は既存行が draft かつ source_type != 'manual'
+  -- (メール/PDF起票の確認待ちdraft) のケース。
+  -- customer_certainty の優先順位（数値が大きいほど確度が高い）で判定する。
+  -- 既存行の customer_certainty が NULL（本文のみのメール起票等、確度情報を
+  -- 持たないdraft）の場合は最も低い優先度(-1)として扱い、PDF取込による
+  -- 確度付け・更新を妨げないようにする。
+  v_existing_priority := CASE v_existing.customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE -1
+  END;
+  v_new_priority := CASE p_customer_certainty
+    WHEN 'forecast_tentative' THEN 0
+    WHEN 'forecast'           THEN 1
+    WHEN 'confirmed'          THEN 2
+    ELSE NULL
+  END;
+
+  -- p_customer_certainty がCHECK制約の許容値以外だった場合
+  -- (呼び出し元での正規化漏れ等) は更新せずコンフリクト扱いにする
+  IF v_new_priority IS NULL
+     OR v_new_priority < v_existing_priority THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_downgrade'::text;
+    RETURN;
+  END IF;
+
+  IF v_new_priority = v_existing_priority AND v_existing.quantity = p_quantity THEN
+    RETURN QUERY SELECT v_existing.id, 'skipped_no_change'::text;
+    RETURN;
+  END IF;
+
+  UPDATE orders
+  SET customer_certainty     = p_customer_certainty,
+      quantity                = p_quantity,
+      source_type             = p_source_type,
+      source_raw              = p_source_raw,
+      extracted_product_name  = p_extracted_product_name
+  WHERE id = v_existing.id;
+
+  RETURN QUERY SELECT v_existing.id, 'updated'::text;
+END;
+$$;


### PR DESCRIPTION
## Summary
- 受注確認・承認ワークフロー(#322)導入のため、`orders.status` に承認待ち状態 `pending_approval` を追加(`draft → pending_approval → confirmed → completed/canceled` の順方向遷移＋差し戻し `pending_approval → draft`)
- 遷移バリデーション関数 `validate_order_status_transition`(`backend/app/services/order_status_service.py`)を新規実装し、`POST /orders/{id}/confirm` はこれを経由して `pending_approval` からのみ確定できるよう変更(従来は無条件にステータス上書きしていた)
- `upsert_order_by_dedupe_key` の自動処理保護対象に `pending_approval` を追加し、メール/PDF自動処理が承認待ち受注を誤って上書きしないようにした
- `customer_certainty` とは独立した軸として扱い、過去のstatus混在の経緯(#267)を繰り返さないようにした

Closes #324

## Test plan
- [x] `pytest __tests__/unit/services/test_order_status_service.py` — 遷移バリデーションの許可/拒否パターン網羅
- [x] `pytest __tests__/api/routers/transaction/test_orders.py` — `confirm_order` が `pending_approval` からのみ成功し、`draft` から直接は400で拒否されることを確認
- [x] `pytest __tests__/unit/ __tests__/api/` 全件パス
- [x] `ruff check` / `mypy` (変更ファイル) パス
- [ ] マイグレーション本番適用(別途承認の上、CLAUDE.md記載の手順で実施予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)