### PR TITLE
fix: x-tenant-idヘッダーのテナント所属をサーバー側で検証

### DIFF
--- a/backend/__tests__/api/routers/master/test_customers_router.py
+++ b/backend/__tests__/api/routers/master/test_customers_router.py
@@ -3,7 +3,7 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from app.dependencies import get_customer_repo
+from app.dependencies import get_current_user_id, get_customer_repo, get_supabase_client
 
 # テスト対象のAPIインスタンス
 from app.main import app
@@ -28,8 +28,12 @@ class TestCustomerRouter:
         """
         テスト実行中だけ get_customer_repo を mock_repo に差し替える。
         autouse=True なので、このクラスの全テストで自動的に適用される。
+        get_current_user_id / get_supabase_client は get_current_tenant_id の
+        テナント所属検証で参照されるためモックする。
         """
         app.dependency_overrides[get_customer_repo] = lambda: mock_repo
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
         yield
         # テスト終了後に元に戻す（重要）
         app.dependency_overrides = {}

--- a/backend/__tests__/api/routers/master/test_customers_router.py
+++ b/backend/__tests__/api/routers/master/test_customers_router.py
@@ -29,11 +29,15 @@ class TestCustomerRouter:
         テスト実行中だけ get_customer_repo を mock_repo に差し替える。
         autouse=True なので、このクラスの全テストで自動的に適用される。
         get_current_user_id / get_supabase_client は get_current_tenant_id の
-        テナント所属検証で参照されるためモックする。
+        テナント所属検証で参照されるため、所属ありの結果を返すようにモックする。
         """
+        mock_tenant_client = MagicMock()
+        mock_tenant_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "user_id": "test-user-id"
+        }
         app.dependency_overrides[get_customer_repo] = lambda: mock_repo
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
-        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
+        app.dependency_overrides[get_supabase_client] = lambda: mock_tenant_client
         yield
         # テスト終了後に元に戻す（重要）
         app.dependency_overrides = {}

--- a/backend/__tests__/api/routers/master/test_equipment_groups.py
+++ b/backend/__tests__/api/routers/master/test_equipment_groups.py
@@ -29,11 +29,15 @@ class TestEquipmentGroupRouter:
         """
         テスト実行中だけ get_equipment_repo を mock_repo に差し替える。
         get_current_user_id / get_supabase_client は get_current_tenant_id の
-        テナント所属検証で参照されるためモックする。
+        テナント所属検証で参照されるため、所属ありの結果を返すようにモックする。
         """
+        mock_tenant_client = MagicMock()
+        mock_tenant_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "user_id": "test-user-id"
+        }
         app.dependency_overrides[get_equipment_repo] = lambda: mock_repo
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
-        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
+        app.dependency_overrides[get_supabase_client] = lambda: mock_tenant_client
         yield
         app.dependency_overrides = {}
 

--- a/backend/__tests__/api/routers/master/test_equipment_groups.py
+++ b/backend/__tests__/api/routers/master/test_equipment_groups.py
@@ -2,7 +2,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from app.dependencies import get_equipment_repo
+from app.dependencies import (
+    get_current_user_id,
+    get_equipment_repo,
+    get_supabase_client,
+)
 from app.main import app
 from fastapi.testclient import TestClient
 
@@ -24,8 +28,12 @@ class TestEquipmentGroupRouter:
     def override_dependency(self, mock_repo):
         """
         テスト実行中だけ get_equipment_repo を mock_repo に差し替える。
+        get_current_user_id / get_supabase_client は get_current_tenant_id の
+        テナント所属検証で参照されるためモックする。
         """
         app.dependency_overrides[get_equipment_repo] = lambda: mock_repo
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
         yield
         app.dependency_overrides = {}
 

--- a/backend/__tests__/api/routers/master/test_equipments.py
+++ b/backend/__tests__/api/routers/master/test_equipments.py
@@ -2,7 +2,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from app.dependencies import get_equipment_repo
+from app.dependencies import (
+    get_current_user_id,
+    get_equipment_repo,
+    get_supabase_client,
+)
 
 # テスト対象のAPIインスタンス
 from app.main import app
@@ -26,8 +30,12 @@ class TestEquipmentRouter:
     def override_dependency(self, mock_repo):
         """
         テスト実行中だけ get_equipment_repo を mock_repo に差し替える。
