### PR TITLE
承認依頼のアプリ内通知を実装 (Issue #327)

### DIFF
--- a/backend/__tests__/api/routers/transaction/test_notifications.py
+++ b/backend/__tests__/api/routers/transaction/test_notifications.py
@@ -79,6 +79,16 @@ class TestNotificationsRouter:
                 "read_at": None,
                 "created_at": "2026-07-22T00:03:00+00:00",
             },
+            {
+                "id": "n5",
+                "tenant_id": TENANT_ID,
+                "notif_type": "approval_requested",
+                "source_table": "orders",
+                "source_id": "42",
+                "detail": {"order_no": "ORD-042"},
+                "read_at": None,
+                "created_at": "2026-07-22T00:04:00+00:00",
+            },
         ]
 
         mock_client = MagicMock()
@@ -126,6 +136,7 @@ class TestNotificationsRouter:
         assert body["n2"]["link_url"] == "https://example.com/signed/att-2.pdf"
         assert body["n3"]["link_url"] == "https://mail.google.com/mail/u/0/#all/gmail-3"
         assert body["n4"]["link_url"] is None
+        assert body["n5"]["link_url"] == "/orders/42"
 
         # order_parse_log / order_attachments への問い合わせが通知件数分ではなく
         # 1回ずつ（バッチ）にまとまっていること（N+1回避の確認）

--- a/backend/__tests__/api/routers/transaction/test_notifications.py
+++ b/backend/__tests__/api/routers/transaction/test_notifications.py
@@ -89,6 +89,16 @@ class TestNotificationsRouter:
                 "read_at": None,
                 "created_at": "2026-07-22T00:04:00+00:00",
             },
+            {
+                "id": "n6",
+                "tenant_id": TENANT_ID,
+                "notif_type": "approval_requested",
+                "source_table": "orders",
+                "source_id": "../not-a-valid-order-id",
+                "detail": None,
+                "read_at": None,
+                "created_at": "2026-07-22T00:05:00+00:00",
+            },
         ]
 
         mock_client = MagicMock()
@@ -137,6 +147,7 @@ class TestNotificationsRouter:
         assert body["n3"]["link_url"] == "https://mail.google.com/mail/u/0/#all/gmail-3"
         assert body["n4"]["link_url"] is None
         assert body["n5"]["link_url"] == "/orders/42"
+        assert body["n6"]["link_url"] is None
 
         # order_parse_log / order_attachments への問い合わせが通知件数分ではなく
         # 1回ずつ（バッチ）にまとまっていること（N+1回避の確認）

--- a/backend/__tests__/api/routers/transaction/test_orders.py
+++ b/backend/__tests__/api/routers/transaction/test_orders.py
@@ -924,6 +924,39 @@ class TestOrderRouter:
             headers["x-tenant-id"], order_id, "request_approval", "test-user-id", None
         )
 
