### PR TITLE
feat: 承認ワークフローの操作主体を記録する監査ログ基盤 (Issue #326)

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -862,7 +862,7 @@ class TestOrderRouter:
 
         assert response.status_code == 200
         mock_approval_log_repo.log_action.assert_called_once_with(
-            headers["x-tenant-id"], order_id, "request_approval", "test-user-id"
+            headers["x-tenant-id"], order_id, "request_approval", "test-user-id", None
         )
 
     def test_confirm_order_logs_action(
@@ -908,7 +908,7 @@ class TestOrderRouter:
 
         assert response.status_code == 200
         mock_approval_log_repo.log_action.assert_called_once_with(
-            headers["x-tenant-id"], order_id, "approve", "test-user-id"
+            headers["x-tenant-id"], order_id, "approve", "test-user-id", None
         )
 
     def test_reject_order_logs_action_with_reason(
@@ -985,8 +985,60 @@ class TestOrderRouter:
 
         assert response.status_code == 200
         mock_approval_log_repo.log_action.assert_called_once_with(
-            headers["x-tenant-id"], 1, "approve", "test-user-id"
+            headers["x-tenant-id"], 1, "approve", "test-user-id", None
         )
+
+    def test_approve_orders_bulk_succeeds_even_if_log_action_raises(
+        self,
+        headers,
+        mock_repo,
+        mock_product_repo,
+        mock_schedule_repo,
+        mock_supabase_client,
+        mock_approval_log_repo,
+    ):
+        """
+        POST /approve-bulk: 監査ログ記録が例外を送出しても、既に確定した注文の結果は
+        失われず200で返る（記録はベストエフォート）
+        """
+        self._set_role(mock_supabase_client, "president")
+        order_data = {
+            "id": 1,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "pending_approval",
+        }
+        mock_repo.get_by_id.return_value = order_data
+        routings = [
+            {
+                "id": 1,
+                "equipment_group_id": 100,
+                "setup_time_seconds": 1800,
+                "unit_time_seconds": 600,
+                "sequence_order": 1,
+                "is_confirmed": True,
+            }
+        ]
+        mock_product_repo.get_routings_by_product.return_value = routings
+        mock_product_repo.client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
+            {"equipment_id": 1}
+        ]
+        mock_schedule_repo.get_last_end_time.return_value = None
+        mock_schedule_repo.get_schedules_by_equipment.return_value = []
+        mock_schedule_repo.create.return_value = None
+        mock_repo.update.return_value = {**order_data, "status": "confirmed"}
+        mock_approval_log_repo.log_action.side_effect = RuntimeError("DB down")
+
+        response = client.post(
+            "/orders/approve-bulk",
+            json={"order_ids": [1]},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        results = {r["order_id"]: r for r in response.json()["results"]}
+        assert results[1]["status"] == "confirmed"
 
     # --- 監査ログ閲覧・出力 (Issue #326) ---
 
@@ -999,17 +1051,24 @@ class TestOrderRouter:
         "created_at": "2026-08-11T00:00:00+00:00",
     }
 
-    def _mock_enrichment(self, mock_admin_client):
-        """orders / profiles への補完クエリのモックを設定する"""
-        table_mock = mock_admin_client.table
+    def _mock_enrichment(self, mock_supabase_client):
+        """
+        orders / profiles への補完クエリのモックを設定する。
+        監査ログの補完取得はユーザーJWTクライアント（mock_supabase_client）で行うため、
+        `_set_role` が使う organization_members 向けチェーンはそのまま残しつつ、
+        table("orders") / table("profiles") の呼び出しだけ差し替える。
+        """
+        default_table_return = mock_supabase_client.table.return_value
 
         def table_side_effect(name):
-            m = MagicMock()
             if name == "orders":
+                m = MagicMock()
                 m.select.return_value.in_.return_value.execute.return_value.data = [
                     {"id": 1, "order_number": "ORD-001"}
                 ]
-            elif name == "profiles":
+                return m
+            if name == "profiles":
+                m = MagicMock()
                 m.select.return_value.in_.return_value.execute.return_value.data = [
                     {
                         "id": "user-1",
@@ -1017,17 +1076,18 @@ class TestOrderRouter:
                         "email": "taro@example.com",
                     }
                 ]
-            return m
+                return m
+            return default_table_return
 
-        table_mock.side_effect = table_side_effect
+        mock_supabase_client.table.side_effect = table_side_effect
 
     def test_list_approval_logs_success(
-        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+        self, headers, mock_supabase_client, mock_approval_log_repo
     ):
         """GET /approval-logs: iso_officer は承認履歴を閲覧できる"""
         self._set_role(mock_supabase_client, "iso_officer")
         mock_approval_log_repo.get_all.return_value = [self._SAMPLE_LOG_ROW]
-        self._mock_enrichment(mock_admin_client)
+        self._mock_enrichment(mock_supabase_client)
 
         response = client.get("/orders/approval-logs", headers=headers)
 
@@ -1051,7 +1111,7 @@ class TestOrderRouter:
         mock_approval_log_repo.get_all.assert_not_called()
 
     def test_list_approval_logs_allowed_for_president(
-        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+        self, headers, mock_supabase_client, mock_approval_log_repo
     ):
         """GET /approval-logs: president も閲覧できる"""
         self._set_role(mock_supabase_client, "president")
@@ -1063,12 +1123,12 @@ class TestOrderRouter:
         assert response.json() == []
 
     def test_export_approval_logs_csv(
-        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+        self, headers, mock_supabase_client, mock_approval_log_repo
     ):
         """GET /approval-logs/export: CSVとして出力される"""
         self._set_role(mock_supabase_client, "iso_officer")
         mock_approval_log_repo.get_all.return_value = [self._SAMPLE_LOG_ROW]
-        self._mock_enrichment(mock_admin_client)
+        self._mock_enrichment(mock_supabase_client)
 
         response = client.get("/orders/approval-logs/export", headers=headers)
 

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -527,7 +527,7 @@ class TestOrderRouter:
     def test_reject_order_reason_optional(
         self, headers, mock_repo, mock_supabase_client
     ):
-        """POST /{order_id}/reject: reasonなしでも却下できる"""
+        """POST /{order_id}/reject: reasonなしでも差し戻しできる"""
         order_id = 1
         self._set_role(mock_supabase_client, "president")
         mock_repo.get_by_id.return_value = {
@@ -559,7 +559,7 @@ class TestOrderRouter:
     def test_reject_order_invalid_transition(
         self, headers, mock_repo, mock_supabase_client
     ):
-        """POST /{order_id}/reject: draftからは却下できない"""
+        """POST /{order_id}/reject: draftからは差し戻しできない"""
         order_id = 1
         self._set_role(mock_supabase_client, "president")
         mock_repo.get_by_id.return_value = {"id": order_id, "status": "draft"}
@@ -568,6 +568,65 @@ class TestOrderRouter:
 
         assert response.status_code == 400
         mock_repo.update.assert_not_called()
+
+    def test_withdraw_order_approval_success(
+        self, headers, mock_repo, mock_supabase_client, mock_approval_log_repo
+    ):
+        """POST /{order_id}/withdraw-approval: pending_approval -> draft への取り下げが成功する"""
+        order_id = 1
+        self._set_role(mock_supabase_client, "order_handler")
+        mock_repo.get_by_id.return_value = {
+            "id": order_id,
+            "product_id": 100,
+            "status": "pending_approval",
+        }
+        mock_repo.update.return_value = {"id": order_id, "status": "draft"}
+
+        response = client.post(f"/orders/{order_id}/withdraw-approval", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "draft"
+        mock_repo.update.assert_called_once_with(order_id, {"status": "draft"})
+        mock_approval_log_repo.log_action.assert_called_once_with(
+            headers["x-tenant-id"], order_id, "withdraw", "test-user-id", None
+        )
+
+    def test_withdraw_order_approval_forbidden_for_non_order_handler(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/withdraw-approval: order_handler以外は403"""
+        order_id = 1
+        self._set_role(mock_supabase_client, "president")
+
+        response = client.post(f"/orders/{order_id}/withdraw-approval", headers=headers)
+
+        assert response.status_code == 403
+        mock_repo.get_by_id.assert_not_called()
+
+    def test_withdraw_order_approval_invalid_transition(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/withdraw-approval: draftからは取り下げできない"""
+        order_id = 1
+        self._set_role(mock_supabase_client, "order_handler")
+        mock_repo.get_by_id.return_value = {"id": order_id, "status": "draft"}
+
+        response = client.post(f"/orders/{order_id}/withdraw-approval", headers=headers)
+
+        assert response.status_code == 400
+        mock_repo.update.assert_not_called()
+
+    def test_withdraw_order_approval_not_found(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/withdraw-approval: 注文が存在しない場合の404エラーテスト"""
+        order_id = 999
+        self._set_role(mock_supabase_client, "order_handler")
+        mock_repo.get_by_id.return_value = None
+
+        response = client.post(f"/orders/{order_id}/withdraw-approval", headers=headers)
+
+        assert response.status_code == 404
 
     def test_approve_orders_bulk_partial_failure(
         self,
@@ -914,7 +973,7 @@ class TestOrderRouter:
     def test_reject_order_logs_action_with_reason(
         self, headers, mock_repo, mock_supabase_client, mock_approval_log_repo
     ):
-        """POST /{order_id}/reject: 却下理由付きで監査ログに記録される"""
+        """POST /{order_id}/reject: 差し戻し理由付きで監査ログに記録される"""
         order_id = 1
         self._set_role(mock_supabase_client, "president")
         mock_repo.get_by_id.return_value = {

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -1197,6 +1197,37 @@ class TestOrderRouter:
         assert "ORD-001" in body
         assert "承認 太郎" in body
 
+    def test_export_approval_logs_csv_falls_back_to_order_id_when_order_number_missing(
+        self, headers, mock_supabase_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs/export: order_numberがNULLの場合は #order_id にフォールバックする"""
+        self._set_role(mock_supabase_client, "iso_officer")
+        mock_approval_log_repo.get_all.return_value = [self._SAMPLE_LOG_ROW]
+
+        default_table_return = mock_supabase_client.table.return_value
+
+        def table_side_effect(name):
+            if name == "orders":
+                m = MagicMock()
+                # order_number が NULL の注文（例: 未確定の自動起票注文）
+                m.select.return_value.in_.return_value.execute.return_value.data = [
+                    {"id": 1, "order_number": None}
+                ]
+                return m
+            if name == "profiles":
+                m = MagicMock()
+                m.select.return_value.in_.return_value.execute.return_value.data = []
+                return m
+            return default_table_return
+
+        mock_supabase_client.table.side_effect = table_side_effect
+
+        response = client.get("/orders/approval-logs/export", headers=headers)
+
+        assert response.status_code == 200
+        body = response.content.decode("utf-8-sig")
+        assert "#1" in body
+
     def test_export_approval_logs_csv_forbidden_for_order_handler(
         self, headers, mock_supabase_client, mock_approval_log_repo
     ):

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -5,9 +5,11 @@ import pytest
 from app.dependencies import (
     get_current_user_id,
     get_equipment_repo,
+    get_order_approval_log_repo,
     get_order_repo,
     get_product_repo,
     get_schedule_repo,
+    get_supabase_admin_client,
     get_supabase_client,
 )
 
@@ -59,6 +61,18 @@ class TestOrderRouter:
         """order_attachments への直接クエリ用クライアントのモック"""
         return MagicMock()
 
+    @pytest.fixture
+    def mock_admin_client(self):
+        """profiles/orders 補完取得用の管理者クライアントのモック"""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_approval_log_repo(self):
+        """承認監査ログリポジトリのモックを作成するフィクスチャ"""
+        mock = MagicMock()
+        mock.get_all.return_value = []
+        return mock
+
     @pytest.fixture(autouse=True)
     def override_dependency(
         self,
@@ -68,6 +82,8 @@ class TestOrderRouter:
         mock_schedule_repo,
         mock_settings_repo,
         mock_supabase_client,
+        mock_admin_client,
+        mock_approval_log_repo,
     ):
         """
         テスト実行中だけ依存関係を mock に差し替える。
@@ -78,6 +94,10 @@ class TestOrderRouter:
         app.dependency_overrides[get_schedule_repo] = lambda: mock_schedule_repo
         app.dependency_overrides[get_settings_repo] = lambda: mock_settings_repo
         app.dependency_overrides[get_supabase_client] = lambda: mock_supabase_client
+        app.dependency_overrides[get_supabase_admin_client] = lambda: mock_admin_client
+        app.dependency_overrides[get_order_approval_log_repo] = (
+            lambda: mock_approval_log_repo
+        )
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
         yield
         app.dependency_overrides = {}
@@ -819,3 +839,252 @@ class TestOrderRouter:
         assert response.status_code == 400
         mock_repo.create.assert_not_called()
         mock_repo.update.assert_not_called()
+
+    # --- 監査ログ記録 (Issue #326) ---
+
+    def test_request_order_approval_logs_action(
+        self, headers, mock_repo, mock_supabase_client, mock_approval_log_repo
+    ):
+        """POST /{order_id}/request-approval: 承認依頼送信が監査ログに記録される"""
+        order_id = 1
+        order_data = {
+            "id": order_id,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "draft",
+        }
+        self._set_role(mock_supabase_client, "order_handler")
+        mock_repo.get_by_id.return_value = order_data
+        mock_repo.update.return_value = {**order_data, "status": "pending_approval"}
+
+        response = client.post(f"/orders/{order_id}/request-approval", headers=headers)
+
+        assert response.status_code == 200
+        mock_approval_log_repo.log_action.assert_called_once_with(
+            headers["x-tenant-id"], order_id, "request_approval", "test-user-id"
+        )
+
+    def test_confirm_order_logs_action(
+        self,
+        headers,
+        mock_repo,
+        mock_product_repo,
+        mock_schedule_repo,
+        mock_supabase_client,
+        mock_approval_log_repo,
+    ):
+        """POST /{order_id}/confirm: 承認が監査ログに記録される"""
+        order_id = 1
+        order_data = {
+            "id": order_id,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "pending_approval",
+        }
+        self._set_role(mock_supabase_client, "president")
+        mock_repo.get_by_id.return_value = order_data
+        routings = [
+            {
+                "id": 1,
+                "equipment_group_id": 100,
+                "setup_time_seconds": 1800,
+                "unit_time_seconds": 600,
+                "sequence_order": 1,
+                "is_confirmed": True,
+            }
+        ]
+        mock_product_repo.get_routings_by_product.return_value = routings
+        mock_product_repo.client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
+            {"equipment_id": 1}
+        ]
+        mock_schedule_repo.get_last_end_time.return_value = None
+        mock_schedule_repo.get_schedules_by_equipment.return_value = []
+        mock_schedule_repo.create.return_value = None
+        mock_repo.update.return_value = {**order_data, "status": "confirmed"}
+
+        response = client.post(f"/orders/{order_id}/confirm", headers=headers)
+
+        assert response.status_code == 200
+        mock_approval_log_repo.log_action.assert_called_once_with(
+            headers["x-tenant-id"], order_id, "approve", "test-user-id"
+        )
+
+    def test_reject_order_logs_action_with_reason(
+        self, headers, mock_repo, mock_supabase_client, mock_approval_log_repo
+    ):
+        """POST /{order_id}/reject: 却下理由付きで監査ログに記録される"""
+        order_id = 1
+        self._set_role(mock_supabase_client, "president")
+        mock_repo.get_by_id.return_value = {
+            "id": order_id,
+            "product_id": 100,
+            "status": "pending_approval",
+        }
+        mock_repo.update.return_value = {"id": order_id, "status": "draft"}
+
+        response = client.post(
+            f"/orders/{order_id}/reject",
+            json={"reason": "表記揺れを修正してください"},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        mock_approval_log_repo.log_action.assert_called_once_with(
+            headers["x-tenant-id"],
+            order_id,
+            "reject",
+            "test-user-id",
+            "表記揺れを修正してください",
+        )
+
+    def test_approve_orders_bulk_logs_action_per_order(
+        self,
+        headers,
+        mock_repo,
+        mock_product_repo,
+        mock_schedule_repo,
+        mock_supabase_client,
+        mock_approval_log_repo,
+    ):
+        """POST /approve-bulk: 成功した注文ごとに監査ログが記録される"""
+        self._set_role(mock_supabase_client, "president")
+        order_data = {
+            "id": 1,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "pending_approval",
+        }
+        mock_repo.get_by_id.side_effect = lambda oid: (order_data if oid == 1 else None)
+        routings = [
+            {
+                "id": 1,
+                "equipment_group_id": 100,
+                "setup_time_seconds": 1800,
+                "unit_time_seconds": 600,
+                "sequence_order": 1,
+                "is_confirmed": True,
+            }
+        ]
+        mock_product_repo.get_routings_by_product.return_value = routings
+        mock_product_repo.client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
+            {"equipment_id": 1}
+        ]
+        mock_schedule_repo.get_last_end_time.return_value = None
+        mock_schedule_repo.get_schedules_by_equipment.return_value = []
+        mock_schedule_repo.create.return_value = None
+        mock_repo.update.return_value = {**order_data, "status": "confirmed"}
+
+        response = client.post(
+            "/orders/approve-bulk",
+            json={"order_ids": [1, 2]},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        mock_approval_log_repo.log_action.assert_called_once_with(
+            headers["x-tenant-id"], 1, "approve", "test-user-id"
+        )
+
+    # --- 監査ログ閲覧・出力 (Issue #326) ---
+
+    _SAMPLE_LOG_ROW = {
+        "id": "log-1",
+        "order_id": 1,
+        "action": "approve",
+        "actor_user_id": "user-1",
+        "reason": None,
+        "created_at": "2026-08-11T00:00:00+00:00",
+    }
+
+    def _mock_enrichment(self, mock_admin_client):
+        """orders / profiles への補完クエリのモックを設定する"""
+        table_mock = mock_admin_client.table
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "orders":
+                m.select.return_value.in_.return_value.execute.return_value.data = [
+                    {"id": 1, "order_number": "ORD-001"}
+                ]
+            elif name == "profiles":
+                m.select.return_value.in_.return_value.execute.return_value.data = [
+                    {
+                        "id": "user-1",
+                        "full_name": "承認 太郎",
+                        "email": "taro@example.com",
+                    }
+                ]
+            return m
+
+        table_mock.side_effect = table_side_effect
+
+    def test_list_approval_logs_success(
+        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs: iso_officer は承認履歴を閲覧できる"""
+        self._set_role(mock_supabase_client, "iso_officer")
+        mock_approval_log_repo.get_all.return_value = [self._SAMPLE_LOG_ROW]
+        self._mock_enrichment(mock_admin_client)
+
+        response = client.get("/orders/approval-logs", headers=headers)
+
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result) == 1
+        assert result[0]["order_number"] == "ORD-001"
+        assert result[0]["actor_full_name"] == "承認 太郎"
+        assert result[0]["actor_email"] == "taro@example.com"
+        assert result[0]["action"] == "approve"
+
+    def test_list_approval_logs_forbidden_for_order_handler(
+        self, headers, mock_supabase_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs: order_handler は閲覧できない"""
+        self._set_role(mock_supabase_client, "order_handler")
+
+        response = client.get("/orders/approval-logs", headers=headers)
+
+        assert response.status_code == 403
+        mock_approval_log_repo.get_all.assert_not_called()
+
+    def test_list_approval_logs_allowed_for_president(
+        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs: president も閲覧できる"""
+        self._set_role(mock_supabase_client, "president")
+        mock_approval_log_repo.get_all.return_value = []
+
+        response = client.get("/orders/approval-logs", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_export_approval_logs_csv(
+        self, headers, mock_supabase_client, mock_admin_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs/export: CSVとして出力される"""
+        self._set_role(mock_supabase_client, "iso_officer")
+        mock_approval_log_repo.get_all.return_value = [self._SAMPLE_LOG_ROW]
+        self._mock_enrichment(mock_admin_client)
+
+        response = client.get("/orders/approval-logs/export", headers=headers)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        body = response.content.decode("utf-8-sig")
+        assert "ORD-001" in body
+        assert "承認 太郎" in body
+
+    def test_export_approval_logs_csv_forbidden_for_order_handler(
+        self, headers, mock_supabase_client, mock_approval_log_repo
+    ):
+        """GET /approval-logs/export: order_handler は出力できない"""
+        self._set_role(mock_supabase_client, "order_handler")
+
+        response = client.get("/orders/approval-logs/export", headers=headers)
+
+        assert response.status_code == 403
+        mock_approval_log_repo.get_all.assert_not_called()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from app.repositories.supa_infra import (
     CustomerRepository,
     EquipmentRepository,
+    OrderApprovalLogRepository,
     OrderRepository,
     ProductRepository,
     ScheduleRepository,
@@ -96,6 +97,13 @@ def get_schedule_repo(
 ) -> ScheduleRepository:
     """スケジュールリポジトリを取得する。"""
     return ScheduleRepository(client)
+
+
+def get_order_approval_log_repo(
+    client: Client = Depends(get_supabase_client),
+) -> OrderApprovalLogRepository:
+    """受注承認監査ログリポジトリを取得する。"""
+    return OrderApprovalLogRepository(client)
 
 
 def get_product_repo(

--- a/backend/app/models/transaction/order_schema.py
+++ b/backend/app/models/transaction/order_schema.py
@@ -91,7 +91,7 @@ class OrderApprovalLogResponse(BaseModel):
     id: str
     order_id: int
     order_number: str | None
-    action: Literal["request_approval", "approve", "reject"]
+    action: Literal["request_approval", "approve", "reject", "withdraw"]
     actor_user_id: str
     actor_full_name: str | None
     actor_email: str | None

--- a/backend/app/models/transaction/order_schema.py
+++ b/backend/app/models/transaction/order_schema.py
@@ -85,6 +85,20 @@ class OrderBulkApproveRequest(BaseSchema):
     order_ids: list[int] = Field(min_length=1)
 
 
+class OrderApprovalLogResponse(BaseModel):
+    """受注承認監査ログのレスポンススキーマ（表示用に注文番号・操作者名を付与）"""
+
+    id: str
+    order_id: int
+    order_number: str | None
+    action: Literal["request_approval", "approve", "reject"]
+    actor_user_id: str
+    actor_full_name: str | None
+    actor_email: str | None
+    reason: str | None
+    created_at: str
+
+
 class OrderAttachmentResponse(BaseModel):
     """注文添付ファイルのレスポンススキーマ"""
 

--- a/backend/app/repositories/supa_infra/__init__.py
+++ b/backend/app/repositories/supa_infra/__init__.py
@@ -5,7 +5,11 @@ from app.repositories.supa_infra.master import (
     EquipmentRepository,
     ProductRepository,
 )
-from app.repositories.supa_infra.transaction import OrderRepository, ScheduleRepository
+from app.repositories.supa_infra.transaction import (
+    OrderApprovalLogRepository,
+    OrderRepository,
+    ScheduleRepository,
+)
 
 __all__ = [
     # common
@@ -18,4 +22,5 @@ __all__ = [
     # transaction
     "ScheduleRepository",
     "OrderRepository",
+    "OrderApprovalLogRepository",
 ]

--- a/backend/app/repositories/supa_infra/common/table_name.py
+++ b/backend/app/repositories/supa_infra/common/table_name.py
@@ -20,3 +20,4 @@ class SupabaseTableName(Enum):
     ORDER_ATTACHMENTS = "order_attachments"
     ORDER_PARSE_LOG = "order_parse_log"
     NOTIFICATIONS = "notifications"
+    ORDER_APPROVAL_LOG = "order_approval_log"

--- a/backend/app/repositories/supa_infra/transaction/__init__.py
+++ b/backend/app/repositories/supa_infra/transaction/__init__.py
@@ -1,5 +1,6 @@
 # repositories/supabase/transaction/__init__.py
+from .order_approval_log_repo import OrderApprovalLogRepository
 from .order_repo import OrderRepository
 from .schedule_repo import ScheduleRepository
 
-__all__ = ["OrderRepository", "ScheduleRepository"]
+__all__ = ["OrderRepository", "OrderApprovalLogRepository", "ScheduleRepository"]

--- a/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
@@ -1,0 +1,49 @@
+# repositories/supa_infra/transaction/order_approval_log_repo.py
+from typing import Any, cast
+
+from app.repositories.supa_infra.common import BaseRepository, SupabaseTableName
+
+
+class OrderApprovalLogRepository(BaseRepository):
+    def __init__(self, client):
+        super().__init__(client, SupabaseTableName.ORDER_APPROVAL_LOG.value)
+
+    def log_action(
+        self,
+        tenant_id: str,
+        order_id: int,
+        action: str,
+        actor_user_id: str,
+        reason: str | None = None,
+    ) -> dict:
+        """承認ワークフローの操作（依頼送信・承認・却下）を監査ログに記録する。"""
+        return self.create(
+            {
+                "tenant_id": tenant_id,
+                "order_id": order_id,
+                "action": action,
+                "actor_user_id": actor_user_id,
+                "reason": reason,
+            }
+        )
+
+    def get_all(self) -> list[dict]:
+        """テナント内の承認監査ログを新しい順に全件取得する（RLSでテナント境界を強制）。"""
+        res = (
+            self.client.table(self.table_name)
+            .select("*")
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], res.data or [])
+
+    def get_by_order_id(self, order_id: int) -> list[dict]:
+        """特定注文の承認監査ログを新しい順に取得する。"""
+        res = (
+            self.client.table(self.table_name)
+            .select("*")
+            .eq("order_id", order_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return cast(list[dict[str, Any]], res.data or [])

--- a/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
@@ -1,6 +1,8 @@
 # repositories/supa_infra/transaction/order_approval_log_repo.py
 from typing import Any, cast
 
+from postgrest.types import ReturnMethod
+
 from app.repositories.supa_infra.common import BaseRepository, SupabaseTableName
 
 
@@ -15,17 +17,26 @@ class OrderApprovalLogRepository(BaseRepository):
         action: str,
         actor_user_id: str,
         reason: str | None = None,
-    ) -> dict:
-        """承認ワークフローの操作（依頼送信・承認・却下）を監査ログに記録する。"""
-        return self.create(
+    ) -> None:
+        """
+        承認ワークフローの操作（依頼送信・承認・却下）を監査ログに記録する。
+
+        order_handler など監査ログの閲覧権限を持たないロールも書き込みは行うため、
+        `returning="minimal"` でINSERT後のRETURNING句を省略する。デフォルトの
+        `returning="representation"` のままだと、PostgRESTがINSERT結果を返す際に
+        SELECT用のRLSポリシー（iso_officer/president/platform_admin限定）が
+        適用され、対象外ロールでは書き込みそのものが失敗してしまう。
+        """
+        self.client.table(self.table_name).insert(
             {
                 "tenant_id": tenant_id,
                 "order_id": order_id,
                 "action": action,
                 "actor_user_id": actor_user_id,
                 "reason": reason,
-            }
-        )
+            },
+            returning=ReturnMethod.minimal,
+        ).execute()
 
     def get_all(self) -> list[dict]:
         """テナント内の承認監査ログを新しい順に全件取得する（RLSでテナント境界を強制）。"""

--- a/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
+++ b/backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py
@@ -19,7 +19,7 @@ class OrderApprovalLogRepository(BaseRepository):
         reason: str | None = None,
     ) -> None:
         """
-        承認ワークフローの操作（依頼送信・承認・却下）を監査ログに記録する。
+        承認ワークフローの操作（依頼送信・承認・差し戻し・取り下げ）を監査ログに記録する。
 
         order_handler など監査ログの閲覧権限を持たないロールも書き込みは行うため、
         `returning="minimal"` でINSERT後のRETURNING句を省略する。デフォルトの

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -1,8 +1,11 @@
 # routers/transaction/orders.py
+import csv
+import io
 from datetime import UTC, date, datetime
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
 from postgrest.exceptions import APIError
 
 from app.dependencies import (
@@ -10,6 +13,7 @@ from app.dependencies import (
     get_current_user_id,
     get_current_user_role,
     get_equipment_repo,
+    get_order_approval_log_repo,
     get_order_repo,
     get_product_repo,
     get_schedule_repo,
@@ -17,6 +21,7 @@ from app.dependencies import (
     get_supabase_client,
 )
 from app.models.transaction.order_schema import (
+    OrderApprovalLogResponse,
     OrderAttachmentResponse,
     OrderBulkApproveRequest,
     OrderCreate,
@@ -31,6 +36,9 @@ from app.repositories.supa_infra.common.scheduling_settings_repo import (
 from app.repositories.supa_infra.common.table_name import SupabaseTableName
 from app.repositories.supa_infra.master.equipment_repo import EquipmentRepository
 from app.repositories.supa_infra.master.product_repo import ProductRepository
+from app.repositories.supa_infra.transaction.order_approval_log_repo import (
+    OrderApprovalLogRepository,
+)
 from app.repositories.supa_infra.transaction.order_repo import OrderRepository
 from app.repositories.supa_infra.transaction.schedule_repo import ScheduleRepository
 from app.scheduler_logic import RoutingUnconfirmedError, schedule_order
@@ -132,6 +140,137 @@ def get_unconfirmed_routing_queue(
 
     items.sort(key=lambda x: (x["buffer_days"] is None, x["buffer_days"] or 0))
     return {"count": len(items), "items": items}
+
+
+# 承認履歴の閲覧・出力を許可するロール（iso_officer: 監査目的、president: 承認者本人としての確認）。
+# order_handler は自身の操作ログであっても閲覧不可とし、監査ログとしての独立性を保つ。
+_APPROVAL_LOG_VIEWER_ROLES = ("iso_officer", "president", "platform_admin")
+
+
+def _fetch_enriched_approval_logs(
+    tenant_id: str,
+    user_id: str,
+    client: Client,
+    admin_client: Client,
+    approval_log_repo: OrderApprovalLogRepository,
+) -> list[dict[str, Any]]:
+    _require_any_role(
+        tenant_id, user_id, client, _APPROVAL_LOG_VIEWER_ROLES, "承認履歴の閲覧"
+    )
+
+    # RLS (is_tenant_member + ロール制約) を通すためユーザーJWTクライアントで取得する。
+    logs = approval_log_repo.get_all()
+    if not logs:
+        return []
+
+    order_ids = list({log["order_id"] for log in logs})
+    actor_ids = list({log["actor_user_id"] for log in logs})
+
+    orders_res = (
+        admin_client.table("orders")
+        .select("id, order_number")
+        .in_("id", order_ids)
+        .execute()
+    )
+    order_number_map = {
+        o["id"]: o["order_number"]
+        for o in cast(list[dict[str, Any]], orders_res.data or [])
+    }
+
+    profiles_res = (
+        admin_client.table("profiles")
+        .select("id, full_name, email")
+        .in_("id", actor_ids)
+        .execute()
+    )
+    profiles_map = {
+        p["id"]: p for p in cast(list[dict[str, Any]], profiles_res.data or [])
+    }
+
+    enriched: list[dict[str, Any]] = []
+    for log in logs:
+        profile = profiles_map.get(log["actor_user_id"], {})
+        enriched.append(
+            {
+                "id": log["id"],
+                "order_id": log["order_id"],
+                "order_number": order_number_map.get(log["order_id"]),
+                "action": log["action"],
+                "actor_user_id": log["actor_user_id"],
+                "actor_full_name": profile.get("full_name"),
+                "actor_email": profile.get("email"),
+                "reason": log.get("reason"),
+                "created_at": log["created_at"],
+            }
+        )
+    return enriched
+
+
+@orders_router.get("/approval-logs", response_model=list[OrderApprovalLogResponse])
+def list_approval_logs(
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
+):
+    """
+    承認ワークフロー（承認依頼送信・承認・却下）の監査ログを一覧取得する
+    （iso_officer / president / platform_admin のみ閲覧可）。
+    """
+    return _fetch_enriched_approval_logs(
+        tenant_id, user_id, client, admin_client, approval_log_repo
+    )
+
+
+@orders_router.get("/approval-logs/export")
+def export_approval_logs_csv(
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
+):
+    """
+    承認ワークフローの監査ログをCSV形式で出力する（iso_officer / president / platform_admin のみ）。
+    """
+    logs = _fetch_enriched_approval_logs(
+        tenant_id, user_id, client, admin_client, approval_log_repo
+    )
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        ["注文番号", "操作", "操作者氏名", "操作者メール", "理由", "操作日時"]
+    )
+    action_labels = {
+        "request_approval": "承認依頼送信",
+        "approve": "承認",
+        "reject": "却下",
+    }
+    for log in logs:
+        writer.writerow(
+            [
+                log["order_number"] or "",
+                action_labels.get(log["action"], log["action"]),
+                log["actor_full_name"] or "",
+                log["actor_email"] or "",
+                log["reason"] or "",
+                log["created_at"],
+            ]
+        )
+
+    # Excelでの文字化けを避けるためBOMを付与する
+    csv_content = "﻿" + buffer.getvalue()
+    return StreamingResponse(
+        iter([csv_content]),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="approval_logs.csv"'},
+    )
 
 
 @orders_router.get("/{order_id}")
@@ -443,6 +582,22 @@ def _require_role(
         )
 
 
+def _require_any_role(
+    tenant_id: str,
+    user_id: str,
+    client: Client,
+    allowed_roles: tuple[str, ...],
+    action: str,
+) -> None:
+    """複数ロールのいずれかであれば実行可能な操作のロールチェック。許可されなければ403を送出する。"""
+    role = get_current_user_role(tenant_id, user_id, client)
+    if role not in allowed_roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"{action}は {'/'.join(allowed_roles)} のみ操作できます",
+        )
+
+
 def _confirm_single_order(
     order_id: int,
     tenant_id: str,
@@ -502,6 +657,9 @@ def request_order_approval(
     user_id: str = Depends(get_current_user_id),
     client: Client = Depends(get_supabase_client),
     order_repo: OrderRepository = Depends(get_order_repo),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
 ):
     """
     下書き注文の承認依頼を送信し、注文ステータスをpending_approvalにする（order_handler限定）。
@@ -523,6 +681,7 @@ def request_order_approval(
     result = order_repo.update(
         order_id, {"status": "pending_approval", "rejection_reason": None}
     )
+    approval_log_repo.log_action(tenant_id, order_id, "request_approval", user_id)
     return _map_order_response(result)
 
 
@@ -536,6 +695,9 @@ def confirm_order(
     product_repo: ProductRepository = Depends(get_product_repo),
     schedule_repo: ScheduleRepository = Depends(get_schedule_repo),
     settings_repo: SchedulingSettingsRepository = Depends(get_settings_repo),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
 ):
     """
     受注を承認する。スケジュールを確定・保存し、注文ステータスをconfirmedにする（president限定）。
@@ -544,9 +706,11 @@ def confirm_order(
     _require_role(tenant_id, user_id, client, "president", "受注の承認（確定）")
 
     try:
-        return _confirm_single_order(
+        result = _confirm_single_order(
             order_id, tenant_id, order_repo, product_repo, schedule_repo, settings_repo
         )
+        approval_log_repo.log_action(tenant_id, order_id, "approve", user_id)
+        return result
     except RoutingUnconfirmedError as e:
         raise HTTPException(
             status_code=422,
@@ -569,6 +733,9 @@ def approve_orders_bulk(
     product_repo: ProductRepository = Depends(get_product_repo),
     schedule_repo: ScheduleRepository = Depends(get_schedule_repo),
     settings_repo: SchedulingSettingsRepository = Depends(get_settings_repo),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
 ):
     """
     複数の承認待ち注文をまとめて承認する（president限定）。1件ごとの成否を返す。
@@ -587,6 +754,7 @@ def approve_orders_bulk(
                 schedule_repo,
                 settings_repo,
             )
+            approval_log_repo.log_action(tenant_id, order_id, "approve", user_id)
             results.append(
                 {
                     "order_id": order_id,
@@ -623,6 +791,9 @@ def reject_order(
     user_id: str = Depends(get_current_user_id),
     client: Client = Depends(get_supabase_client),
     order_repo: OrderRepository = Depends(get_order_repo),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
 ):
     """
     承認待ちの注文を却下し、下書きに差し戻す（president限定）。却下理由は任意入力。
@@ -641,5 +812,8 @@ def reject_order(
 
     result = order_repo.update(
         order_id, {"status": "draft", "rejection_reason": reject_data.reason}
+    )
+    approval_log_repo.log_action(
+        tenant_id, order_id, "reject", user_id, reject_data.reason
     )
     return _map_order_response(result)

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -151,14 +151,17 @@ def _fetch_enriched_approval_logs(
     tenant_id: str,
     user_id: str,
     client: Client,
-    admin_client: Client,
     approval_log_repo: OrderApprovalLogRepository,
 ) -> list[dict[str, Any]]:
     _require_any_role(
         tenant_id, user_id, client, _APPROVAL_LOG_VIEWER_ROLES, "承認履歴の閲覧"
     )
 
-    # RLS (is_tenant_member + ロール制約) を通すためユーザーJWTクライアントで取得する。
+    # 監査ログ本体・注文番号・操作者プロフィールのいずれも、閲覧者自身のユーザーJWT
+    # クライアントで取得する（Service Role Keyは使わない）。orders / profiles は
+    # 「同一テナントのメンバーなら閲覧可」というRLSを既に持つため、
+    # _require_any_role でテナントメンバー かつ 閲覧許可ロールであることを検証済みの
+    # このユーザーであれば、RLSをバイパスせずに参照できる。
     logs = approval_log_repo.get_all()
     if not logs:
         return []
@@ -167,10 +170,7 @@ def _fetch_enriched_approval_logs(
     actor_ids = list({log["actor_user_id"] for log in logs})
 
     orders_res = (
-        admin_client.table("orders")
-        .select("id, order_number")
-        .in_("id", order_ids)
-        .execute()
+        client.table("orders").select("id, order_number").in_("id", order_ids).execute()
     )
     order_number_map = {
         o["id"]: o["order_number"]
@@ -178,7 +178,7 @@ def _fetch_enriched_approval_logs(
     }
 
     profiles_res = (
-        admin_client.table("profiles")
+        client.table("profiles")
         .select("id, full_name, email")
         .in_("id", actor_ids)
         .execute()
@@ -211,7 +211,6 @@ def list_approval_logs(
     tenant_id: str = Depends(get_current_tenant_id),
     user_id: str = Depends(get_current_user_id),
     client: Client = Depends(get_supabase_client),
-    admin_client: Client = Depends(get_supabase_admin_client),
     approval_log_repo: OrderApprovalLogRepository = Depends(
         get_order_approval_log_repo
     ),
@@ -220,9 +219,7 @@ def list_approval_logs(
     承認ワークフロー（承認依頼送信・承認・却下）の監査ログを一覧取得する
     （iso_officer / president / platform_admin のみ閲覧可）。
     """
-    return _fetch_enriched_approval_logs(
-        tenant_id, user_id, client, admin_client, approval_log_repo
-    )
+    return _fetch_enriched_approval_logs(tenant_id, user_id, client, approval_log_repo)
 
 
 @orders_router.get("/approval-logs/export")
@@ -230,7 +227,6 @@ def export_approval_logs_csv(
     tenant_id: str = Depends(get_current_tenant_id),
     user_id: str = Depends(get_current_user_id),
     client: Client = Depends(get_supabase_client),
-    admin_client: Client = Depends(get_supabase_admin_client),
     approval_log_repo: OrderApprovalLogRepository = Depends(
         get_order_approval_log_repo
     ),
@@ -238,9 +234,7 @@ def export_approval_logs_csv(
     """
     承認ワークフローの監査ログをCSV形式で出力する（iso_officer / president / platform_admin のみ）。
     """
-    logs = _fetch_enriched_approval_logs(
-        tenant_id, user_id, client, admin_client, approval_log_repo
-    )
+    logs = _fetch_enriched_approval_logs(tenant_id, user_id, client, approval_log_repo)
 
     buffer = io.StringIO()
     writer = csv.writer(buffer)
@@ -582,6 +576,29 @@ def _require_role(
         )
 
 
+def _log_approval_action_safely(
+    approval_log_repo: OrderApprovalLogRepository,
+    tenant_id: str,
+    order_id: int,
+    action: str,
+    user_id: str,
+    reason: str | None = None,
+) -> None:
+    """
+    承認監査ログの記録はベストエフォートとする。
+    状態遷移（承認依頼送信・承認・却下）自体は既にDB更新が成功しており、
+    監査ログの記録に失敗したからといって業務上成功した操作をエラー扱いにはしない
+    （特に `approve-bulk` では、1件のログ記録失敗が他の注文の確定結果を
+    巻き込んで500にしてしまうことを防ぐ）。
+    """
+    try:
+        approval_log_repo.log_action(tenant_id, order_id, action, user_id, reason)
+    except Exception:
+        logger.exception(
+            f"Failed to record approval log: order_id={order_id}, action={action}"
+        )
+
+
 def _require_any_role(
     tenant_id: str,
     user_id: str,
@@ -681,7 +698,9 @@ def request_order_approval(
     result = order_repo.update(
         order_id, {"status": "pending_approval", "rejection_reason": None}
     )
-    approval_log_repo.log_action(tenant_id, order_id, "request_approval", user_id)
+    _log_approval_action_safely(
+        approval_log_repo, tenant_id, order_id, "request_approval", user_id
+    )
     return _map_order_response(result)
 
 
@@ -709,7 +728,9 @@ def confirm_order(
         result = _confirm_single_order(
             order_id, tenant_id, order_repo, product_repo, schedule_repo, settings_repo
         )
-        approval_log_repo.log_action(tenant_id, order_id, "approve", user_id)
+        _log_approval_action_safely(
+            approval_log_repo, tenant_id, order_id, "approve", user_id
+        )
         return result
     except RoutingUnconfirmedError as e:
         raise HTTPException(
@@ -754,7 +775,9 @@ def approve_orders_bulk(
                 schedule_repo,
                 settings_repo,
             )
-            approval_log_repo.log_action(tenant_id, order_id, "approve", user_id)
+            _log_approval_action_safely(
+                approval_log_repo, tenant_id, order_id, "approve", user_id
+            )
             results.append(
                 {
                     "order_id": order_id,
@@ -813,7 +836,7 @@ def reject_order(
     result = order_repo.update(
         order_id, {"status": "draft", "rejection_reason": reject_data.reason}
     )
-    approval_log_repo.log_action(
-        tenant_id, order_id, "reject", user_id, reject_data.reason
+    _log_approval_action_safely(
+        approval_log_repo, tenant_id, order_id, "reject", user_id, reject_data.reason
     )
     return _map_order_response(result)

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -250,7 +250,7 @@ def export_approval_logs_csv(
     for log in logs:
         writer.writerow(
             [
-                log["order_number"] or "",
+                log["order_number"] or f"#{log['order_id']}",
                 action_labels.get(log["action"], log["action"]),
                 log["actor_full_name"] or "",
                 log["actor_email"] or "",

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -216,7 +216,7 @@ def list_approval_logs(
     ),
 ):
     """
-    承認ワークフロー（承認依頼送信・承認・却下）の監査ログを一覧取得する
+    承認ワークフロー（承認依頼送信・承認・差し戻し・取り下げ）の監査ログを一覧取得する
     （iso_officer / president / platform_admin のみ閲覧可）。
     """
     return _fetch_enriched_approval_logs(tenant_id, user_id, client, approval_log_repo)
@@ -244,7 +244,8 @@ def export_approval_logs_csv(
     action_labels = {
         "request_approval": "承認依頼送信",
         "approve": "承認",
-        "reject": "却下",
+        "reject": "差し戻し",
+        "withdraw": "取り下げ",
     }
     for log in logs:
         writer.writerow(
@@ -586,7 +587,7 @@ def _log_approval_action_safely(
 ) -> None:
     """
     承認監査ログの記録はベストエフォートとする。
-    状態遷移（承認依頼送信・承認・却下）自体は既にDB更新が成功しており、
+    状態遷移（承認依頼送信・承認・差し戻し・取り下げ）自体は既にDB更新が成功しており、
     監査ログの記録に失敗したからといって業務上成功した操作をエラー扱いにはしない
     （特に `approve-bulk` では、1件のログ記録失敗が他の注文の確定結果を
     巻き込んで500にしてしまうことを防ぐ）。
@@ -819,10 +820,10 @@ def reject_order(
     ),
 ):
     """
-    承認待ちの注文を却下し、下書きに差し戻す（president限定）。却下理由は任意入力。
+    承認待ちの注文を差し戻す（president限定）。理由は任意入力。
     """
     logger.info(f"Rejecting order {order_id}")
-    _require_role(tenant_id, user_id, client, "president", "受注の却下")
+    _require_role(tenant_id, user_id, client, "president", "受注の差し戻し")
 
     order = order_repo.get_by_id(order_id)
     if not order:
@@ -838,5 +839,42 @@ def reject_order(
     )
     _log_approval_action_safely(
         approval_log_repo, tenant_id, order_id, "reject", user_id, reject_data.reason
+    )
+    return _map_order_response(result)
+
+
+@orders_router.post("/{order_id}/withdraw-approval")
+def withdraw_order_approval(
+    order_id: int,
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    order_repo: OrderRepository = Depends(get_order_repo),
+    approval_log_repo: OrderApprovalLogRepository = Depends(
+        get_order_approval_log_repo
+    ),
+):
+    """
+    誤って送信した承認依頼を取り下げ、下書きに差し戻す（order_handler限定）。
+
+    president による差し戻し（`reject`）とは異なり理由は付かない。
+    「差し戻し」を業務上の判断（president による reject）と、送信主自身による単純な取り消しとで
+    区別できるよう、監査ログには別action（`withdraw`）として記録する。
+    """
+    logger.info(f"Withdrawing approval request for order {order_id}")
+    _require_role(tenant_id, user_id, client, "order_handler", "承認依頼の取り下げ")
+
+    order = order_repo.get_by_id(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    try:
+        validate_order_status_transition(order.get("status"), "draft")
+    except InvalidOrderStatusTransitionError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None
+
+    result = order_repo.update(order_id, {"status": "draft"})
+    _log_approval_action_safely(
+        approval_log_repo, tenant_id, order_id, "withdraw", user_id
     )
     return _map_order_response(result)

--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -55,3 +55,59 @@ order_handler へディスパッチし、president は最終承認（および�
 - `backend/__tests__/api/routers/transaction/test_orders.py`: 各エンドポイントのロール別403、
   ステータス遷移バリデーション違反、`request-approval` の `product_unmatched`、`approve-bulk` の
   部分失敗（1件成功・1件404）を検証
+
+## 操作主体の記録（監査ログ基盤） (Issue #326)
+
+共有端末での操作であっても、承認依頼送信・承認・却下の各操作を実行したユーザーと日時をアプリ層で記録し、
+ISO要件である承認プロセスの証跡を残す。
+
+### データモデル
+
+- `order_approval_log`
+  （[20260811000000_add_order_approval_log.sql](../../supabase/migrations/20260811000000_add_order_approval_log.sql)）
+  - `id, tenant_id, order_id, action(request_approval/approve/reject), actor_user_id, reason, created_at`
+  - RLS: `is_tenant_member(tenant_id)` に加え、SELECTは `organization_members.role` が
+    `iso_officer` / `president` / `platform_admin` のいずれかであることを要求（`order_handler` は
+    自身の操作ログであっても閲覧不可とし、監査ログとしての独立性を保つ）。INSERTは
+    `actor_user_id = auth.uid()` を要求し、なりすまし記録を防ぐ。
+- `backend/app/repositories/supa_infra/transaction/order_approval_log_repo.py`:
+  `OrderApprovalLogRepository.log_action()` / `get_all()` / `get_by_order_id()`
+
+### 記録タイミング
+
+`backend/app/routers/transaction/orders.py` の各エンドポイントで、状態遷移の更新が成功した直後に
+`approval_log_repo.log_action(tenant_id, order_id, action, user_id, reason)` を呼び出す。
+
+| エンドポイント | action | reason |
+|---|---|---|
+| `POST /orders/{id}/request-approval` | `request_approval` | なし |
+| `POST /orders/{id}/confirm` | `approve` | なし |
+| `POST /orders/approve-bulk` | `approve`（成功した注文ごと） | なし |
+| `POST /orders/{id}/reject` | `reject` | 却下理由（任意） |
+
+### 閲覧・出力API
+
+- `GET /orders/approval-logs`（`iso_officer` / `president` / `platform_admin` のみ）: 監査ログ一覧を
+  新しい順に返す。`order_number` と操作者の `actor_full_name` / `actor_email` を
+  `profiles` テーブルから補完して返す（`_fetch_enriched_approval_logs`）。
+- `GET /orders/approval-logs/export`（同ロール限定）: 同内容をCSV（BOM付きUTF-8、Excel向け）で
+  ダウンロードする。
+- ルーティング順序の都合上、`/orders/{order_id}` より前に定義する必要がある
+  （`{order_id}: int` へのパス変換失敗で `/approval-logs` が誤って先にマッチするのを防ぐため）。
+
+### Frontend
+
+- `frontend/src/hooks/use-orders.ts`: `useApprovalLogs()`（一覧取得）、`downloadApprovalLogsCsv()`
+  （CSVダウンロード、JSON以外を返すため `apiClient` を使わず直接 `fetch`）
+- `frontend/src/app/orders/approval-logs/page.tsx`: 監査ログ一覧画面。
+  `useCurrentMember()` の `role` が `iso_officer` / `president` / `platform_admin` 以外の場合は
+  アクセス不可メッセージを表示し、編集・承認操作用のUIは一切持たない（閲覧・出力のみ）。
+- サイドバー（`frontend/src/components/layout/app-sidebar.tsx`）に「承認監査ログ」リンクを追加
+  （ページ側でロールチェックするため、リンク自体は全ロールに表示）。
+
+### テスト
+
+- `backend/__tests__/api/routers/transaction/test_orders.py`:
+  各操作エンドポイントで監査ログが正しい引数で記録されること、`GET /orders/approval-logs` /
+  `/export` が `iso_officer`/`president` では成功し `order_handler` では403になること、
+  CSVレスポンスの内容を検証

--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -1,10 +1,15 @@
-# 承認依頼送信・承認・却下ワークフロー (Issue #325)
+# 承認依頼送信・承認・差し戻しワークフロー (Issue #325)
 
 ## 概要
 
 [受注ステータス遷移](order-status-workflow.md)（Issue #324）で用意した `draft → pending_approval →
 confirmed` の土台に対し、実際に状態を遷移させるAPI/UIを実装した。表記揺れ確認・修正は
-order_handler へディスパッチし、president は最終承認（および却下）のみを行うという業務分担を実現する。
+order_handler へディスパッチし、president は最終承認（および差し戻し）のみを行うという業務分担を実現する。
+
+> **用語について**: `pending_approval → draft` への逆遷移を業務上「差し戻し」と呼ぶ。
+> 内部実装（DBのaction値・エンドポイントパス・関数名等）では最初に実装した際の名残で `reject` を
+> 使っているが、UI上のラベル・トースト・監査ログ表示はすべて「差し戻し」に統一している
+> （Issue #326 のE2Eフィードバックで「却下」という強い語感が実態と合わないため改称）。
 
 ## ステータス遷移とAPIエンドポイント
 
@@ -13,7 +18,8 @@ order_handler へディスパッチし、president は最終承認（および�
 | `draft → pending_approval` | `POST /orders/{id}/request-approval` | `order_handler` |
 | `pending_approval → confirmed` | `POST /orders/{id}/confirm` | `president` |
 | `pending_approval → confirmed`（複数件） | `POST /orders/approve-bulk`（body: `order_ids`） | `president` |
-| `pending_approval → draft`（却下） | `POST /orders/{id}/reject`（body: `reason`、任意） | `president` |
+| `pending_approval → draft`（差し戻し／内部名`reject`） | `POST /orders/{id}/reject`（body: `reason`、任意） | `president` |
+| `pending_approval → draft`（取り下げ） | `POST /orders/{id}/withdraw-approval` | `order_handler` |
 
 いずれも `backend/app/routers/transaction/orders.py` の
 [order_status_service.py](../../backend/app/services/order_status_service.py) 経由の遷移バリデーションと、
@@ -27,45 +33,71 @@ order_handler へディスパッチし、president は最終承認（および�
 `approve-bulk` は同じヘルパーをループで呼び出し、1件ごとの成否を `results` 配列で返す
 （1件が404/422/400等で失敗しても他の注文の処理は継続する）。
 
-## 却下理由
+### 取り下げ（`withdraw-approval`） (Issue #326 フォローアップ)
+
+order_handler が誤って承認依頼を送信してしまった場合、president による差し戻しを待たずに
+自分自身で `pending_approval → draft` に戻せる。president の差し戻しとは異なり理由の入力欄は無く、
+`orders.rejection_reason` も変更しない（業務上の指摘ではなく単なる取り消しのため）。
+監査ログ上は `reject` とは別の `withdraw` actionとして記録し、「業務判断としての差し戻し」と
+「送信者本人による取り消し」を区別できるようにしている。
+
+## 差し戻し理由
 
 `orders.rejection_reason`（nullable text、
 [20260810000003_add_orders_rejection_reason.sql](../../supabase/migrations/20260810000003_add_orders_rejection_reason.sql)）
-に任意入力の却下理由を保存する。`request-approval` で再度承認依頼を送信した時点で `NULL` にクリアされる。
+に任意入力の差し戻し理由を保存する。`request-approval` で再度承認依頼を送信した時点で `NULL` にクリアされる。
+
+`order_handler` から理由が見えず、内容を直さないまま再送信できてしまう問題（Issue #326 のE2E
+フィードバック）に対応するため、フロントエンドでは以下の2段構えで可視化・注意喚起している。
+
+1. **常時表示**: `draft` ステータスかつ `rejection_reason` が設定されている注文には、受注一覧の
+   ステータスバッジ横にアイコン＋ツールチップ（`order-table-row.tsx`）、受注詳細ページには
+   理由全文を表示するアラートパネル（`orders/[id]/page.tsx`）を表示する。閲覧はロール制限なし
+   （order_handler含め誰でも見える）。
+2. **再送信前の確認**: `rejection_reason` が設定されたままの注文に対して「承認依頼を送信」を押すと、
+   理由を表示する確認ダイアログ（`AlertDialog`）を挟んでから送信する（一覧・詳細どちらも同様）。
+   実際に内容を修正したかどうかまでは検証しない（ソフトな注意喚起であり、ハードなブロックではない）。
 
 ## Frontend
 
-- `frontend/src/hooks/use-orders.ts`: `useRequestApproval` / `useRejectOrder` / `useApproveOrdersBulk` を追加
+- `frontend/src/hooks/use-orders.ts`: `useRequestApproval` / `useRejectOrder` /
+  `useWithdrawApproval` / `useApproveOrdersBulk` を追加
 - ロール判定は `useCurrentMember()`（`frontend/src/hooks/use-tenant-members.ts`）の `role` を使用
 - 受注一覧（`frontend/src/app/orders/page.tsx`, `order-table-row.tsx`）:
   - `draft` かつシミュレーション済みの注文には、`order_handler` にのみ「承認依頼を送信」ボタンを表示
     （旧「確定」ボタンを置き換え。`draft → confirmed` の直接遷移は #324 時点で既に不可になっているため）
-  - `pending_approval` の注文には、`president` にのみ「承認」「却下」ボタンを表示
+  - `pending_approval` の注文には、`president` にのみ「承認」「差し戻し」ボタン、`order_handler`
+    にのみ「取り下げ」ボタンを表示（president/order_handlerで排他、同時には出ない）
   - 「承認待ち」ステータスタブ（`STATUS_TABS`）を追加
   - `president` は「承認待ち」タブでチェックボックス選択→一括承認バーから `approve-bulk` を呼び出せる
-- 受注詳細（`frontend/src/app/orders/[id]/page.tsx`）: 一覧と同様に承認依頼送信／承認／却下ボタンを表示
+- 受注詳細（`frontend/src/app/orders/[id]/page.tsx`）: 一覧と同様に承認依頼送信／承認／差し戻し／
+  取り下げボタンを表示。「承認依頼を送信」ボタンはクリック後もページ遷移せずその場に留まる
+  （送信直後に一覧へ強制遷移されて混乱するというIssue #326のE2Eフィードバックに対応。
+  「承認」ボタンは対象注文がその場では操作不要になるため、従来通り一覧へ遷移する）
 - シミュレーション結果サイドシート・一括シミュレーション結果ダイアログの「確定」系ボタンも
   「承認依頼を送信」に統一（シミュレーション自体は `draft` 状態の注文に対して行うため、確定ではなく
   承認依頼送信が正しい遷移になる）
-- 却下ダイアログ（`frontend/src/components/orders/reject-order-dialog.tsx`）: 却下理由を任意入力できる
-  シンプルなダイアログ
+- 差し戻しダイアログ（`frontend/src/components/orders/reject-order-dialog.tsx`、コンポーネント名は
+  実装当初の名残で `RejectOrderDialog` のまま）: 差し戻し理由を任意入力できるシンプルなダイアログ
 
 ## テスト
 
 - `backend/__tests__/api/routers/transaction/test_orders.py`: 各エンドポイントのロール別403、
   ステータス遷移バリデーション違反、`request-approval` の `product_unmatched`、`approve-bulk` の
-  部分失敗（1件成功・1件404）を検証
+  部分失敗（1件成功・1件404）、`withdraw-approval` の成功/403/400/404を検証
 
 ## 操作主体の記録（監査ログ基盤） (Issue #326)
 
-共有端末での操作であっても、承認依頼送信・承認・却下の各操作を実行したユーザーと日時をアプリ層で記録し、
-ISO要件である承認プロセスの証跡を残す。
+共有端末での操作であっても、承認依頼送信・承認・差し戻し・取り下げの各操作を実行したユーザーと日時を
+アプリ層で記録し、ISO要件である承認プロセスの証跡を残す。
 
 ### データモデル
 
 - `order_approval_log`
-  （[20260811000000_add_order_approval_log.sql](../../supabase/migrations/20260811000000_add_order_approval_log.sql)）
-  - `id, tenant_id, order_id, action(request_approval/approve/reject), actor_user_id, reason, created_at`
+  （[20260811000000_add_order_approval_log.sql](../../supabase/migrations/20260811000000_add_order_approval_log.sql)、
+  action追加は
+  [20260811000001_add_withdraw_action_to_order_approval_log.sql](../../supabase/migrations/20260811000001_add_withdraw_action_to_order_approval_log.sql)）
+  - `id, tenant_id, order_id, action(request_approval/approve/reject/withdraw), actor_user_id, reason, created_at`
   - RLS: `is_tenant_member(tenant_id)` に加え、SELECTは `organization_members.role` が
     `iso_officer` / `president` / `platform_admin` のいずれかであることを要求（`order_handler` は
     自身の操作ログであっても閲覧不可とし、監査ログとしての独立性を保つ）。INSERTは
@@ -83,7 +115,8 @@ ISO要件である承認プロセスの証跡を残す。
 | `POST /orders/{id}/request-approval` | `request_approval` | なし |
 | `POST /orders/{id}/confirm` | `approve` | なし |
 | `POST /orders/approve-bulk` | `approve`（成功した注文ごと） | なし |
-| `POST /orders/{id}/reject` | `reject` | 却下理由（任意） |
+| `POST /orders/{id}/reject` | `reject`（UI表示は「差し戻し」） | 差し戻し理由（任意） |
+| `POST /orders/{id}/withdraw-approval` | `withdraw`（UI表示は「取り下げ」） | なし |
 
 監査ログの記録はベストエフォートとする（`_log_approval_action_safely`
 が例外を捕捉してログ出力のみ行う）。状態遷移自体は既にDB更新が成功しているため、

--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -76,7 +76,7 @@ ISO要件である承認プロセスの証跡を残す。
 ### 記録タイミング
 
 `backend/app/routers/transaction/orders.py` の各エンドポイントで、状態遷移の更新が成功した直後に
-`approval_log_repo.log_action(tenant_id, order_id, action, user_id, reason)` を呼び出す。
+`_log_approval_action_safely()`（内部で `approval_log_repo.log_action(...)` を呼ぶ）を実行する。
 
 | エンドポイント | action | reason |
 |---|---|---|
@@ -85,11 +85,27 @@ ISO要件である承認プロセスの証跡を残す。
 | `POST /orders/approve-bulk` | `approve`（成功した注文ごと） | なし |
 | `POST /orders/{id}/reject` | `reject` | 却下理由（任意） |
 
+監査ログの記録はベストエフォートとする（`_log_approval_action_safely`
+が例外を捕捉してログ出力のみ行う）。状態遷移自体は既にDB更新が成功しているため、
+監査ログ書き込みの失敗（一時的なDB不調等）で業務上成功した操作をエラー扱いにしない。
+特に `approve-bulk` は複数注文をループ処理するため、1件のログ記録失敗で他の注文の
+確定結果まで失われて500になることを避ける。
+
+`OrderApprovalLogRepository.log_action()` はINSERT時に `returning=ReturnMethod.minimal`
+を指定する。デフォルトの `returning=representation`（`BaseRepository.create()` の挙動）のままだと、
+PostgRESTがINSERT結果を返す際にSELECT用RLSポリシー（`iso_officer`/`president`/`platform_admin`限定）
+を評価してしまい、閲覧権限を持たない `order_handler` からの書き込みそのものが失敗する
+（`42501 new row violates row-level security policy` で500になる不具合があった）。
+
 ### 閲覧・出力API
 
 - `GET /orders/approval-logs`（`iso_officer` / `president` / `platform_admin` のみ）: 監査ログ一覧を
   新しい順に返す。`order_number` と操作者の `actor_full_name` / `actor_email` を
-  `profiles` テーブルから補完して返す（`_fetch_enriched_approval_logs`）。
+  `orders` / `profiles` テーブルから補完して返す（`_fetch_enriched_approval_logs`）。
+  補完クエリは呼び出し元ユーザー自身のJWTクライアント（`get_supabase_client`）で行い、
+  Service Role Key（`get_supabase_admin_client`）は使わない。`orders`・`profiles` はいずれも
+  「同一テナントのメンバーなら閲覧可」というRLSを既に持つため、`_require_any_role` で
+  閲覧許可ロールであることを検証済みのユーザーであれば、RLSをバイパスせず素通しで参照できる。
 - `GET /orders/approval-logs/export`（同ロール限定）: 同内容をCSV（BOM付きUTF-8、Excel向け）で
   ダウンロードする。
 - ルーティング順序の都合上、`/orders/{order_id}` より前に定義する必要がある
@@ -97,11 +113,14 @@ ISO要件である承認プロセスの証跡を残す。
 
 ### Frontend
 
-- `frontend/src/hooks/use-orders.ts`: `useApprovalLogs()`（一覧取得）、`downloadApprovalLogsCsv()`
-  （CSVダウンロード、JSON以外を返すため `apiClient` を使わず直接 `fetch`）
+- `frontend/src/hooks/use-orders.ts`: `useApprovalLogs({ enabled })`（一覧取得。閲覧不可ロールで
+  無駄な403リクエストを飛ばさないよう、呼び出し側がロール確定後にのみ `enabled: true` を渡す設計）、
+  `downloadApprovalLogsCsv()`（CSVダウンロード、JSON以外を返すため `apiClient` を使わず直接 `fetch`）
 - `frontend/src/app/orders/approval-logs/page.tsx`: 監査ログ一覧画面。
   `useCurrentMember()` の `role` が `iso_officer` / `president` / `platform_admin` 以外の場合は
   アクセス不可メッセージを表示し、編集・承認操作用のUIは一切持たない（閲覧・出力のみ）。
+  `useApprovalLogs({ enabled: !isMemberLoading && canView })` として、ロール確定前・閲覧不可ロールでは
+  一覧取得APIを呼び出さない。
 - サイドバー（`frontend/src/components/layout/app-sidebar.tsx`）に「承認監査ログ」リンクを追加
   （ページ側でロールチェックするため、リンク自体は全ロールに表示）。
 

--- a/frontend/src/app/orders/[id]/page.tsx
+++ b/frontend/src/app/orders/[id]/page.tsx
@@ -13,9 +13,20 @@ import {
   Pencil,
   Split,
   Trash2,
+  Undo2,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { SimulationResult } from "@/components/simulation-result"
 import { EditOrderDialog } from "@/components/orders/edit-order-dialog"
 import { DeleteOrderDialog } from "@/components/orders/delete-order-dialog"
@@ -28,6 +39,7 @@ import {
   useConfirmOrder,
   useRequestApproval,
   useRejectOrder,
+  useWithdrawApproval,
   useDeleteOrder,
 } from "@/hooks/use-orders"
 import { useCurrentMember } from "@/hooks/use-tenant-members"
@@ -61,6 +73,7 @@ export default function OrderDetailPage() {
   const confirmMutation = useConfirmOrder()
   const requestApprovalMutation = useRequestApproval()
   const rejectMutation = useRejectOrder()
+  const withdrawMutation = useWithdrawApproval()
   const deleteMutation = useDeleteOrder()
 
   const [simulationResult, setSimulationResult] = useState<OrderSimulateResponse | null>(null)
@@ -69,6 +82,7 @@ export default function OrderDetailPage() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isSplitDialogOpen, setIsSplitDialogOpen] = useState(false)
   const [isRejectDialogOpen, setIsRejectDialogOpen] = useState(false)
+  const [isResubmitConfirmOpen, setIsResubmitConfirmOpen] = useState(false)
 
   const handleOpenEditDialog = () => {
     setIsEditDialogOpen(true)
@@ -119,9 +133,19 @@ export default function OrderDetailPage() {
     try {
       await requestApprovalMutation.mutateAsync(orderId)
       toast.success("承認依頼を送信しました")
-      router.push("/orders")
+      setIsResubmitConfirmOpen(false)
     } catch {
       toast.error("承認依頼の送信に失敗しました")
+    }
+  }
+
+  const handleRequestApprovalClick = () => {
+    // 差し戻し理由が残っている場合は、内容を見落としたまま再送信しないよう
+    // 一度確認ダイアログを挟む（Issue #326 E2Eフィードバック）
+    if (order?.rejection_reason) {
+      setIsResubmitConfirmOpen(true)
+    } else {
+      handleRequestApproval()
     }
   }
 
@@ -138,10 +162,19 @@ export default function OrderDetailPage() {
   const handleReject = async (reason: string) => {
     try {
       await rejectMutation.mutateAsync({ id: orderId, reason: reason || undefined })
-      toast.success("注文を却下しました")
+      toast.success("注文を差し戻しました")
       setIsRejectDialogOpen(false)
     } catch {
-      toast.error("却下に失敗しました")
+      toast.error("差し戻しに失敗しました")
+    }
+  }
+
+  const handleWithdraw = async () => {
+    try {
+      await withdrawMutation.mutateAsync(orderId)
+      toast.success("承認依頼を取り下げました")
+    } catch {
+      toast.error("承認依頼の取り下げに失敗しました")
     }
   }
 
@@ -257,6 +290,19 @@ export default function OrderDetailPage() {
             </dl>
           </div>
 
+          {/* 差し戻し理由パネル (draft かつ 直近に差し戻された場合のみ) */}
+          {isDraft && order.rejection_reason && (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-4">
+              <p className="text-sm font-medium text-amber-800 flex items-center gap-1.5">
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                差し戻し理由
+              </p>
+              <p className="text-sm text-amber-900 mt-1 whitespace-pre-wrap">
+                {order.rejection_reason}
+              </p>
+            </div>
+          )}
+
           {/* メール本文パネル (メール起票時のみ) */}
           {order.source_type === 'email' && order.source_raw && (
             <div className="rounded-lg border bg-muted/50 p-4">
@@ -365,13 +411,23 @@ export default function OrderDetailPage() {
             )}
             {isDraft && order.is_scheduled && currentUserRole === "order_handler" && (
               <Button
-                onClick={handleRequestApproval}
+                onClick={handleRequestApprovalClick}
                 disabled={requestApprovalMutation.isPending}
                 variant="default"
                 className="flex-1"
               >
                 <Check className="mr-2 h-4 w-4" />
                 {requestApprovalMutation.isPending ? "処理中..." : "承認依頼を送信"}
+              </Button>
+            )}
+            {isPendingApproval && currentUserRole === "order_handler" && (
+              <Button
+                onClick={handleWithdraw}
+                disabled={withdrawMutation.isPending}
+                variant="outline"
+              >
+                <Undo2 className="mr-2 h-4 w-4" />
+                {withdrawMutation.isPending ? "処理中..." : "承認依頼を取り下げる"}
               </Button>
             )}
             {isPendingApproval && currentUserRole === "president" && (
@@ -389,7 +445,7 @@ export default function OrderDetailPage() {
                   onClick={() => setIsRejectDialogOpen(true)}
                   variant="outline"
                 >
-                  却下
+                  差し戻し
                 </Button>
               </>
             )}
@@ -462,6 +518,28 @@ export default function OrderDetailPage() {
         onConfirm={handleReject}
         onOpenChange={(open) => { if (!open) setIsRejectDialogOpen(false) }}
       />
+
+      <AlertDialog open={isResubmitConfirmOpen} onOpenChange={setIsResubmitConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>差し戻し理由を確認してください</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>この注文は一度差し戻されています。内容を修正したうえで再送信してください。</p>
+                <p className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 whitespace-pre-wrap">
+                  {order.rejection_reason}
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRequestApproval}>
+              確認のうえ承認依頼を送信する
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/frontend/src/app/orders/approval-logs/page.tsx
+++ b/frontend/src/app/orders/approval-logs/page.tsx
@@ -21,7 +21,8 @@ import type { OrderApprovalLog } from "@/types/order"
 const ACTION_LABELS: Record<OrderApprovalLog["action"], string> = {
   request_approval: "承認依頼送信",
   approve: "承認",
-  reject: "却下",
+  reject: "差し戻し",
+  withdraw: "取り下げ",
 }
 
 const ACTION_BADGE_VARIANTS: Record<
@@ -31,6 +32,7 @@ const ACTION_BADGE_VARIANTS: Record<
   request_approval: "secondary",
   approve: "default",
   reject: "outline",
+  withdraw: "outline",
 }
 
 function formatDateTime(value: string): string {
@@ -89,7 +91,7 @@ export default function ApprovalLogsPage() {
         <div>
           <h1 className="text-xl font-bold">承認監査ログ</h1>
           <p className="text-sm text-muted-foreground">
-            承認依頼送信・承認・却下の各操作の記録です。閲覧・出力のみで編集はできません。
+            承認依頼送信・承認・差し戻し・取り下げの各操作の記録です。閲覧・出力のみで編集はできません。
           </p>
         </div>
         <Button onClick={handleExport} disabled={isExporting} variant="outline">

--- a/frontend/src/app/orders/approval-logs/page.tsx
+++ b/frontend/src/app/orders/approval-logs/page.tsx
@@ -50,7 +50,9 @@ export default function ApprovalLogsPage() {
     currentUserRole === "president" ||
     currentUserRole === "platform_admin"
 
-  const { data: logs, isLoading, isError } = useApprovalLogs()
+  const { data: logs, isLoading, isError } = useApprovalLogs({
+    enabled: !isMemberLoading && canView,
+  })
   const [isExporting, setIsExporting] = useState(false)
 
   const handleExport = async () => {

--- a/frontend/src/app/orders/approval-logs/page.tsx
+++ b/frontend/src/app/orders/approval-logs/page.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useState } from "react"
+import { Download, ShieldAlert } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useApprovalLogs, downloadApprovalLogsCsv } from "@/hooks/use-orders"
+import { useCurrentMember } from "@/hooks/use-tenant-members"
+import type { OrderApprovalLog } from "@/types/order"
+
+const ACTION_LABELS: Record<OrderApprovalLog["action"], string> = {
+  request_approval: "承認依頼送信",
+  approve: "承認",
+  reject: "却下",
+}
+
+const ACTION_BADGE_VARIANTS: Record<
+  OrderApprovalLog["action"],
+  "default" | "secondary" | "outline"
+> = {
+  request_approval: "secondary",
+  approve: "default",
+  reject: "outline",
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString("ja-JP")
+}
+
+/**
+ * 承認ワークフロー監査ログ閲覧ページ
+ * URL: /orders/approval-logs
+ * 閲覧・出力のみ提供し、編集・承認操作は一切行わない（iso_officer / president / platform_admin 限定）
+ */
+export default function ApprovalLogsPage() {
+  const { data: currentMember, isLoading: isMemberLoading } = useCurrentMember()
+  const currentUserRole = currentMember?.role ?? null
+  const canView =
+    currentUserRole === "iso_officer" ||
+    currentUserRole === "president" ||
+    currentUserRole === "platform_admin"
+
+  const { data: logs, isLoading, isError } = useApprovalLogs()
+  const [isExporting, setIsExporting] = useState(false)
+
+  const handleExport = async () => {
+    setIsExporting(true)
+    try {
+      await downloadApprovalLogsCsv()
+    } catch {
+      toast.error("CSV出力に失敗しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  if (isMemberLoading) {
+    return (
+      <div className="p-6">
+        <Skeleton className="h-8 w-64" />
+      </div>
+    )
+  }
+
+  if (!canView) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-12 text-center text-muted-foreground">
+        <ShieldAlert className="h-8 w-8" />
+        <p>この画面は iso_officer / president / platform_admin のみ閲覧できます。</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">承認監査ログ</h1>
+          <p className="text-sm text-muted-foreground">
+            承認依頼送信・承認・却下の各操作の記録です。閲覧・出力のみで編集はできません。
+          </p>
+        </div>
+        <Button onClick={handleExport} disabled={isExporting} variant="outline">
+          <Download className="mr-2 h-4 w-4" />
+          {isExporting ? "出力中..." : "CSV出力"}
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-sm text-destructive">監査ログの取得に失敗しました。</p>
+      )}
+
+      {!isLoading && !isError && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>注文番号</TableHead>
+              <TableHead>操作</TableHead>
+              <TableHead>操作者</TableHead>
+              <TableHead>理由</TableHead>
+              <TableHead>操作日時</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(logs ?? []).length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-muted-foreground">
+                  監査ログはまだありません
+                </TableCell>
+              </TableRow>
+            ) : (
+              (logs ?? []).map((log) => (
+                <TableRow key={log.id}>
+                  <TableCell>{log.order_number ?? `#${log.order_id}`}</TableCell>
+                  <TableCell>
+                    <Badge variant={ACTION_BADGE_VARIANTS[log.action]}>
+                      {ACTION_LABELS[log.action]}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {log.actor_full_name ?? log.actor_email ?? log.actor_user_id}
+                  </TableCell>
+                  <TableCell>{log.reason ?? "-"}</TableCell>
+                  <TableCell>{formatDateTime(log.created_at)}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/orders/page.tsx
+++ b/frontend/src/app/orders/page.tsx
@@ -12,6 +12,16 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { MasterPagination } from "@/components/master-pagination"
 import { BulkActionBar } from "@/components/orders/bulk-action-bar"
 import { BulkSimulateConfirmDialog } from "@/components/orders/bulk-simulate-confirm-dialog"
@@ -53,12 +63,14 @@ export default function OrdersPage() {
     confirmOrder,
     requestApproval,
     rejectOrder,
+    withdrawApproval,
     deleteOrder,
     simulatingOrderId,
     simulationErrorOrderId,
     setParam,
     handleApproveFromRow,
     handleRequestApprovalFromRow,
+    handleWithdrawFromRow,
     handleRejectRequest,
     handleConfirmReject,
     handleSimulate,
@@ -67,6 +79,9 @@ export default function OrdersPage() {
     closeSimResult,
     rejectTargetOrder,
     setRejectTargetOrder,
+    resubmitTargetOrder,
+    setResubmitTargetOrder,
+    handleConfirmResubmit,
     selectedOrderIds,
     selectedScheduledCount,
     selectedPendingApprovalCount,
@@ -192,6 +207,7 @@ export default function OrdersPage() {
                     hasSimulationError={simulationErrorOrderId === order.id}
                     requestApprovalIsPending={requestApproval.isPending}
                     approveIsPending={confirmOrder.isPending}
+                    withdrawIsPending={withdrawApproval.isPending}
                     currentUserRole={currentUserRole}
                     isSelected={selectedOrderIds.includes(order.id)}
                     selectionIndex={selectedOrderIds.includes(order.id) ? selectedOrderIds.indexOf(order.id) + 1 : undefined}
@@ -201,6 +217,7 @@ export default function OrdersPage() {
                     onRequestApproval={handleRequestApprovalFromRow}
                     onApprove={handleApproveFromRow}
                     onReject={handleRejectRequest}
+                    onWithdraw={handleWithdrawFromRow}
                     onEdit={handleOpenEditDialog}
                     onDelete={setDeleteTargetOrder}
                     onToggleSelect={handleToggleSelect}
@@ -257,6 +274,34 @@ export default function OrdersPage() {
           onConfirm={handleConfirmReject}
           onOpenChange={(open) => { if (!open) setRejectTargetOrder(null) }}
         />
+
+        <AlertDialog
+          open={resubmitTargetOrder !== null}
+          onOpenChange={(open) => { if (!open) setResubmitTargetOrder(null) }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>差し戻し理由を確認してください</AlertDialogTitle>
+              <AlertDialogDescription asChild>
+                <div className="space-y-2">
+                  <p>
+                    注文「{resubmitTargetOrder?.order_no ?? ""}」は一度差し戻されています。
+                    内容を修正したうえで再送信してください。
+                  </p>
+                  <p className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 whitespace-pre-wrap">
+                    {resubmitTargetOrder?.rejection_reason}
+                  </p>
+                </div>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirmResubmit}>
+                確認のうえ承認依頼を送信する
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <SimulationSideSheet
           open={expandedSimResult !== null}

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Calendar,
   Users,
   Settings,
+  ClipboardList,
 } from "lucide-react"
 
 import {
@@ -63,6 +64,11 @@ const menuItems: MenuItem[] = [
     title: "生産スケジュール",
     url: "/schedule",
     icon: Calendar,
+  },
+  {
+    title: "承認監査ログ",
+    url: "/orders/approval-logs",
+    icon: ClipboardList,
   },
   {
     title: "マスタデータ",

--- a/frontend/src/components/orders/order-table-row.tsx
+++ b/frontend/src/components/orders/order-table-row.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { AlertCircle, Loader2, Mail, MoreHorizontal } from "lucide-react"
+import { AlertCircle, Loader2, Mail, MoreHorizontal, MessageSquareWarning, Undo2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -38,15 +38,17 @@ interface OrderTableRowProps {
   hasSimulationError: boolean
   requestApprovalIsPending: boolean
   approveIsPending: boolean
+  withdrawIsPending: boolean
   currentUserRole: string | null
   isSelected: boolean
   selectionIndex?: number
   isBulkOperationInProgress: boolean
   hasBulkSimFailed?: boolean
   onSimulate: (order: Order) => void
-  onRequestApproval: (orderId: number, orderNo: string) => void
+  onRequestApproval: (order: Order) => void
   onApprove: (orderId: number, orderNo: string) => void
   onReject: (order: Order) => void
+  onWithdraw: (orderId: number, orderNo: string) => void
   onEdit: (order: Order) => void
   onDelete: (order: Order) => void
   onToggleSelect: (orderId: number) => void
@@ -60,6 +62,7 @@ export function OrderTableRow({
   hasSimulationError,
   requestApprovalIsPending,
   approveIsPending,
+  withdrawIsPending,
   currentUserRole,
   isSelected,
   selectionIndex,
@@ -69,6 +72,7 @@ export function OrderTableRow({
   onRequestApproval,
   onApprove,
   onReject,
+  onWithdraw,
   onEdit,
   onDelete,
   onToggleSelect,
@@ -151,9 +155,21 @@ export function OrderTableRow({
         </TableCell>
         <TableCell>
           <div className="flex flex-col items-start gap-1">
-            <Badge className={getStatusBadgeClass(order.status)}>
-              {getStatusLabel(order.status)}
-            </Badge>
+            <div className="flex items-center gap-1.5">
+              <Badge className={getStatusBadgeClass(order.status)}>
+                {getStatusLabel(order.status)}
+              </Badge>
+              {order.status === "draft" && order.rejection_reason && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <MessageSquareWarning className="h-4 w-4 text-amber-600 shrink-0" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs whitespace-pre-wrap">
+                    差し戻し理由: {order.rejection_reason}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             {order.customer_certainty && (
               <Badge className={getCertaintyBadgeClass(order.customer_certainty)}>
                 {getCertaintyLabel(order.customer_certainty)}
@@ -202,10 +218,21 @@ export function OrderTableRow({
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => onRequestApproval(order.id, order.order_no ?? "")}
+                onClick={() => onRequestApproval(order)}
                 disabled={requestApprovalIsPending || isBulkOperationInProgress}
               >
                 承認依頼を送信
+              </Button>
+            )}
+            {order.status === "pending_approval" && currentUserRole === "order_handler" && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onWithdraw(order.id, order.order_no ?? "")}
+                disabled={withdrawIsPending || isBulkOperationInProgress}
+              >
+                <Undo2 className="mr-1.5 h-3.5 w-3.5" />
+                取り下げ
               </Button>
             )}
             {order.status === "pending_approval" && currentUserRole === "president" && (
@@ -223,7 +250,7 @@ export function OrderTableRow({
                   onClick={() => onReject(order)}
                   disabled={isBulkOperationInProgress}
                 >
-                  却下
+                  差し戻し
                 </Button>
               </>
             )}

--- a/frontend/src/components/orders/reject-order-dialog.tsx
+++ b/frontend/src/components/orders/reject-order-dialog.tsx
@@ -46,14 +46,14 @@ function RejectOrderDialogForm({
   return (
     <DialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-[720px]">
       <DialogHeader className="px-6 pb-4 pt-6">
-        <DialogTitle>受注の却下</DialogTitle>
+        <DialogTitle>受注の差し戻し</DialogTitle>
         <DialogDescription>
-          注文「{order.order_no ?? ""}」を却下し、下書きに差し戻します。理由は任意で入力できます。
+          注文「{order.order_no ?? ""}」を下書きに差し戻します。理由は任意で入力できます。
         </DialogDescription>
       </DialogHeader>
 
       <div className="flex min-h-0 flex-1 border-t">
-        {/* 左: 注文基本情報（却下理由を書く際に注文内容を見返せるようにする） */}
+        {/* 左: 注文基本情報（差し戻し理由を書く際に注文内容を見返せるようにする） */}
         <div className="w-[280px] shrink-0 space-y-4 overflow-y-auto border-r bg-muted/30 p-5">
           <p className="text-sm font-medium">注文基本情報</p>
           <dl className="space-y-3 text-sm">
@@ -84,9 +84,9 @@ function RejectOrderDialogForm({
           </dl>
         </div>
 
-        {/* 右: 却下理由 */}
+        {/* 右: 差し戻し理由 */}
         <div className="flex flex-1 flex-col gap-2 p-5">
-          <Label htmlFor="reject-reason">却下理由（任意）</Label>
+          <Label htmlFor="reject-reason">差し戻し理由（任意）</Label>
           <textarea
             id="reject-reason"
             value={reason}
@@ -105,7 +105,7 @@ function RejectOrderDialogForm({
           キャンセル
         </Button>
         <Button variant="destructive" onClick={() => onConfirm(reason)} disabled={isPending}>
-          {isPending ? "却下中..." : "却下する"}
+          {isPending ? "差し戻し中..." : "差し戻す"}
         </Button>
       </DialogFooter>
     </DialogContent>

--- a/frontend/src/components/orders/simulation-side-sheet.tsx
+++ b/frontend/src/components/orders/simulation-side-sheet.tsx
@@ -18,7 +18,7 @@ interface SimulationSideSheetProps {
   requestApprovalIsPending: boolean
   currentUserRole: string | null
   onClose: () => void
-  onRequestApproval: (orderId: number, orderNo: string) => void
+  onRequestApproval: (order: Order) => void
 }
 
 export function SimulationSideSheet({
@@ -53,7 +53,7 @@ export function SimulationSideSheet({
             <Button
               disabled={requestApprovalIsPending || !order}
               onClick={() => {
-                if (order) onRequestApproval(order.id, order.order_no ?? '')
+                if (order) onRequestApproval(order)
               }}
             >
               承認依頼を送信

--- a/frontend/src/hooks/use-orders-page.ts
+++ b/frontend/src/hooks/use-orders-page.ts
@@ -12,6 +12,7 @@ import {
   useRejectOrder,
   useRequestApproval,
   useSimulateOrderById,
+  useWithdrawApproval,
 } from "@/hooks/use-orders"
 import { useCurrentMember } from "@/hooks/use-tenant-members"
 import { useProducts } from "@/hooks/use-products"
@@ -54,6 +55,7 @@ export function useOrdersPage() {
   const [bulkSimSummary, setBulkSimSummary] = useState<BulkSimulateResult[] | null>(null)
   const [bulkSimFailedIds, setBulkSimFailedIds] = useState<Set<number>>(new Set())
   const [rejectTargetOrder, setRejectTargetOrder] = useState<Order | null>(null)
+  const [resubmitTargetOrder, setResubmitTargetOrder] = useState<Order | null>(null)
 
   const queryClient = useQueryClient()
 
@@ -66,6 +68,7 @@ export function useOrdersPage() {
   const confirmOrder = useConfirmOrder()
   const requestApproval = useRequestApproval()
   const rejectOrder = useRejectOrder()
+  const withdrawApproval = useWithdrawApproval()
   const approveOrdersBulk = useApproveOrdersBulk()
   const deleteOrder = useDeleteOrder()
   const simulateOrderById = useSimulateOrderById()
@@ -158,15 +161,44 @@ export function useOrdersPage() {
     })
   }
 
-  const handleRequestApprovalFromRow = (orderId: number, orderNo: string) => {
+  const submitRequestApproval = (orderId: number, orderNo: string) => {
     requestApproval.mutate(orderId, {
       onSuccess: () => {
         toast.success(`注文「${orderNo}」の承認依頼を送信しました`)
         setExpandedOrderId(null)
         setExpandedSimResult(null)
+        setResubmitTargetOrder(null)
       },
       onError: (error: Error) => {
         toast.error(`承認依頼の送信に失敗しました: ${error.message}`)
+      },
+    })
+  }
+
+  const handleRequestApprovalFromRow = (order: Order) => {
+    // 差し戻し理由が残っている場合は、内容を見落としたまま再送信しないよう
+    // 一度確認ダイアログを挟む（Issue #326 E2Eフィードバック）
+    if (order.rejection_reason) {
+      setResubmitTargetOrder(order)
+    } else {
+      submitRequestApproval(order.id, order.order_no ?? "")
+    }
+  }
+
+  const handleConfirmResubmit = () => {
+    if (!resubmitTargetOrder) return
+    submitRequestApproval(resubmitTargetOrder.id, resubmitTargetOrder.order_no ?? "")
+  }
+
+  const handleWithdrawFromRow = (orderId: number, orderNo: string) => {
+    withdrawApproval.mutate(orderId, {
+      onSuccess: () => {
+        toast.success(`注文「${orderNo}」の承認依頼を取り下げました`)
+        setExpandedOrderId(null)
+        setExpandedSimResult(null)
+      },
+      onError: (error: Error) => {
+        toast.error(`承認依頼の取り下げに失敗しました: ${error.message}`)
       },
     })
   }
@@ -181,11 +213,11 @@ export function useOrdersPage() {
       { id: targetId, reason: reason || undefined },
       {
         onSuccess: () => {
-          toast.success(`注文「${orderNo}」を却下しました`)
+          toast.success(`注文「${orderNo}」を差し戻しました`)
           setRejectTargetOrder(null)
         },
         onError: (error: Error) => {
-          toast.error(`却下に失敗しました: ${error.message}`)
+          toast.error(`差し戻しに失敗しました: ${error.message}`)
         },
       }
     )
@@ -430,6 +462,7 @@ export function useOrdersPage() {
     confirmOrder,
     requestApproval,
     rejectOrder,
+    withdrawApproval,
     deleteOrder,
     simulateOrderById,
     simulatingOrderId,
@@ -437,6 +470,7 @@ export function useOrdersPage() {
     // Handlers
     handleApproveFromRow,
     handleRequestApprovalFromRow,
+    handleWithdrawFromRow,
     handleRejectRequest,
     handleConfirmReject,
     handleSimulate,
@@ -446,6 +480,10 @@ export function useOrdersPage() {
     // Reject dialog state
     rejectTargetOrder,
     setRejectTargetOrder,
+    // Resubmit (差し戻し後の再送信) confirmation dialog state
+    resubmitTargetOrder,
+    setResubmitTargetOrder,
+    handleConfirmResubmit,
     // Bulk selection
     selectedOrderIds,
     selectedScheduledCount,

--- a/frontend/src/hooks/use-orders.ts
+++ b/frontend/src/hooks/use-orders.ts
@@ -117,8 +117,8 @@ export function useRequestApproval() {
 }
 
 /**
- * 承認待ちの注文を却下するフック（president限定）
- * 注文ステータスを pending_approval -> draft に差し戻す
+ * 承認待ちの注文を差し戻すフック（president限定）
+ * 注文ステータスを pending_approval -> draft に差し戻す（理由は任意）
  */
 export function useRejectOrder() {
   const queryClient = useQueryClient()
@@ -128,6 +128,24 @@ export function useRejectOrder() {
       apiClient<Order>(`/orders/${id}/reject`, {
         method: "POST",
         body: JSON.stringify({ reason: reason ?? null }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ORDERS_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * 承認依頼を取り下げるフック（order_handler限定）
+ * 誤って送信した承認依頼を自分で取り消し、注文ステータスを pending_approval -> draft に戻す
+ */
+export function useWithdrawApproval() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (orderId: number) =>
+      apiClient<Order>(`/orders/${orderId}/withdraw-approval`, {
+        method: "POST",
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ORDERS_QUERY_KEY })
@@ -155,7 +173,7 @@ export function useApproveOrdersBulk() {
 }
 
 /**
- * 承認ワークフロー（承認依頼送信・承認・却下）の監査ログを取得するフック
+ * 承認ワークフロー（承認依頼送信・承認・差し戻し・取り下げ）の監査ログを取得するフック
  * （iso_officer / president / platform_admin のみ閲覧可）
  *
  * 呼び出し側は、閲覧権限を持つロールであることが確定してから

--- a/frontend/src/hooks/use-orders.ts
+++ b/frontend/src/hooks/use-orders.ts
@@ -157,11 +157,16 @@ export function useApproveOrdersBulk() {
 /**
  * 承認ワークフロー（承認依頼送信・承認・却下）の監査ログを取得するフック
  * （iso_officer / president / platform_admin のみ閲覧可）
+ *
+ * 呼び出し側は、閲覧権限を持つロールであることが確定してから
+ * `enabled: true` を渡すこと。閲覧不可ロール（order_handler等）で
+ * 常時リクエストしてしまうと、成功しない403アクセスがAPIに飛び続けてしまう。
  */
-export function useApprovalLogs() {
+export function useApprovalLogs(options?: { enabled?: boolean }) {
   return useQuery<OrderApprovalLog[]>({
     queryKey: ["orders", "approval-logs"],
     queryFn: () => apiClient<OrderApprovalLog[]>("/orders/approval-logs"),
+    enabled: options?.enabled ?? true,
   })
 }
 

--- a/frontend/src/hooks/use-orders.ts
+++ b/frontend/src/hooks/use-orders.ts
@@ -2,8 +2,10 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { apiClient } from "@/lib/api-client"
+import { createClient } from "@/utils/supabase/client"
 import type {
   Order,
+  OrderApprovalLog,
   OrderAttachment,
   OrderBulkApproveResponse,
   OrderCreate,
@@ -150,6 +152,57 @@ export function useApproveOrdersBulk() {
       queryClient.invalidateQueries({ queryKey: ["schedules"] })
     },
   })
+}
+
+/**
+ * 承認ワークフロー（承認依頼送信・承認・却下）の監査ログを取得するフック
+ * （iso_officer / president / platform_admin のみ閲覧可）
+ */
+export function useApprovalLogs() {
+  return useQuery<OrderApprovalLog[]>({
+    queryKey: ["orders", "approval-logs"],
+    queryFn: () => apiClient<OrderApprovalLog[]>("/orders/approval-logs"),
+  })
+}
+
+/**
+ * 承認ワークフローの監査ログをCSVとしてダウンロードする
+ * （JSONを返さないエンドポイントのため apiClient は使わず直接fetchする）
+ */
+export async function downloadApprovalLogsCsv(): Promise<void> {
+  const supabase = createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  const token = session?.access_token
+  if (!token) {
+    throw new Error("Unauthorized")
+  }
+  const tenantId =
+    typeof window !== "undefined" ? localStorage.getItem("currentTenantId") : null
+
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/orders/approval-logs/export`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(tenantId && { "x-tenant-id": tenantId }),
+      },
+    },
+  )
+  if (!response.ok) {
+    throw new Error("承認履歴のCSV出力に失敗しました")
+  }
+
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = "approval_logs.csv"
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
 }
 
 /**

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -126,7 +126,7 @@ export interface OrderApprovalLog {
   id: string
   order_id: number
   order_number: string | null
-  action: 'request_approval' | 'approve' | 'reject'
+  action: 'request_approval' | 'approve' | 'reject' | 'withdraw'
   actor_user_id: string
   actor_full_name: string | null
   actor_email: string | null

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -120,6 +120,21 @@ export interface OrderBulkApproveResponse {
 }
 
 /**
+ * 承認ワークフロー監査ログのデータ型（iso_officer / president / platform_admin のみ閲覧可）
+ */
+export interface OrderApprovalLog {
+  id: string
+  order_id: number
+  order_number: string | null
+  action: 'request_approval' | 'approve' | 'reject'
+  actor_user_id: string
+  actor_full_name: string | null
+  actor_email: string | null
+  reason: string | null
+  created_at: string
+}
+
+/**
  * 注文添付ファイルのデータ型
  */
 export interface OrderAttachment {

--- a/supabase/migrations/20260811000000_add_order_approval_log.sql
+++ b/supabase/migrations/20260811000000_add_order_approval_log.sql
@@ -1,0 +1,40 @@
+-- 承認ワークフローの操作主体を記録する監査ログ基盤 (Issue #326)
+-- 共有端末での操作であっても、承認依頼送信・承認・却下の各操作を実行した
+-- ユーザーIDと日時をアプリ層で記録し、ISO要件である承認プロセスの証跡を残す。
+
+CREATE TABLE order_approval_log (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     uuid NOT NULL REFERENCES tenants(id),
+  order_id      bigint NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  action        text NOT NULL CHECK (action IN ('request_approval', 'approve', 'reject')),
+  actor_user_id uuid NOT NULL REFERENCES auth.users(id),
+  reason        text,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE order_approval_log ENABLE ROW LEVEL SECURITY;
+
+-- CLAUDE.md の規約に従い is_tenant_member(tenant_id) を使用する。
+-- 承認系エンドポイントはユーザーJWTクライアント経由で処理されるため
+-- (routers/transaction/orders.py の get_supabase_client 依存)、
+-- notifications と異なり INSERT もユーザーJWTから行う。
+-- 閲覧は監査目的のため iso_officer / president / platform_admin に限定する
+-- （order_handler は自身の操作ログであっても閲覧不可とし、監査ログとしての
+--   独立性を保つ）。
+CREATE POLICY "tenant isolation (select)" ON order_approval_log
+  FOR SELECT
+  USING (
+    is_tenant_member(tenant_id)
+    AND EXISTS (
+      SELECT 1 FROM organization_members om
+      WHERE om.tenant_id = order_approval_log.tenant_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('iso_officer', 'president', 'platform_admin')
+    )
+  );
+
+CREATE POLICY "tenant isolation (insert)" ON order_approval_log
+  FOR INSERT
+  WITH CHECK (is_tenant_member(tenant_id) AND actor_user_id = auth.uid());
+
+CREATE INDEX idx_order_approval_log_tenant_order ON order_approval_log (tenant_id, order_id, created_at DESC);

--- a/supabase/migrations/20260811000001_add_withdraw_action_to_order_approval_log.sql
+++ b/supabase/migrations/20260811000001_add_withdraw_action_to_order_approval_log.sql
@@ -1,0 +1,10 @@
+-- order_handler が誤って送信した承認依頼を自分で取り下げられるようにする (Issue #326 フォローアップ)
+-- pending_approval -> draft への遷移はorder_status_service.py上で既に許可されているが、
+-- これまで実行経路が president 限定の reject (却下) しかなかったため、
+-- order_handler 自身による取り下げ用に action='withdraw' を追加する。
+
+ALTER TABLE order_approval_log DROP CONSTRAINT order_approval_log_action_check;
+
+ALTER TABLE order_approval_log
+  ADD CONSTRAINT order_approval_log_action_check
+  CHECK (action IN ('request_approval', 'approve', 'reject', 'withdraw'));

--- a/supabase/migrations/20260811000002_fix_order_approval_log_insert_policy_order_tenant.sql
+++ b/supabase/migrations/20260811000002_fix_order_approval_log_insert_policy_order_tenant.sql
@@ -1,0 +1,20 @@
+-- order_approval_log の INSERT ポリシー強化 (Copilotレビュー指摘対応)
+-- 従来は is_tenant_member(tenant_id) と actor_user_id = auth.uid() のみを検証しており、
+-- order_id が実際にその tenant_id の orders に属するかまでは検証していなかった。
+-- そのため同一テナントの正規メンバーが、他テナントの order_id（連番のbigintで推測可能）を
+-- 指定して監査ログに偽の行を挿入し、監査ログの整合性を汚染できてしまう余地があった。
+-- order_id が指定した tenant_id の orders に属することを WITH CHECK で追加検証する。
+
+DROP POLICY "tenant isolation (insert)" ON order_approval_log;
+
+CREATE POLICY "tenant isolation (insert)" ON order_approval_log
+  FOR INSERT
+  WITH CHECK (
+    is_tenant_member(tenant_id)
+    AND actor_user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM orders o
+      WHERE o.id = order_approval_log.order_id
+        AND o.tenant_id = order_approval_log.tenant_id
+    )
+  );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,8 +1,9 @@
--- テストユーザーは2名分作成する（承認ワークフロー Issue #325 の動作確認用）。
--- どちらもパスワードは Test123!（backend/.env.sample の TEST_USER_PASS と同じ
+-- テストユーザーは3名分作成する（承認ワークフロー Issue #325 / 監査ログ Issue #326 の動作確認用）。
+-- いずれもパスワードは Test123!（backend/.env.sample の TEST_USER_PASS と同じ
 -- bcryptハッシュを共有しているため、パスワード自体はハッシュ化前の平文で共通）。
---   test@example.com          … president（承認・却下を行う）
---   order_handler@example.com … order_handler（承認依頼の送信を行う）
+--   test@example.com          … president（承認・却下、承認監査ログの閲覧を行う）
+--   order_handler@example.com … order_handler（承認依頼の送信を行う。監査ログは閲覧不可）
+--   iso_officer@example.com   … iso_officer（承認監査ログの閲覧・CSV出力のみ行う）
 
 -- 1. Create Test Users
 INSERT INTO auth.users (
@@ -24,6 +25,15 @@ INSERT INTO auth.users (
     '33333333-3333-3333-3333-333333333333',
     'authenticated', 'authenticated',
     'order_handler@example.com',
+    '$2a$10$.Ulu3FXi6elgYxA/bwIjYuYBYi05tEYmknOuBfeIb1VE1D.KNzxhe',  -- ハッシュ化されたパスワード (Test123!)
+    now(), '{"provider":"email","providers":["email"]}', '{}',
+    now(), now(), '', '', '', ''
+),
+(
+    '00000000-0000-0000-0000-000000000000',
+    '44444444-4444-4444-4444-444444444444',
+    'authenticated', 'authenticated',
+    'iso_officer@example.com',
     '$2a$10$.Ulu3FXi6elgYxA/bwIjYuYBYi05tEYmknOuBfeIb1VE1D.KNzxhe',  -- ハッシュ化されたパスワード (Test123!)
     now(), '{"provider":"email","providers":["email"]}', '{}',
     now(), now(), '', '', '', ''
@@ -56,6 +66,14 @@ INSERT INTO auth.identities (
     'email',
     '33333333-3333-3333-3333-333333333333', -- provider_idとしてuser_idと同じものを指定
     now(), now(), now()
+),
+(
+    '44444444-4444-4444-4444-444444444444', -- pkey用
+    '44444444-4444-4444-4444-444444444444', -- auth.usersのID
+    format('{"sub":"%s","email":"%s"}', '44444444-4444-4444-4444-444444444444', 'iso_officer@example.com')::jsonb,
+    'email',
+    '44444444-4444-4444-4444-444444444444', -- provider_idとしてuser_idと同じものを指定
+    now(), now(), now()
 )
 ON CONFLICT (provider_id, provider) DO NOTHING;
 
@@ -67,5 +85,14 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO public.organization_members (user_id, tenant_id, role)
 VALUES
     ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'president'),
-    ('33333333-3333-3333-3333-333333333333', '22222222-2222-2222-2222-222222222222', 'order_handler')
+    ('33333333-3333-3333-3333-333333333333', '22222222-2222-2222-2222-222222222222', 'order_handler'),
+    ('44444444-4444-4444-4444-444444444444', '22222222-2222-2222-2222-222222222222', 'iso_officer')
 ON CONFLICT (user_id, tenant_id) DO NOTHING;
+
+-- 4. Profiles（承認監査ログ画面 (Issue #326) で操作者の氏名・メールを表示するため）
+INSERT INTO public.profiles (id, full_name, email)
+VALUES
+    ('11111111-1111-1111-1111-111111111111', '社長 太郎', 'test@example.com'),
+    ('33333333-3333-3333-3333-333333333333', '受注 花子', 'order_handler@example.com'),
+    ('44444444-4444-4444-4444-444444444444', 'ISO 次郎', 'iso_officer@example.com')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- `order_approval_log` テーブルを新設し、承認依頼送信・承認・却下の各操作について実行者（JWTから取得したユーザーID）と操作日時をアプリ層で記録する（共有端末運用でも操作主体を追跡可能に）
- `GET /orders/approval-logs` / `GET /orders/approval-logs/export`（CSV）を追加し、`iso_officer` / `president` / `platform_admin` に閲覧・出力を許可。`order_handler` は403（監査ログとしての独立性を保つため、自身の操作ログも含め閲覧不可）
- フロントエンドに `/orders/approval-logs` 画面を追加。iso_officer は閲覧・出力のみで編集・承認操作は一切できない（該当ボタン自体を持たない画面として実装）

## 実装内容
- **DB**: `supabase/migrations/20260811000000_add_order_approval_log.sql`（RLS: `is_tenant_member` + 閲覧ロール制約、INSERTは `actor_user_id = auth.uid()` を要求）
- **Backend**: `OrderApprovalLogRepository` を追加し、`request-approval` / `confirm` / `approve-bulk` / `reject` の各エンドポイントで状態遷移成功後にログを記録。一覧・CSV出力APIは `profiles` / `orders` から表示用情報（氏名・メール・注文番号）を補完して返す
- **Frontend**: `useApprovalLogs` / `downloadApprovalLogsCsv` フック、監査ログ一覧ページ、サイドバーへのリンク追加
- **Docs**: `docs/features/approval-workflow.md` に監査ログ基盤のセクションを追加

Closes #326

## Test plan
- [x] `backend`: `pytest __tests__/unit __tests__/api` 全件成功（新規テスト含む）
- [x] `backend`: `ruff check` / `ruff format` / `mypy` エラーなし
- [x] `frontend`: `tsc --noEmit` / `npm run lint` / `npm run build` エラーなし（新規ファイルに警告なし）
- [ ] 本番/ローカルSupabaseへのマイグレーション適用（レビュー後に実施）
- [ ] 実際のブラウザでの承認履歴画面の目視確認（ローカルSupabase起動が必要なため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)