+        get_current_user_id / get_supabase_client は get_current_tenant_id の
+        テナント所属検証で参照されるためモックする。
         """
         app.dependency_overrides[get_equipment_repo] = lambda: mock_repo
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
         yield
         app.dependency_overrides = {}
 

--- a/backend/__tests__/api/routers/master/test_equipments.py
+++ b/backend/__tests__/api/routers/master/test_equipments.py
@@ -31,11 +31,15 @@ class TestEquipmentRouter:
         """
         テスト実行中だけ get_equipment_repo を mock_repo に差し替える。
         get_current_user_id / get_supabase_client は get_current_tenant_id の
-        テナント所属検証で参照されるためモックする。
+        テナント所属検証で参照されるため、所属ありの結果を返すようにモックする。
         """
+        mock_tenant_client = MagicMock()
+        mock_tenant_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "user_id": "test-user-id"
+        }
         app.dependency_overrides[get_equipment_repo] = lambda: mock_repo
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
-        app.dependency_overrides[get_supabase_client] = lambda: MagicMock()
+        app.dependency_overrides[get_supabase_client] = lambda: mock_tenant_client
         yield
         app.dependency_overrides = {}
 

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -195,9 +195,9 @@ class TestMembersRouter:
         assert result["full_name"] == "受注担当 太郎"
 
     def test_get_my_membership_not_found(self, headers, mock_client):
-        """GET /me: 対象テナントのメンバーでない場合は404"""
+        """GET /me: 対象テナントのメンバーでない場合は403（get_current_tenant_idのテナント所属検証で拒否される）"""
         mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = None
 
         response = client.get("/tenant/members/me", headers=headers)
 
-        assert response.status_code == 404
+        assert response.status_code == 403

--- a/backend/__tests__/unit/test_dependencies.py
+++ b/backend/__tests__/unit/test_dependencies.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from app.dependencies import get_current_tenant_id
 from fastapi import HTTPException
+from postgrest.exceptions import APIError
 
 
 class TestGetCurrentTenantId:
@@ -34,3 +35,30 @@ class TestGetCurrentTenantId:
             )
 
         assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize("code", ["22P02", "PGRST116"])
+    def test_raises_403_when_query_fails_with_expected_api_error(self, code):
+        """不正なUUID形式（22P02）や0件時のsingle()エラー（PGRST116）は403として扱う"""
+        mock_client = MagicMock()
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.side_effect = APIError(
+            {"code": code, "message": "error"}
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_tenant_id(
+                x_tenant_id="not-a-uuid", user_id="user-1", client=mock_client
+            )
+
+        assert exc_info.value.status_code == 403
+
+    def test_reraises_unexpected_api_error(self):
+        """想定外のAPIErrorはそのまま再送出され、FastAPI側で500になる"""
+        mock_client = MagicMock()
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.side_effect = APIError(
+            {"code": "500", "message": "unexpected"}
+        )
+
+        with pytest.raises(APIError):
+            get_current_tenant_id(
+                x_tenant_id="tenant-1", user_id="user-1", client=mock_client
+            )

--- a/backend/__tests__/unit/test_dependencies.py
+++ b/backend/__tests__/unit/test_dependencies.py
@@ -1,0 +1,36 @@
+# __tests__/unit/test_dependencies.py
+from unittest.mock import MagicMock
+
+import pytest
+from app.dependencies import get_current_tenant_id
+from fastapi import HTTPException
+
+
+class TestGetCurrentTenantId:
+    """get_current_tenant_id: x-tenant-id ヘッダーとJWTユーザーのテナント所属検証（Issue #343）"""
+
+    def test_returns_tenant_id_when_user_is_member(self):
+        """JWTユーザーがorganization_membersに所属していればテナントIDを返す"""
+        mock_client = MagicMock()
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+            "user_id": "user-1"
+        }
+
+        result = get_current_tenant_id(
+            x_tenant_id="tenant-1", user_id="user-1", client=mock_client
+        )
+
+        assert result == "tenant-1"
+        mock_client.table.assert_called_with("organization_members")
+
+    def test_raises_403_when_user_is_not_member(self):
+        """JWTユーザーが指定テナントのorganization_membersに存在しない場合は403"""
+        mock_client = MagicMock()
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_current_tenant_id(
+                x_tenant_id="other-tenant", user_id="user-1", client=mock_client
+            )
+
+        assert exc_info.value.status_code == 403

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -3,6 +3,7 @@ import os
 
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from postgrest.exceptions import APIError
 
 from app.repositories.supa_infra import (
     CustomerRepository,
@@ -90,14 +91,24 @@ def get_current_tenant_id(
     実際にそのテナント（organization_members）に所属していることをサーバー側で検証する。
     所属していない場合は403を返し、クライアントによる値の改ざんを防ぐ。
     """
-    res = (
-        client.table("organization_members")
-        .select("user_id")
-        .eq("tenant_id", x_tenant_id)
-        .eq("user_id", user_id)
-        .single()
-        .execute()
-    )
+    try:
+        res = (
+            client.table("organization_members")
+            .select("user_id")
+            .eq("tenant_id", x_tenant_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        )
+    except APIError as e:
+        # 不正なUUID形式（22P02）や0件時のsingle()エラー（PGRST116）等は
+        # 「テナントに所属していない」として扱う。それ以外は500として再送出する。
+        if e.code in ("22P02", "PGRST116"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="指定されたテナントのメンバーではありません",
+            ) from e
+        raise
     if not res.data:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -25,11 +25,6 @@ def get_current_user_token(
     return credentials.credentials
 
 
-def get_current_tenant_id(x_tenant_id: str = Header(...)) -> str:
-    """テナントIDを取得する"""
-    return x_tenant_id
-
-
 def get_supabase_client(token: str = Depends(get_current_user_token)) -> Client:
     """
     ユーザーのトークンを使ってSupabaseクライアントを初期化する。
@@ -82,6 +77,33 @@ def get_current_user_id(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials",
         ) from e
+
+
+def get_current_tenant_id(
+    x_tenant_id: str = Header(...),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+) -> str:
+    """テナントIDを取得する。
+
+    `x-tenant-id` ヘッダーはクライアント供給値のため、JWTで認証されたユーザーが
+    実際にそのテナント（organization_members）に所属していることをサーバー側で検証する。
+    所属していない場合は403を返し、クライアントによる値の改ざんを防ぐ。
+    """
+    res = (
+        client.table("organization_members")
+        .select("user_id")
+        .eq("tenant_id", x_tenant_id)
+        .eq("user_id", user_id)
+        .single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="指定されたテナントのメンバーではありません",
+        )
+    return x_tenant_id
 
 
 # --- Dependency Injection用の関数 ---

--- a/docs/features/tenant-id-authorization.md
+++ b/docs/features/tenant-id-authorization.md
@@ -17,6 +17,7 @@
 
 - 所属していない場合: `403 Forbidden`（`指定されたテナントのメンバーではありません`）
 - 所属している場合: 従来通り `x-tenant-id` の値をそのまま返す
+- `x-tenant-id` が不正なUUID形式の場合や `.single()` が0件でエラーになる場合（PostgRESTの `APIError`、コード `22P02` / `PGRST116`）も「未所属」として `403` に正規化する。それ以外の想定外の `APIError` はそのまま再送出し `500` として扱う（Copilotレビュー指摘対応）
 
 `get_current_tenant_id` は `backend/app/routers/` 配下のほぼ全てのエンドポイントで `Depends` されているため、
 この一箇所の修正で全ルーターに対して所属検証がかかる。

--- a/docs/features/tenant-id-authorization.md
+++ b/docs/features/tenant-id-authorization.md
@@ -1,0 +1,39 @@
+# x-tenant-id ヘッダーのサーバー側検証（Issue #343）
+
+## 課題
+
+`x-tenant-id` ヘッダーはクライアント（フロントエンドの `localStorage.currentTenantId`）が自由に指定できる値であるにも関わらず、
+`get_current_tenant_id`（`backend/app/dependencies.py`）はヘッダー値をそのまま返しており、JWTで認証されたユーザーが
+実際にそのテナントの `organization_members` に所属しているかの照合を行っていなかった。
+
+各テーブルの RLS（`is_tenant_member(tenant_id)`）が最終防衛線として機能する想定だったが、アプリ層の権限判定
+（`_require_member_admin` 等）は未検証の `tenant_id` をそのままクエリ条件に使っており、将来 RLS の実装漏れが
+あるテーブルが追加された場合に多層防御が効かない構造だった。
+
+## 修正内容
+
+`get_current_tenant_id` を、JWTから取得した `user_id`（`get_current_user_id` 依存）を用いて `organization_members`
+テーブルを照合し、そのユーザーが実際に所属しているテナントであることを検証したうえで返す実装に変更した。
+
+- 所属していない場合: `403 Forbidden`（`指定されたテナントのメンバーではありません`）
+- 所属している場合: 従来通り `x-tenant-id` の値をそのまま返す
+
+`get_current_tenant_id` は `backend/app/routers/` 配下のほぼ全てのエンドポイントで `Depends` されているため、
+この一箇所の修正で全ルーターに対して所属検証がかかる。
+
+## 影響範囲・注意点
+
+- 既存の `get_current_user_role()` は同じ `organization_members` を再度クエリしてロールを取得する。所属チェック自体は
+  `get_current_tenant_id` で先に行われるため冗長だが、ロール取得という別の責務のため実装は変更していない。
+- `tenant/members.py` の `GET /tenant/members/me` は、対象テナントのメンバーでない場合に自前で `404` を返す分岐を
+  持っていたが、`get_current_tenant_id` の検証が先に走るため、この分岐はレスポンスとしては到達不能になった
+  （呼び出し前に `403` で弾かれる）。ハンドラ内のチェック自体は防御的コードとして残してある。
+- フロントエンド（`frontend/src/lib/api-client.ts`）は引き続き `localStorage.currentTenantId` を `x-tenant-id` として
+  送信するのみで変更なし。改ざんされた値が送られてきても、サーバー側の所属検証で `403` になるため対処範囲。
+
+## テスト
+
+- `backend/__tests__/unit/test_dependencies.py`: `get_current_tenant_id` の所属あり/なしの単体テスト
+- 既存の API テストのうち、`get_current_user_id` / `get_supabase_client` を未モックだったルーター
+  （`test_customers_router.py` / `test_equipments.py` / `test_equipment_groups.py`）にモックを追加
+- `test_members.py` の `test_get_my_membership_not_found` は期待値を `404` → `403` に修正


### PR DESCRIPTION
## Summary
- `get_current_tenant_id`（`backend/app/dependencies.py`）がクライアント供給値の `x-tenant-id` をそのまま返しており、JWTユーザーが実際にそのテナントに所属しているかの照合を行っていなかった脆弱性を修正
- `organization_members` テーブルを照合し、JWTユーザーが指定テナントに所属していない場合は `403 Forbidden` を返すように変更
- `get_current_tenant_id` は全ルーターで `Depends` されているため、この一箇所の修正で横断的に検証がかかる

## Test plan
- [x] `backend/__tests__/unit/test_dependencies.py`: `get_current_tenant_id` の所属あり/なしの単体テストを追加
- [x] `pytest __tests__/unit __tests__/api` 全391件パス（未所属時に401/403等の意図しない失敗をしていた3ルーターのテストにモック追加、`test_get_my_membership_not_found` の期待値を404→403に修正）
- [x] `ruff check .` / `mypy .` エラーなし
- [x] `docs/features/tenant-id-authorization.md` を追加

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)