+    # --- アプリ内通知 (Issue #327) ---
+
+    def test_request_order_approval_notifies_approval_requested(
+        self, headers, mock_repo, mock_supabase_client
+    ):
+        """POST /{order_id}/request-approval: notificationsにapproval_requestedが書き込まれる"""
+        order_id = 1
+        order_data = {
+            "id": order_id,
+            "product_id": 100,
+            "quantity": 10,
+            "order_number": "ORD-001",
+            "status": "draft",
+        }
+        self._set_role(mock_supabase_client, "order_handler")
+        mock_repo.get_by_id.return_value = order_data
+        mock_repo.update.return_value = {**order_data, "status": "pending_approval"}
+
+        response = client.post(f"/orders/{order_id}/request-approval", headers=headers)
+
+        assert response.status_code == 200
+        insert_calls = [
+            call
+            for call in mock_supabase_client.table.return_value.insert.call_args_list
+            if call.args and call.args[0].get("notif_type") == "approval_requested"
+        ]
+        assert len(insert_calls) == 1
+        inserted = insert_calls[0].args[0]
+        assert inserted["tenant_id"] == headers["x-tenant-id"]
+        assert inserted["source_table"] == "orders"
+        assert inserted["source_id"] == str(order_id)
+        assert inserted["detail"] == {"order_no": "ORD-001"}
+
     def test_confirm_order_logs_action(
         self,
         headers,

--- a/backend/__tests__/integration/test_notifications_rls.py
+++ b/backend/__tests__/integration/test_notifications_rls.py
@@ -199,8 +199,10 @@ class TestNotificationsRls:
         self, real_supabase_client, notif_tenants
     ):
         """
-        notifications はSELECTポリシーのみでINSERT/UPDATE/DELETEにポリシーが
-        無い（デフォルト拒否）。以前の FOR ALL ポリシーからの回帰確認。
+        notifications はSELECTと、notif_type='approval_requested'限定のINSERT
+        （Issue #327）以外にポリシーが無い（デフォルト拒否）。
+        それ以外のnotif_type（本テストのnon_order_email等、cron専用）は
+        ユーザーJWT経由で偽装挿入できないことの回帰確認。
         """
         with pytest.raises(APIError):
             real_supabase_client.table("notifications").insert(
@@ -209,6 +211,51 @@ class TestNotificationsRls:
                     "notif_type": "non_order_email",
                     "source_table": "gmail_message",
                     "source_id": "spy-insert-attempt",
+                }
+            ).execute()
+
+    def test_insert_approval_requested_via_user_jwt_succeeds_for_own_tenant(
+        self, real_supabase_client, admin_db, notif_tenants
+    ):
+        """
+        Issue #327: 承認依頼通知はユーザーJWT経由での書き込みを新設したパスのため、
+        notif_type='approval_requested' かつ source_table='orders' であれば
+        自テナントに対しては書き込める。
+        """
+        order = (
+            admin_db.table("orders")
+            .insert({"tenant_id": notif_tenants["own_id"], "quantity": 1})
+            .execute()
+        )
+        order_id = cast(list[dict[str, Any]], order.data)[0]["id"]
+
+        result = (
+            real_supabase_client.table("notifications")
+            .insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "approval_requested",
+                    "source_table": "orders",
+                    "source_id": str(order_id),
+                }
+            )
+            .execute()
+        )
+        assert cast(list[dict[str, Any]], result.data)[0]["notif_type"] == (
+            "approval_requested"
+        )
+
+    def test_insert_approval_requested_via_user_jwt_rejected_for_other_tenant(
+        self, real_supabase_client, notif_tenants
+    ):
+        """所属していないテナント宛の承認依頼通知はis_tenant_memberにより拒否される"""
+        with pytest.raises(APIError):
+            real_supabase_client.table("notifications").insert(
+                {
+                    "tenant_id": notif_tenants["other_id"],
+                    "notif_type": "approval_requested",
+                    "source_table": "orders",
+                    "source_id": "spy-other-tenant-order",
                 }
             ).execute()
 

--- a/backend/__tests__/integration/test_notifications_rls.py
+++ b/backend/__tests__/integration/test_notifications_rls.py
@@ -259,6 +259,48 @@ class TestNotificationsRls:
                 }
             ).execute()
 
