### PR TITLE
サイドバー「承認監査ログ」をロール未許可ユーザーに非表示化 (#337)

### DIFF
--- a/docs/features/approval-workflow.md
+++ b/docs/features/approval-workflow.md
@@ -154,8 +154,14 @@ PostgRESTがINSERT結果を返す際にSELECT用RLSポリシー（`iso_officer`/
   アクセス不可メッセージを表示し、編集・承認操作用のUIは一切持たない（閲覧・出力のみ）。
   `useApprovalLogs({ enabled: !isMemberLoading && canView })` として、ロール確定前・閲覧不可ロールでは
   一覧取得APIを呼び出さない。
-- サイドバー（`frontend/src/components/layout/app-sidebar.tsx`）に「承認監査ログ」リンクを追加
-  （ページ側でロールチェックするため、リンク自体は全ロールに表示）。
+- サイドバー（`frontend/src/components/layout/app-sidebar.tsx`）に「承認監査ログ」リンクを追加。
+  当初はページ側のロールチェックのみに依存し、リンク自体は全ロールに表示していたが、
+  `order_handler` にもクリックできてしまいアクセス拒否画面が出る体験だったため、
+  Issue #337 で表示自体もロール制御するよう変更（defense in depth）。
+  `frontend/src/types/member.ts` の `ORDER_APPROVAL_LOG_VIEWER_ROLES`（`iso_officer` / `president` /
+  `platform_admin`）を `page.tsx` の `canView` 判定とサイドバーの両方から共通参照する。
+  `MenuItem` 型に `allowedRoles?: MemberRole[]` を追加し、指定された項目のみ `useCurrentMember()` の
+  ロールでフィルタする。ロール未確定（`isMemberLoading`）の間は `allowedRoles` 付き項目を表示しない。
 
 ### テスト
 

--- a/frontend/src/app/orders/approval-logs/page.tsx
+++ b/frontend/src/app/orders/approval-logs/page.tsx
@@ -17,6 +17,7 @@ import {
 import { useApprovalLogs, downloadApprovalLogsCsv } from "@/hooks/use-orders"
 import { useCurrentMember } from "@/hooks/use-tenant-members"
 import type { OrderApprovalLog } from "@/types/order"
+import { ORDER_APPROVAL_LOG_VIEWER_ROLES } from "@/types/member"
 
 const ACTION_LABELS: Record<OrderApprovalLog["action"], string> = {
   request_approval: "承認依頼送信",
@@ -48,9 +49,8 @@ export default function ApprovalLogsPage() {
   const { data: currentMember, isLoading: isMemberLoading } = useCurrentMember()
   const currentUserRole = currentMember?.role ?? null
   const canView =
-    currentUserRole === "iso_officer" ||
-    currentUserRole === "president" ||
-    currentUserRole === "platform_admin"
+    !!currentUserRole &&
+    ORDER_APPROVAL_LOG_VIEWER_ROLES.includes(currentUserRole)
 
   const { data: logs, isLoading, isError } = useApprovalLogs({
     enabled: !isMemberLoading && canView,

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -39,6 +39,11 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { logout } from "@/lib/auth-server-actions"
+import { useCurrentMember } from "@/hooks/use-tenant-members"
+import {
+  ORDER_APPROVAL_LOG_VIEWER_ROLES,
+  type MemberRole,
+} from "@/types/member"
 
 type SubMenuItem = { title: string; url: string; icon: React.ElementType }
 type MenuItem = {
@@ -47,6 +52,8 @@ type MenuItem = {
   url?: string
   activePrefix?: string
   items?: SubMenuItem[]
+  /** 指定した場合、このロールを持つメンバーにのみメニュー項目を表示する */
+  allowedRoles?: MemberRole[]
 }
 
 const menuItems: MenuItem[] = [
@@ -69,6 +76,7 @@ const menuItems: MenuItem[] = [
     title: "承認監査ログ",
     url: "/orders/approval-logs",
     icon: ClipboardList,
+    allowedRoles: ORDER_APPROVAL_LOG_VIEWER_ROLES,
   },
   {
     title: "マスタデータ",
@@ -99,6 +107,15 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
 export function AppSidebar({ user, ...props }: AppSidebarProps) {
   const pathname = usePathname()
   const [isLoggingOut, setIsLoggingOut] = React.useState(false)
+  const { data: currentMember, isLoading: isMemberLoading } = useCurrentMember()
+  const currentUserRole = currentMember?.role ?? null
+
+  const visibleMenuItems = menuItems.filter((item) => {
+    if (!item.allowedRoles) return true
+    // ロール未確定の間はロール制御付き項目を表示しない
+    if (isMemberLoading || !currentUserRole) return false
+    return item.allowedRoles.includes(currentUserRole)
+  })
 
   const handleLogout = async () => {
     setIsLoggingOut(true)
@@ -120,7 +137,7 @@ export function AppSidebar({ user, ...props }: AppSidebarProps) {
           <SidebarGroupLabel>メニュー</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {menuItems.map((item) =>
+              {visibleMenuItems.map((item) =>
                 item.items ? (
                   <Collapsible
                     key={item.title}

--- a/frontend/src/types/member.ts
+++ b/frontend/src/types/member.ts
@@ -4,6 +4,16 @@ export type MemberRole =
   | "order_handler"
   | "platform_admin"
 
+/**
+ * 承認監査ログ（/orders/approval-logs）の閲覧を許可するロール。
+ * ページ側の `canView` 判定とサイドバーメニューの表示制御で共通利用する。
+ */
+export const ORDER_APPROVAL_LOG_VIEWER_ROLES: MemberRole[] = [
+  "iso_officer",
+  "president",
+  "platform_admin",
+]
+
 export interface TenantMember {
   user_id: string
   email: string


### PR DESCRIPTION
## Summary
- サイドバーの「承認監査ログ」(`/orders/approval-logs`) メニュー項目を `iso_officer` / `president` / `platform_admin` のみに表示するよう変更（`order_handler` では非表示）
- 許可ロールの判定を `ORDER_APPROVAL_LOG_VIEWER_ROLES`（`frontend/src/types/member.ts`）に切り出し、ページ側の `canView` 判定とサイドバー双方から共通参照
- `MenuItem` 型に `allowedRoles?: MemberRole[]` を追加し、ロール制御が必要な項目のみフィルタする汎用的な仕組みに
- ロール未確定時（`useCurrentMember` 読み込み中）は `allowedRoles` 付きの項目を表示しない
- バックエンドAPIの認可は変更なし（既存の `_APPROVAL_LOG_VIEWER_ROLES` を踏襲）

Closes #337

## Test plan
- [x] `npx tsc --noEmit` 型チェック成功
- [x] `npx eslint` エラーなし
- [x] `order_handler` でログインし、サイドバーに「承認監査ログ」が表示されないことを確認
- [x] `iso_officer` / `president` / `platform_admin` でログインし、従来通り表示・遷移できることを確認
- [x] `order_handler` で `/orders/approval-logs` に直接アクセスし、既存のページ内 `canView` ガードでアクセス拒否表示になることを確認（後退なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)