+    def test_insert_approval_requested_via_user_jwt_rejected_for_non_numeric_source_id(
+        self, real_supabase_client, notif_tenants
+    ):
+        """
+        PRレビュー指摘対応: source_id が数値でない場合、GET /notifications の
+        link_url組み立て（/orders/{source_id}）で不正な相対パスになりうるため、
+        DB側でも数値形式であることを検証し拒否する。
+        """
+        with pytest.raises(APIError):
+            real_supabase_client.table("notifications").insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "approval_requested",
+                    "source_table": "orders",
+                    "source_id": "../not-a-valid-order-id",
+                }
+            ).execute()
+
+    def test_insert_approval_requested_via_user_jwt_rejected_for_other_tenant_order_id(
+        self, real_supabase_client, admin_db, notif_tenants
+    ):
+        """
+        PRレビュー指摘対応: source_id が数値であっても、その注文が別テナントに
+        属する場合はEXISTS句（tenant_id一致）により拒否される（IDOR対策）。
+        """
+        other_order = (
+            admin_db.table("orders")
+            .insert({"tenant_id": notif_tenants["other_id"], "quantity": 1})
+            .execute()
+        )
+        other_order_id = cast(list[dict[str, Any]], other_order.data)[0]["id"]
+
+        with pytest.raises(APIError):
+            real_supabase_client.table("notifications").insert(
+                {
+                    "tenant_id": notif_tenants["own_id"],
+                    "notif_type": "approval_requested",
+                    "source_table": "orders",
+                    "source_id": str(other_order_id),
+                }
+            ).execute()
+
     def test_direct_update_via_user_jwt_is_rejected(
         self, real_supabase_client, admin_db, notif_tenants
     ):

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -82,6 +82,8 @@ def _collect_parse_log_ids(
             continue
         if row["notif_type"] == "non_order_email":
             link_urls[row["id"]] = f"https://mail.google.com/mail/u/0/#all/{source_id}"
+        elif row["notif_type"] == "approval_requested":
+            link_urls[row["id"]] = f"/orders/{source_id}"
         elif (
             row["source_table"] == "order_parse_log"
             and row["notif_type"] in _PARSE_LOG_NOTIF_TYPES

--- a/backend/app/routers/transaction/notifications.py
+++ b/backend/app/routers/transaction/notifications.py
@@ -83,7 +83,12 @@ def _collect_parse_log_ids(
         if row["notif_type"] == "non_order_email":
             link_urls[row["id"]] = f"https://mail.google.com/mail/u/0/#all/{source_id}"
         elif row["notif_type"] == "approval_requested":
-            link_urls[row["id"]] = f"/orders/{source_id}"
+            # source_id はRLS側で数値かつ自テナントの注文であることを検証しているが
+            # （20260812000000_...migration）、アプリ層でも念のため数値のみ許可し、
+            # 不正な相対パス（/orders/../..等）が生成されないようにする。
+            link_urls[row["id"]] = (
+                f"/orders/{source_id}" if source_id.isdigit() else None
+            )
         elif (
             row["source_table"] == "order_parse_log"
             and row["notif_type"] in _PARSE_LOG_NOTIF_TYPES

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -43,6 +43,7 @@ from app.repositories.supa_infra.transaction.order_repo import OrderRepository
 from app.repositories.supa_infra.transaction.schedule_repo import ScheduleRepository
 from app.scheduler_logic import RoutingUnconfirmedError, schedule_order
 from app.services.attachment_service import create_signed_url
+from app.services.notification_service import create_notification
 from app.services.order_status_service import (
     InvalidOrderStatusTransitionError,
     validate_order_status_transition,
@@ -600,6 +601,28 @@ def _log_approval_action_safely(
         )
 
 
+def _notify_approval_requested_safely(
+    client: Client, tenant_id: str, order_id: int, order_no: str | None
+) -> None:
+    """
+    承認依頼通知の書き込みはベストエフォートとする（Issue #327）。
+    通知の記録に失敗しても、承認依頼送信自体（既にDB更新済み）はエラー扱いにしない。
+    """
+    try:
+        create_notification(
+            client,
+            tenant_id,
+            "approval_requested",
+            "orders",
+            str(order_id),
+            detail={"order_no": order_no} if order_no else None,
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to record approval_requested notification: order_id={order_id}"
+        )
+
+
 def _require_any_role(
     tenant_id: str,
     user_id: str,
@@ -701,6 +724,9 @@ def request_order_approval(
     )
     _log_approval_action_safely(
         approval_log_repo, tenant_id, order_id, "request_approval", user_id
+    )
+    _notify_approval_requested_safely(
+        client, tenant_id, order_id, order.get("order_number")
     )
     return _map_order_response(result)
 

--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -163,3 +163,16 @@ PostgRESTがINSERT結果を返す際にSELECT用RLSポリシー（`iso_officer`/
   各操作エンドポイントで監査ログが正しい引数で記録されること、`GET /orders/approval-logs` /
   `/export` が `iso_officer`/`president` では成功し `order_handler` では403になること、
   CSVレスポンスの内容を検証
+
+## 承認依頼のアプリ内通知 (Issue #327)
+
+`request-approval`（`draft → pending_approval`）成功時、president 向けに `notifications`
+テーブルへ `approval_requested` 通知を書き込む。メール確認依頼で発生していた「返信が来ない」
+問題の代替として、アプリ内で完結させる狙い。`approve-bulk` からの一括承認時は既存の通知に
+対する操作（既読化等）のみで、新規通知の書き込みは発生しない
+（一括承認対象はいずれも `request-approval` 送信時に既に通知済みのため）。
+
+社長ダッシュボード（ホーム画面）には `pending_approval` 件数が1件以上あれば目立つバナーを表示し、
+`/orders?status=pending_approval`（本ページの一括承認UI）へ直接遷移できる。
+
+詳細な通知テーブル設計・RLS・フロントエンド実装は [notifications.md](notifications.md) を参照。

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -58,6 +58,41 @@ CREATE TABLE notifications (
 | `failed_image` | 同上 | `order_attachments` | `attachment_id` |
 | `non_order_email` | `gmail_service._process_message` | `gmail_message` | Gmail `msg_id` |
 | `customer_draft_created` | `resolve_or_create_customer` 呼び出し元（`gmail_service._process_message`）| `gmail_message` | Gmail `msg_id` |
+| `approval_requested` | `orders.request_order_approval`（`POST /orders/{id}/request-approval`）| `orders` | `order_id` |
+
+### `approval_requested`（承認依頼のアプリ内通知, Issue #327）
+
+社長（president）向けに、[承認ワークフロー](approval-workflow.md)（Issue #325）の承認依頼送信
+（`draft → pending_approval`）を通知する。メール確認依頼で発生していた「返信が来ない」問題の
+代替として、アプリ内で完結させる。
+
+- 書き込み元は `orders.py` の `request_order_approval`。既存の `create_notification()` を
+  ユーザーJWTクライアント（`client`、`get_supabase_client`）で呼び出す。監査ログ記録
+  （`_log_approval_action_safely`）と同様、通知の記録失敗は承認依頼送信自体を失敗させない
+  ベストエフォート（`_notify_approval_requested_safely`）
+- `detail` には `{"order_no": ...}` のみを保存する
+- `link_url` は `_resolve_link_urls()` で `/orders/{order_id}`（アプリ内相対パス）に解決する
+  （他のnotif_typeのような署名付きURL生成や外部リンク組み立ては不要）
+
+#### 書き込み経路の追加（RLS）
+
+これまで `notifications` への書き込みは cron/Service Role Key 経由（admin_client, RLSバイパス）に
+限定され、ユーザーJWTからの書き込みは default deny だった。承認依頼はユーザー操作起点のため、
+[order_approval_log](approval-workflow.md) と同じ考え方で、ユーザーJWT経由の書き込みを
+`notif_type = 'approval_requested' AND source_table = 'orders'` に限定した INSERT ポリシーを
+新設した（`supabase/migrations/20260812000000_add_approval_requested_notif_type.sql`）。
+他のnotif_type（PDF解析ログ等、cron専用）はこれまで通りユーザーJWT経由での偽装挿入を防ぐ。
+
+#### フロントエンド
+
+- `NotificationType` / `NOTIF_TYPE_LABELS`（`notification-bell.tsx`）に `approval_requested`（「承認依頼」）
+  を追加。`formatDetail()` で `detail.order_no` から「注文「ORD-xxx」の承認依頼」を表示する
+- ホームダッシュボード（`frontend/src/app/page.tsx`）: president がログインした際、
+  `pending_approval` 件数が1件以上あればページ上部に目立つバナーを表示し、
+  クリックで `/orders?status=pending_approval`（[承認ワークフロー](approval-workflow.md)の
+  一括承認UI）へ遷移する。メール確認依頼と同じ「後回しにされる」問題の再発を防ぐため、
+  通知ベルの未読バッジだけでなく能動的に表示する設計とした
+  （バナーは `orders` の現在ステータス集計ベースで、通知イベントの既読/未読とは独立して表示する）
 
 ---
 
@@ -151,6 +186,9 @@ RLSの `is_tenant_member(tenant_id)` は所属する全テナントの行を許�
 - [x] 通知ベル＋未読バッジがUIに表示される（ブラウザで実際にログインし目視確認済み）
 - [x] 通知一覧から各詳細（PDF/添付ファイル/Gmailメール）へ遷移できる（`link_url` 経由）
 - [x] 一覧表示（オープン時）で既読化される
+- [x] 承認依頼送信時に president へアプリ内通知（`approval_requested`）が届く（Issue #327）
+- [x] 社長ダッシュボードで承認待ち件数・一覧が確認できる（Issue #327、ホーム画面の目立つバナー）
+- [x] 一覧から一括承認ができる（Issue #325 で実装済みの `/orders?status=pending_approval` 経由）
 
 ---
 
@@ -197,6 +235,19 @@ supabase start
 cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-integration
 ```
 
+### Issue #327 で追加したテスト
+
+- `backend/__tests__/api/routers/transaction/test_orders.py::test_request_order_approval_notifies_approval_requested`
+  — `request-approval` 成功時に `notifications` へ `approval_requested` がinsertされること（モック）
+- `backend/__tests__/api/routers/transaction/test_notifications.py` — `approval_requested` の
+  `link_url` が `/orders/{order_id}` に解決されること
+- `backend/__tests__/integration/test_notifications_rls.py`
+  - `test_insert_approval_requested_via_user_jwt_succeeds_for_own_tenant` — ユーザーJWT経由で
+    自テナントの `approval_requested` はINSERTできる
+  - `test_insert_approval_requested_via_user_jwt_rejected_for_other_tenant` — 他テナント宛は拒否される
+  - 既存 `test_direct_insert_via_user_jwt_is_rejected`（`non_order_email`）で、新設ポリシーが
+    `approval_requested` 以外には影響しないことを回帰確認
+
 ## 関連
 
 - [pdf-order-parsing.md](pdf-order-parsing.md): PDF自動パース処理（Issue #249, #252、通知発生元）
@@ -205,5 +256,8 @@ cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-in
   の定義（`failed_encrypted` / `failed_image` の発生元、対象外メール検知時の挙動変更）
 - [customer-draft-auto-create.md](customer-draft-auto-create.md): `customer_draft_created`
   の追加（Issue #263）
+- [approval-workflow.md](approval-workflow.md): 承認ワークフロー本体（Issue #325）。
+  `approval_requested` 通知（Issue #327）はこのワークフローの `request-approval` に連動する
 - Issue #249, #252: `order_parse_log` への記録処理（本Issueの通知発生元）
 - Issue #256: integrationテスト追加（RLS/IDOR回帰）
+- Issue #327: 承認依頼のアプリ内通知（`approval_requested`）

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -72,7 +72,8 @@ CREATE TABLE notifications (
   ベストエフォート（`_notify_approval_requested_safely`）
 - `detail` には `{"order_no": ...}` のみを保存する
 - `link_url` は `_resolve_link_urls()` で `/orders/{order_id}`（アプリ内相対パス）に解決する
-  （他のnotif_typeのような署名付きURL生成や外部リンク組み立ては不要）
+  （他のnotif_typeのような署名付きURL生成や外部リンク組み立ては不要）。`source_id` が数値
+  文字列でない場合は `link_url: null` とする（下記のPRレビュー指摘対応）
 
 #### 書き込み経路の追加（RLS）
 
@@ -82,6 +83,13 @@ CREATE TABLE notifications (
 `notif_type = 'approval_requested' AND source_table = 'orders'` に限定した INSERT ポリシーを
 新設した（`supabase/migrations/20260812000000_add_approval_requested_notif_type.sql`）。
 他のnotif_type（PDF解析ログ等、cron専用）はこれまで通りユーザーJWT経由での偽装挿入を防ぐ。
+
+`source_id` はアプリ層が渡す値をそのまま信頼せず、RLS側でも検証する（PRレビュー指摘対応）。
+INSERTポリシーの `WITH CHECK` に `source_id ~ '^[0-9]+$'`（数値形式）と
+`EXISTS (... orders o WHERE o.id = source_id::bigint AND o.tenant_id = notifications.tenant_id)`
+（同一テナントに実在する注文であること）を追加し、任意文字列や他テナントの注文IDを
+`source_id` に持つ通知の作成を防ぐ。アプリ側（`_resolve_link_urls`）でも `source_id.isdigit()`
+を確認してから `link_url` を組み立てる二重防御にしている。
 
 #### フロントエンド
 
@@ -240,11 +248,15 @@ cd backend && pytest __tests__/integration/test_notifications_rls.py -v --run-in
 - `backend/__tests__/api/routers/transaction/test_orders.py::test_request_order_approval_notifies_approval_requested`
   — `request-approval` 成功時に `notifications` へ `approval_requested` がinsertされること（モック）
 - `backend/__tests__/api/routers/transaction/test_notifications.py` — `approval_requested` の
-  `link_url` が `/orders/{order_id}` に解決されること
+  `link_url` が `/orders/{order_id}` に解決されること（数値以外の `source_id` では `null` になること含む）
 - `backend/__tests__/integration/test_notifications_rls.py`
   - `test_insert_approval_requested_via_user_jwt_succeeds_for_own_tenant` — ユーザーJWT経由で
-    自テナントの `approval_requested` はINSERTできる
+    自テナントの実在する注文を指す `approval_requested` はINSERTできる
   - `test_insert_approval_requested_via_user_jwt_rejected_for_other_tenant` — 他テナント宛は拒否される
+  - `test_insert_approval_requested_via_user_jwt_rejected_for_non_numeric_source_id` —
+    `source_id` が数値でない場合はRLSで拒否される（PRレビュー指摘対応）
+  - `test_insert_approval_requested_via_user_jwt_rejected_for_other_tenant_order_id` —
+    `source_id` が数値でも他テナントの注文を指す場合はRLSで拒否される（IDOR対策、PRレビュー指摘対応）
   - 既存 `test_direct_insert_via_user_jwt_is_rejected`（`non_order_email`）で、新設ポリシーが
     `approval_requested` 以外には影響しないことを回帰確認
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,10 +12,12 @@ import {
   ArrowRight,
   CalendarDays,
   PackageSearch,
+  BellRing,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useOrders } from "@/hooks/use-orders"
 import { useProducts } from "@/hooks/use-products"
+import { useCurrentMember } from "@/hooks/use-tenant-members"
 import { format, startOfDay, addDays, startOfWeek } from "date-fns"
 import { ja } from "date-fns/locale"
 import { getProductName, getStatusLabel } from "@/lib/order-utils"
@@ -31,6 +33,7 @@ export default function Home() {
   const router = useRouter()
   const { data: orders, isLoading: ordersLoading } = useOrders()
   const { data: products, isLoading: productsLoading } = useProducts()
+  const { data: currentMember } = useCurrentMember()
   const today = useMemo(() => startOfDay(new Date()), [])
   const tomorrow = useMemo(() => addDays(today, 1), [today])
   const weekStart = useMemo(() => startOfWeek(today, { locale: ja }), [today])
@@ -46,6 +49,12 @@ export default function Home() {
   const draftOrdersCount = useMemo(() => {
     return orders?.filter((order) => order.status === "draft").length ?? 0
   }, [orders])
+
+  const pendingApprovalCount = useMemo(() => {
+    return orders?.filter((order) => order.status === "pending_approval").length ?? 0
+  }, [orders])
+
+  const isPresident = currentMember?.role === "president"
 
   const confirmedOrdersCount = useMemo(() => {
     return orders?.filter((order) => order.status === "confirmed").length ?? 0
@@ -120,6 +129,29 @@ export default function Home() {
           </div>
         </div>
       </div>
+
+      {/* 承認待ちバナー（president 限定・メール確認依頼の「後回しにされる」問題を再発させないため、
+          ログイン直後に目立つ形で表示する） */}
+      {isPresident && !ordersLoading && pendingApprovalCount > 0 && (
+        <button
+          type="button"
+          onClick={() => router.push("/orders?status=pending_approval")}
+          className="mb-8 flex w-full items-center justify-between gap-4 rounded-lg border border-red-300 bg-red-50 px-6 py-4 text-left shadow-sm transition-colors hover:bg-red-100"
+        >
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-red-100 p-2.5">
+              <BellRing className="h-5 w-5 text-red-600" />
+            </div>
+            <div>
+              <p className="font-semibold text-red-800">
+                承認待ちの注文が{pendingApprovalCount}件あります
+              </p>
+              <p className="text-sm text-red-600">確認して承認をお願いします</p>
+            </div>
+          </div>
+          <ArrowRight className="h-5 w-5 shrink-0 text-red-600" />
+        </button>
+      )}
 
       {/* KPI カード */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5 mb-8">

--- a/frontend/src/components/layout/notification-bell.tsx
+++ b/frontend/src/components/layout/notification-bell.tsx
@@ -21,6 +21,7 @@ const NOTIF_TYPE_LABELS: Record<NotificationType, string> = {
   non_order_email: "対象外メール",
   customer_draft_created: "顧客の下書き作成",
   multi_order_suspected: "複数受注の疑い",
+  approval_requested: "承認依頼",
 }
 
 function groupByType(notifications: Notification[]): [NotificationType, Notification[]][] {
@@ -133,6 +134,10 @@ function NotificationRow({ notif }: { notif: Notification }) {
 function formatDetail(notif: Notification): string {
   const detail = notif.detail
   if (!detail) return "詳細なし"
+  if (notif.notif_type === "approval_requested") {
+    const orderNo = detail.order_no
+    return typeof orderNo === "string" ? `注文「${orderNo}」の承認依頼` : "承認依頼"
+  }
   const productName = detail.product_name_raw ?? detail.product_number_raw
   if (typeof productName === "string") return productName
   const snippet = detail.body_snippet

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -7,6 +7,7 @@ export type NotificationType =
   | "non_order_email"
   | "customer_draft_created"
   | "multi_order_suspected"
+  | "approval_requested"
 
 export interface Notification {
   id: string

--- a/supabase/migrations/20260812000000_add_approval_requested_notif_type.sql
+++ b/supabase/migrations/20260812000000_add_approval_requested_notif_type.sql
@@ -17,13 +17,22 @@ CHECK (notif_type IN (
 -- order_approval_log (20260811000000_add_order_approval_log.sql) と同じ考え方で、
 -- notif_type と source_table をこの用途に固定した WITH CHECK により、他のnotif_type
 -- （PDF解析ログ等、cron専用）をユーザーJWT経由で偽装挿入できないようにする。
--- source_id（orders.id）の正当性については、is_tenant_member(tenant_id) チェックに加え、
--- アプリ層（POST /orders/{order_id}/request-approval）で常にログイン中テナントの
--- 注文からしか呼び出されないことで担保する。
+--
+-- source_id（orders.id想定）はアプリ層が渡す値をそのまま信頼せず、DB側でも
+-- 数値形式であること・その注文が同一tenant_idに実在することを検証する
+-- （PRレビュー指摘対応）。これを怠ると、任意のsource_idを持つ通知をユーザーJWT
+-- 経由で作成でき、GET /notifications の link_url 組み立て（/orders/{source_id}）で
+-- 不正な相対パスや他テナント注文IDの詮索に使われうる。
 CREATE POLICY "insert approval_requested from user jwt" ON notifications
   FOR INSERT
   WITH CHECK (
     is_tenant_member(tenant_id)
     AND notif_type = 'approval_requested'
     AND source_table = 'orders'
+    AND source_id ~ '^[0-9]+$'
+    AND EXISTS (
+      SELECT 1 FROM orders o
+      WHERE o.id = source_id::bigint
+        AND o.tenant_id = notifications.tenant_id
+    )
   );

--- a/supabase/migrations/20260812000000_add_approval_requested_notif_type.sql
+++ b/supabase/migrations/20260812000000_add_approval_requested_notif_type.sql
@@ -1,0 +1,29 @@
+-- 承認依頼のアプリ内通知 (Issue #327)
+-- order_handler が承認依頼を送信した際（draft→pending_approval）、president 向けに
+-- notifications へ書き込めるようにする。
+
+ALTER TABLE notifications DROP CONSTRAINT notifications_notif_type_check;
+ALTER TABLE notifications ADD CONSTRAINT notifications_notif_type_check
+CHECK (notif_type IN (
+  'no_product_match', 'downgrade_skipped', 'draft_conflict_skipped',
+  'failed_encrypted', 'failed_image', 'non_order_email', 'customer_draft_created',
+  'multi_order_suspected', 'approval_requested'
+));
+
+-- notifications への書き込みはこれまで cron/Service Role Key 経由に限定されていたが
+-- （20260703000000_add_notifications.sql 参照）、承認依頼はユーザー操作（APIリクエスト）
+-- 起点のため、ユーザーJWTクライアントからの書き込み経路を新設する。
+--
+-- order_approval_log (20260811000000_add_order_approval_log.sql) と同じ考え方で、
+-- notif_type と source_table をこの用途に固定した WITH CHECK により、他のnotif_type
+-- （PDF解析ログ等、cron専用）をユーザーJWT経由で偽装挿入できないようにする。
+-- source_id（orders.id）の正当性については、is_tenant_member(tenant_id) チェックに加え、
+-- アプリ層（POST /orders/{order_id}/request-approval）で常にログイン中テナントの
+-- 注文からしか呼び出されないことで担保する。
+CREATE POLICY "insert approval_requested from user jwt" ON notifications
+  FOR INSERT
+  WITH CHECK (
+    is_tenant_member(tenant_id)
+    AND notif_type = 'approval_requested'
+    AND source_table = 'orders'
+  );


### PR DESCRIPTION
## Summary
- order_handler が承認依頼を送信した際（`draft→pending_approval`）、既存の `notifications` テーブルへ `notif_type=approval_requested` として書き込み、president 向けのアプリ内通知とした
- `notifications` への書き込みはこれまで cron/Service Role Key 経由に限定されていたため、`order_approval_log`（Issue #326）と同じ考え方で、ユーザーJWT経由の書き込みを `notif_type='approval_requested' AND source_table='orders'` に限定したRLS INSERTポリシーを新設
- 社長ダッシュボード（ホーム画面）に承認待ち件数の目立つバナーを追加し、`/orders?status=pending_approval`（Issue #325で実装済みの一覧・一括承認UI）へ直接遷移できるようにした

## Test plan
- [x] `pytest __tests__/unit __tests__/api`（全件パス）
- [x] `pytest __tests__/integration/test_notifications_rls.py -v --run-integration`（ローカルSupabaseで新設RLSポリシーの許可/拒否を確認、全13件パス）
- [x] `ruff check` / `mypy`（変更ファイルはエラーなし。既存ファイルの `I001` は本PR起因ではなく事前から存在する既知の状態）
- [x] `tsc --noEmit` / `eslint`（変更ファイルはエラーなし）
- [x] `docs/features/notifications.md` / `docs/features/approval-workflow.md` を更新

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)