### PR TITLE
feat: 共有端末向けPIN認証・端末信頼を追加 (Issue #342)

### DIFF
--- a/backend/__tests__/api/routers/auth/test_device.py
+++ b/backend/__tests__/api/routers/auth/test_device.py
@@ -1,0 +1,269 @@
+# __tests__/api/routers/auth/test_device.py
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import bcrypt
+import pytest
+from app.dependencies import (
+    get_current_user_id,
+    get_supabase_admin_client,
+    get_supabase_client,
+)
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def _set_role(mock_client: MagicMock, role: str | None) -> None:
+    """organization_members からのロール取得チェーンのモックを設定する。"""
+    data = {"role": role} if role is not None else None
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = data
+
+
+def _set_trust(
+    mock_admin_client: MagicMock,
+    *,
+    tenant_id: str = "tenant-1",
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+    found: bool = True,
+) -> None:
+    """device_trust_registrations の検索チェーンのモックを設定する。"""
+    if not found:
+        data = None
+    else:
+        data = {
+            "id": "trust-1",
+            "tenant_id": tenant_id,
+            "expires_at": (
+                expires_at or datetime.now(UTC) + timedelta(days=1)
+            ).isoformat(),
+            "revoked_at": revoked_at.isoformat() if revoked_at else None,
+        }
+    mock_admin_client.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = data
+
+
+@pytest.mark.api
+class TestDeviceRouterAdminEndpoints:
+    """/auth/device の管理系エンドポイント（要JWT・president/platform_admin限定）のテスト"""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_admin_client(self):
+        return MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def override_dependency(self, mock_client, mock_admin_client):
+        app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
+        app.dependency_overrides[get_supabase_client] = lambda: mock_client
+        app.dependency_overrides[get_supabase_admin_client] = lambda: mock_admin_client
+        yield
+        app.dependency_overrides = {}
+
+    def test_register_device_forbidden_for_order_handler(self, headers, mock_client):
+        _set_role(mock_client, "order_handler")
+
+        response = client.post("/auth/device/register", headers=headers)
+
+        assert response.status_code == 403
+
+    def test_register_device_allowed_for_president(
+        self, headers, mock_client, mock_admin_client
+    ):
+        _set_role(mock_client, "president")
+        expires_at = (datetime.now(UTC) + timedelta(days=365)).isoformat()
+        mock_admin_client.table.return_value.insert.return_value.execute.return_value.data = [
+            {"expires_at": expires_at}
+        ]
+
+        response = client.post("/auth/device/register", headers=headers)
+
+        assert response.status_code == 200
+        assert "device_id" in response.json()
+
+    def test_list_devices_forbidden_for_iso_officer(self, headers, mock_client):
+        _set_role(mock_client, "iso_officer")
+
+        response = client.get("/auth/device", headers=headers)
+
+        assert response.status_code == 403
+
+    def test_list_devices_allowed_for_platform_admin(
+        self, headers, mock_client, mock_admin_client
+    ):
+        _set_role(mock_client, "platform_admin")
+        mock_client.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value.data = []
+
+        response = client.get("/auth/device", headers=headers)
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_revoke_device_forbidden_for_order_handler(self, headers, mock_client):
+        _set_role(mock_client, "order_handler")
+
+        response = client.delete("/auth/device/some-device-id", headers=headers)
+
+        assert response.status_code == 403
+
+    def test_revoke_device_not_found(self, headers, mock_client, mock_admin_client):
+        _set_role(mock_client, "president")
+        mock_admin_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value.data = []
+
+        response = client.delete("/auth/device/unknown-device-id", headers=headers)
+
+        assert response.status_code == 404
+
+    def test_revoke_device_success(self, headers, mock_client, mock_admin_client):
+        _set_role(mock_client, "president")
+        mock_admin_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value.data = [
+            {"device_id": "some-device-id"}
+        ]
+
+        response = client.delete("/auth/device/some-device-id", headers=headers)
+
+        assert response.status_code == 204
+
+
+@pytest.mark.api
+class TestDeviceRouterPublicEndpoints:
+    """/auth/device/status, /auth/device/pin-login (認証不要) のテスト"""
+
+    @pytest.fixture
+    def mock_admin_client(self):
+        return MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def override_dependency(self, mock_admin_client):
+        app.dependency_overrides[get_supabase_admin_client] = lambda: mock_admin_client
+        yield
+        app.dependency_overrides = {}
+
+    def test_status_untrusted_device(self, mock_admin_client):
+        _set_trust(mock_admin_client, found=False)
+
+        response = client.get("/auth/device/status", params={"device_id": "unknown"})
+
+        assert response.status_code == 200
+        assert response.json() == {"trusted": False, "tenant_id": None, "members": []}
+
+    def test_status_expired_trust(self, mock_admin_client):
+        _set_trust(mock_admin_client, expires_at=datetime.now(UTC) - timedelta(days=1))
+
+        response = client.get("/auth/device/status", params={"device_id": "expired"})
+
+        assert response.json()["trusted"] is False
+
+    def test_status_revoked_trust(self, mock_admin_client):
+        _set_trust(mock_admin_client, revoked_at=datetime.now(UTC) - timedelta(days=1))
+
+        response = client.get("/auth/device/status", params={"device_id": "revoked"})
+
+        assert response.json()["trusted"] is False
+
+    def test_status_trusted_with_members(self, mock_admin_client):
+        _set_trust(mock_admin_client, tenant_id="tenant-1")
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
+            {"user_id": "user-1"}
+        ]
+        mock_admin_client.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+            {"id": "user-1", "full_name": "山田太郎"}
+        ]
+
+        response = client.get("/auth/device/status", params={"device_id": "trusted"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["trusted"] is True
+        assert body["tenant_id"] == "tenant-1"
+        assert body["members"] == [{"user_id": "user-1", "full_name": "山田太郎"}]
+
+    def test_pin_login_untrusted_device(self, mock_admin_client):
+        _set_trust(mock_admin_client, found=False)
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "unknown", "user_id": "user-1", "pin": "1234"},
+        )
+
+        assert response.status_code == 403
+
+    def test_pin_login_no_pin_set(self, mock_admin_client):
+        _set_trust(mock_admin_client)
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = None
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "trusted", "user_id": "user-1", "pin": "1234"},
+        )
+
+        assert response.status_code == 401
+
+    def test_pin_login_locked(self, mock_admin_client):
+        _set_trust(mock_admin_client)
+        locked_until = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
+            "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
+            "failed_attempts": 5,
+            "locked_until": locked_until,
+        }
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "trusted", "user_id": "user-1", "pin": "1234"},
+        )
+
+        assert response.status_code == 423
+
+    def test_pin_login_wrong_pin(self, mock_admin_client):
+        _set_trust(mock_admin_client)
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
+            "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
+            "failed_attempts": 0,
+            "locked_until": None,
+        }
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "trusted", "user_id": "user-1", "pin": "0000"},
+        )
+
+        assert response.status_code == 401
+        update_call = mock_admin_client.table.return_value.update.call_args
+        assert update_call[0][0]["failed_attempts"] == 1
+
+    def test_pin_login_success(self, mock_admin_client):
+        _set_trust(mock_admin_client, tenant_id="tenant-1")
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
+            "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
+            "failed_attempts": 0,
+            "locked_until": None,
+        }
+        mock_admin_client.auth.admin.get_user_by_id.return_value.user.email = (
+            "user@example.com"
+        )
+        mock_admin_client.auth.admin.generate_link.return_value.properties.hashed_token = "hashed-token"
+        mock_admin_client.auth.verify_otp.return_value.session.access_token = (
+            "access-token"
+        )
+        mock_admin_client.auth.verify_otp.return_value.session.refresh_token = (
+            "refresh-token"
+        )
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "trusted", "user_id": "user-1", "pin": "1234"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+        }
+        (link_payload,), _ = mock_admin_client.auth.admin.generate_link.call_args
+        assert link_payload == {"type": "magiclink", "email": "user@example.com"}

--- a/backend/__tests__/api/routers/auth/test_device.py
+++ b/backend/__tests__/api/routers/auth/test_device.py
@@ -44,6 +44,13 @@ def _set_trust(
     mock_admin_client.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = data
 
 
+def _set_active_members(mock_admin_client: MagicMock, user_ids: list[str]) -> None:
+    """organization_members からの現在所属メンバー絞り込みチェーンのモックを設定する。"""
+    mock_admin_client.table.return_value.select.return_value.eq.return_value.in_.return_value.execute.return_value.data = [
+        {"user_id": uid} for uid in user_ids
+    ]
+
+
 @pytest.mark.api
 class TestDeviceRouterAdminEndpoints:
     """/auth/device の管理系エンドポイント（要JWT・president/platform_admin限定）のテスト"""
@@ -170,6 +177,7 @@ class TestDeviceRouterPublicEndpoints:
         mock_admin_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
             {"user_id": "user-1"}
         ]
+        _set_active_members(mock_admin_client, ["user-1"])
         mock_admin_client.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
             {"id": "user-1", "full_name": "山田太郎"}
         ]
@@ -181,6 +189,19 @@ class TestDeviceRouterPublicEndpoints:
         assert body["trusted"] is True
         assert body["tenant_id"] == "tenant-1"
         assert body["members"] == [{"user_id": "user-1", "full_name": "山田太郎"}]
+
+    def test_status_excludes_pin_of_member_no_longer_in_tenant(self, mock_admin_client):
+        """テナントを離れた後もmember_pinsが残っている場合、候補一覧から除外される"""
+        _set_trust(mock_admin_client, tenant_id="tenant-1")
+        mock_admin_client.table.return_value.select.return_value.eq.return_value.execute.return_value.data = [
+            {"user_id": "left-user"}
+        ]
+        _set_active_members(mock_admin_client, [])
+
+        response = client.get("/auth/device/status", params={"device_id": "trusted"})
+
+        assert response.status_code == 200
+        assert response.json()["members"] == []
 
     def test_pin_login_untrusted_device(self, mock_admin_client):
         _set_trust(mock_admin_client, found=False)
@@ -194,6 +215,7 @@ class TestDeviceRouterPublicEndpoints:
 
     def test_pin_login_no_pin_set(self, mock_admin_client):
         _set_trust(mock_admin_client)
+        _set_active_members(mock_admin_client, ["user-1"])
         mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = None
 
         response = client.post(
@@ -203,8 +225,21 @@ class TestDeviceRouterPublicEndpoints:
 
         assert response.status_code == 401
 
+    def test_pin_login_rejected_when_no_longer_tenant_member(self, mock_admin_client):
+        """member_pinsが残っていても、テナントを離れていればPINログインできない"""
+        _set_trust(mock_admin_client)
+        _set_active_members(mock_admin_client, [])
+
+        response = client.post(
+            "/auth/device/pin-login",
+            json={"device_id": "trusted", "user_id": "left-user", "pin": "1234"},
+        )
+
+        assert response.status_code == 401
+
     def test_pin_login_locked(self, mock_admin_client):
         _set_trust(mock_admin_client)
+        _set_active_members(mock_admin_client, ["user-1"])
         locked_until = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
         mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
             "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
@@ -221,6 +256,7 @@ class TestDeviceRouterPublicEndpoints:
 
     def test_pin_login_wrong_pin(self, mock_admin_client):
         _set_trust(mock_admin_client)
+        _set_active_members(mock_admin_client, ["user-1"])
         mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
             "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
             "failed_attempts": 0,
@@ -238,6 +274,7 @@ class TestDeviceRouterPublicEndpoints:
 
     def test_pin_login_success(self, mock_admin_client):
         _set_trust(mock_admin_client, tenant_id="tenant-1")
+        _set_active_members(mock_admin_client, ["user-1"])
         mock_admin_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value.data = {
             "pin_hash": bcrypt.hashpw(b"1234", bcrypt.gensalt()).decode(),
             "failed_attempts": 0,

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -117,6 +117,28 @@ class TestMembersRouter:
 
         assert response.status_code == 403
 
+    def test_delete_member_also_deletes_member_pins(
+        self, headers, mock_client, mock_admin_client
+    ):
+        """DELETE /{user_id}: メンバー削除時にmember_pinsも削除される（Copilotレビュー指摘）
+
+        削除しないと、テナントから外れた後もPINハッシュが残り続け、共有端末の
+        PINログイン候補一覧に表示されたりPINログインが通ってしまう。
+        """
+        _set_role(mock_client, "president")
+        # 対象ユーザーの role も president 扱いになる（single()チェーンを共有するため）ので、
+        # 「最後の president を削除できない」ガードに掛からないよう人数を2人以上にしておく
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value.count = 2
+
+        response = client.delete("/tenant/members/other-user-id", headers=headers)
+
+        assert response.status_code == 204
+        deleted_tables = [
+            call.args[0] for call in mock_admin_client.table.call_args_list
+        ]
+        assert "organization_members" in deleted_tables
+        assert "member_pins" in deleted_tables
+
     def test_list_members_allowed_for_platform_admin(
         self, headers, mock_client, mock_admin_client
     ):

--- a/backend/__tests__/api/routers/tenant/test_members.py
+++ b/backend/__tests__/api/routers/tenant/test_members.py
@@ -201,3 +201,49 @@ class TestMembersRouter:
         response = client.get("/tenant/members/me", headers=headers)
 
         assert response.status_code == 403
+
+    def test_set_my_pin_success(self, headers, mock_client, mock_admin_client):
+        """PATCH /me/pin: 自分自身のPINを設定できる（ロール制限なし）"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.patch(
+            "/tenant/members/me/pin", json={"pin": "1234"}, headers=headers
+        )
+
+        assert response.status_code == 204
+        (upsert_payload,), _ = mock_admin_client.table.return_value.upsert.call_args
+        assert upsert_payload["user_id"] == "test-user-id"
+        assert upsert_payload["pin_hash"] != "1234"
+
+    def test_set_my_pin_rejects_non_digit(self, headers, mock_client):
+        """PATCH /me/pin: 4桁の数字以外は422"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.patch(
+            "/tenant/members/me/pin", json={"pin": "abcd"}, headers=headers
+        )
+
+        assert response.status_code == 422
+
+    def test_reset_member_pin_forbidden_for_order_handler(self, headers, mock_client):
+        """POST /{user_id}/pin/reset: president / platform_admin 以外は403"""
+        _set_role(mock_client, "order_handler")
+
+        response = client.post(
+            "/tenant/members/other-user-id/pin/reset", headers=headers
+        )
+
+        assert response.status_code == 403
+
+    def test_reset_member_pin_allowed_for_president(
+        self, headers, mock_client, mock_admin_client
+    ):
+        """POST /{user_id}/pin/reset: president は他メンバーのPINを削除できる"""
+        _set_role(mock_client, "president")
+
+        response = client.post(
+            "/tenant/members/other-user-id/pin/reset", headers=headers
+        )
+
+        assert response.status_code == 204
+        mock_admin_client.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.assert_called_once()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers.admin import admin_router
+from app.routers.auth import device_router
 from app.routers.cron import cron_router, parse_order_pdfs_router
 from app.routers.master import (
     calendar_router,
@@ -61,6 +62,7 @@ app.include_router(notifications_router)
 app.include_router(production_schedules_router)
 app.include_router(scheduling_settings_router)
 app.include_router(member_router)
+app.include_router(device_router)
 app.include_router(admin_router)
 app.include_router(cron_router)
 app.include_router(parse_order_pdfs_router)

--- a/backend/app/models/auth/__init__.py
+++ b/backend/app/models/auth/__init__.py
@@ -1,0 +1,17 @@
+from app.models.auth.device_schemas import (
+    DeviceMemberOption,
+    DeviceRegisterResponse,
+    DeviceStatusResponse,
+    DeviceTrustResponse,
+    PinLoginRequest,
+    PinLoginResponse,
+)
+
+__all__ = [
+    "DeviceMemberOption",
+    "DeviceRegisterResponse",
+    "DeviceStatusResponse",
+    "DeviceTrustResponse",
+    "PinLoginRequest",
+    "PinLoginResponse",
+]

--- a/backend/app/models/auth/device_schemas.py
+++ b/backend/app/models/auth/device_schemas.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.models.tenant.pin_schemas import PIN_PATTERN
+
+
+class DeviceRegisterResponse(BaseModel):
+    """端末信頼登録レスポンスのスキーマ"""
+
+    device_id: str = Field(
+        description="発行された端末識別子（クライアント側で保存する）"
+    )
+    expires_at: datetime = Field(description="端末信頼の有効期限")
+
+
+class DeviceMemberOption(BaseModel):
+    """PINログイン画面に表示するメンバー選択肢"""
+
+    user_id: str = Field(description="ユーザーID")
+    full_name: str | None = Field(default=None, description="氏名")
+
+
+class DeviceStatusResponse(BaseModel):
+    """端末信頼状態レスポンスのスキーマ"""
+
+    trusted: bool = Field(description="この端末が信頼済みかどうか")
+    tenant_id: str | None = Field(default=None, description="信頼済みテナントID")
+    members: list[DeviceMemberOption] = Field(
+        default_factory=list, description="PIN設定済みメンバーの一覧"
+    )
+
+
+class DeviceTrustResponse(BaseModel):
+    """端末信頼レコードのレスポンススキーマ（端末管理一覧用）"""
+
+    device_id: str = Field(description="端末識別子")
+    registered_by: str = Field(description="登録者のユーザーID")
+    created_at: datetime = Field(description="登録日時")
+    expires_at: datetime = Field(description="有効期限")
+    revoked_at: datetime | None = Field(default=None, description="失効日時")
+
+
+class PinLoginRequest(BaseModel):
+    """PINログインリクエストのスキーマ"""
+
+    device_id: str = Field(description="端末識別子")
+    user_id: str = Field(description="ログインするユーザーID")
+    pin: str = Field(pattern=PIN_PATTERN, description="4桁の数字PIN")
+
+
+class PinLoginResponse(BaseModel):
+    """PINログイン成功レスポンスのスキーマ"""
+
+    access_token: str
+    refresh_token: str

--- a/backend/app/models/tenant/__init__.py
+++ b/backend/app/models/tenant/__init__.py
@@ -3,9 +3,11 @@ from app.models.tenant.member_schemas import (
     MemberResponse,
     MemberUpdateSchema,
 )
+from app.models.tenant.pin_schemas import PinSetSchema
 
 __all__ = [
     "MemberCreateSchema",
     "MemberUpdateSchema",
     "MemberResponse",
+    "PinSetSchema",
 ]

--- a/backend/app/models/tenant/pin_schemas.py
+++ b/backend/app/models/tenant/pin_schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+
+PIN_PATTERN = r"^\d{4}$"
+
+
+class PinSetSchema(BaseModel):
+    """PIN設定/変更リクエストのスキーマ"""
+
+    pin: str = Field(pattern=PIN_PATTERN, description="4桁の数字PIN")

--- a/backend/app/routers/auth/__init__.py
+++ b/backend/app/routers/auth/__init__.py
@@ -1,0 +1,3 @@
+from app.routers.auth.device import device_router
+
+__all__ = ["device_router"]

--- a/backend/app/routers/auth/device.py
+++ b/backend/app/routers/auth/device.py
@@ -1,0 +1,274 @@
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import bcrypt
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies import (
+    get_current_tenant_id,
+    get_current_user_id,
+    get_supabase_admin_client,
+    get_supabase_client,
+)
+from app.models.auth import (
+    DeviceMemberOption,
+    DeviceRegisterResponse,
+    DeviceStatusResponse,
+    DeviceTrustResponse,
+    PinLoginRequest,
+    PinLoginResponse,
+)
+from app.utils.logger import get_logger
+from supabase import Client  # type: ignore
+
+device_router = APIRouter(prefix="/auth/device", tags=["Auth (Device)"])
+
+logger = get_logger(__name__)
+
+# members.py の _MEMBER_ADMIN_ROLES と同じ方針: 端末信頼の登録・失効・一覧閲覧は
+# president / platform_admin のみが行える（PINログイン自体の対象外の操作）。
+_DEVICE_ADMIN_ROLES = ("president", "platform_admin")
+
+# PINロックアウト設定
+_MAX_FAILED_ATTEMPTS = 5
+_LOCKOUT_DURATION = timedelta(minutes=5)
+
+
+def _require_device_admin(
+    current_user_id: str,
+    tenant_id: str,
+    client: Client,
+) -> None:
+    """現在のユーザーが対象テナントで端末管理権限を持つことを検証する。"""
+    res = (
+        client.table("organization_members")
+        .select("role")
+        .eq("user_id", current_user_id)
+        .eq("tenant_id", tenant_id)
+        .single()
+        .execute()
+    )
+    if (
+        not res.data
+        or cast(dict[str, Any], res.data).get("role") not in _DEVICE_ADMIN_ROLES
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この操作には president または platform_admin 権限が必要です",
+        )
+
+
+def _active_trust(admin_client: Client, device_id: str) -> dict[str, Any] | None:
+    """有効な（未失効・未期限切れの）端末信頼レコードを取得する。"""
+    res = (
+        admin_client.table("device_trust_registrations")
+        .select("id, tenant_id, expires_at, revoked_at")
+        .eq("device_id", device_id)
+        .maybe_single()
+        .execute()
+    )
+    if not res or not res.data:
+        return None
+    row = cast(dict[str, Any], res.data)
+    if row.get("revoked_at"):
+        return None
+    expires_at = datetime.fromisoformat(row["expires_at"])
+    if expires_at <= datetime.now(UTC):
+        return None
+    return row
+
+
+@device_router.post("/register", response_model=DeviceRegisterResponse)
+def register_device(
+    tenant_id: str = Depends(get_current_tenant_id),
+    current_user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """現在使用中の端末をこのテナントの信頼済み端末として登録する（president / platform_admin のみ）"""
+    _require_device_admin(current_user_id, tenant_id, client)
+
+    device_id = secrets.token_urlsafe(32)
+    insert_res = (
+        admin_client.table("device_trust_registrations")
+        .insert(
+            {
+                "tenant_id": tenant_id,
+                "device_id": device_id,
+                "registered_by": current_user_id,
+            }
+        )
+        .execute()
+    )
+    row = cast(dict[str, Any], insert_res.data[0])
+    return DeviceRegisterResponse(device_id=device_id, expires_at=row["expires_at"])
+
+
+@device_router.get("", response_model=list[DeviceTrustResponse])
+def list_devices(
+    tenant_id: str = Depends(get_current_tenant_id),
+    current_user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+):
+    """テナントの信頼済み端末一覧を取得する（president / platform_admin のみ）"""
+    _require_device_admin(current_user_id, tenant_id, client)
+
+    res = (
+        client.table("device_trust_registrations")
+        .select("device_id, registered_by, created_at, expires_at, revoked_at")
+        .eq("tenant_id", tenant_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], res.data or [])
+    return [DeviceTrustResponse(**row) for row in rows]
+
+
+@device_router.delete("/{device_id}", status_code=status.HTTP_204_NO_CONTENT)
+def revoke_device(
+    device_id: str,
+    tenant_id: str = Depends(get_current_tenant_id),
+    current_user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """端末信頼を失効させる（president / platform_admin のみ）"""
+    _require_device_admin(current_user_id, tenant_id, client)
+
+    res = (
+        admin_client.table("device_trust_registrations")
+        .update({"revoked_at": datetime.now(UTC).isoformat()})
+        .eq("device_id", device_id)
+        .eq("tenant_id", tenant_id)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="端末が見つかりません"
+        )
+
+
+@device_router.get("/status", response_model=DeviceStatusResponse)
+def get_device_status(
+    device_id: str,
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """端末の信頼状態を取得する（認証不要、ログイン画面から呼び出す）"""
+    trust = _active_trust(admin_client, device_id)
+    if not trust:
+        return DeviceStatusResponse(trusted=False)
+
+    tenant_id = trust["tenant_id"]
+    pins_res = (
+        admin_client.table("member_pins")
+        .select("user_id")
+        .eq("tenant_id", tenant_id)
+        .execute()
+    )
+    pin_user_ids = [
+        row["user_id"] for row in cast(list[dict[str, Any]], pins_res.data or [])
+    ]
+    if not pin_user_ids:
+        return DeviceStatusResponse(trusted=True, tenant_id=tenant_id, members=[])
+
+    profiles_res = (
+        admin_client.table("profiles")
+        .select("id, full_name")
+        .in_("id", pin_user_ids)
+        .execute()
+    )
+    profiles = cast(list[dict[str, Any]], profiles_res.data or [])
+    members = [
+        DeviceMemberOption(user_id=p["id"], full_name=p.get("full_name"))
+        for p in profiles
+    ]
+    return DeviceStatusResponse(trusted=True, tenant_id=tenant_id, members=members)
+
+
+@device_router.post("/pin-login", response_model=PinLoginResponse)
+def pin_login(
+    data: PinLoginRequest,
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """信頼済み端末上でPINによりログインする（認証不要）"""
+    trust = _active_trust(admin_client, data.device_id)
+    if not trust:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="この端末は信頼済みではありません",
+        )
+    tenant_id = trust["tenant_id"]
+
+    pin_res = (
+        admin_client.table("member_pins")
+        .select("pin_hash, failed_attempts, locked_until")
+        .eq("tenant_id", tenant_id)
+        .eq("user_id", data.user_id)
+        .maybe_single()
+        .execute()
+    )
+    if not pin_res or not pin_res.data:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="PINが設定されていません"
+        )
+    pin_row = cast(dict[str, Any], pin_res.data)
+
+    locked_until = pin_row.get("locked_until")
+    if locked_until and datetime.fromisoformat(locked_until) > datetime.now(UTC):
+        raise HTTPException(
+            status_code=status.HTTP_423_LOCKED,
+            detail="PIN試行回数の上限に達しました。しばらくしてから再試行してください",
+        )
+
+    if not bcrypt.checkpw(data.pin.encode(), pin_row["pin_hash"].encode()):
+        failed_attempts = pin_row.get("failed_attempts", 0) + 1
+        update: dict[str, Any] = {"failed_attempts": failed_attempts}
+        if failed_attempts >= _MAX_FAILED_ATTEMPTS:
+            update["locked_until"] = (datetime.now(UTC) + _LOCKOUT_DURATION).isoformat()
+        admin_client.table("member_pins").update(update).eq("tenant_id", tenant_id).eq(
+            "user_id", data.user_id
+        ).execute()
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="PINが正しくありません"
+        )
+
+    user_res = admin_client.auth.admin.get_user_by_id(data.user_id)
+    email = user_res.user.email if user_res.user else None
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ユーザー情報の取得に失敗しました",
+        )
+
+    try:
+        link_res = admin_client.auth.admin.generate_link(
+            {"type": "magiclink", "email": email}
+        )
+        verify_res = admin_client.auth.verify_otp(
+            {
+                "token_hash": link_res.properties.hashed_token,
+                "type": "magiclink",
+            }
+        )
+    except Exception as e:
+        logger.error(f"PINログインのセッション発行に失敗しました: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ログイン処理に失敗しました",
+        ) from e
+
+    if not verify_res or not verify_res.session:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ログイン処理に失敗しました",
+        )
+
+    admin_client.table("member_pins").update(
+        {"failed_attempts": 0, "locked_until": None}
+    ).eq("tenant_id", tenant_id).eq("user_id", data.user_id).execute()
+
+    return PinLoginResponse(
+        access_token=verify_res.session.access_token,
+        refresh_token=verify_res.session.refresh_token,
+    )

--- a/backend/app/routers/auth/device.py
+++ b/backend/app/routers/auth/device.py
@@ -79,6 +79,26 @@ def _active_trust(admin_client: Client, device_id: str) -> dict[str, Any] | None
     return row
 
 
+def _active_member_ids(
+    admin_client: Client, tenant_id: str, user_ids: set[str]
+) -> set[str]:
+    """指定したユーザーIDのうち、現在もそのテナントに所属しているものだけを返す。
+
+    member_pins はメンバー削除時に基本連動して削除されるが、それに頼らない
+    防御的なフィルタとして、PIN候補一覧・PINログインの両方で使用する。
+    """
+    if not user_ids:
+        return set()
+    res = (
+        admin_client.table("organization_members")
+        .select("user_id")
+        .eq("tenant_id", tenant_id)
+        .in_("user_id", list(user_ids))
+        .execute()
+    )
+    return {row["user_id"] for row in cast(list[dict[str, Any]], res.data or [])}
+
+
 @device_router.post("/register", response_model=DeviceRegisterResponse)
 def register_device(
     tenant_id: str = Depends(get_current_tenant_id),
@@ -166,16 +186,23 @@ def get_device_status(
         .eq("tenant_id", tenant_id)
         .execute()
     )
-    pin_user_ids = [
+    pin_user_ids = {
         row["user_id"] for row in cast(list[dict[str, Any]], pins_res.data or [])
-    ]
+    }
     if not pin_user_ids:
+        return DeviceStatusResponse(trusted=True, tenant_id=tenant_id, members=[])
+
+    # member_pins にはPIN設定後にテナントから外れたユーザーのレコードが
+    # 残っている可能性があるため、organization_members で現在も所属している
+    # ユーザーに絞り込む（Copilotレビュー指摘）
+    active_member_ids = _active_member_ids(admin_client, tenant_id, pin_user_ids)
+    if not active_member_ids:
         return DeviceStatusResponse(trusted=True, tenant_id=tenant_id, members=[])
 
     profiles_res = (
         admin_client.table("profiles")
         .select("id, full_name")
-        .in_("id", pin_user_ids)
+        .in_("id", list(active_member_ids))
         .execute()
     )
     profiles = cast(list[dict[str, Any]], profiles_res.data or [])
@@ -199,6 +226,14 @@ def pin_login(
             detail="この端末は信頼済みではありません",
         )
     tenant_id = trust["tenant_id"]
+
+    # member_pins にはPIN設定後にテナントから外れたユーザーのレコードが
+    # 残っている可能性があるため、organization_members で現在も所属している
+    # ことを確認してからPIN照合を行う（Copilotレビュー指摘）
+    if not _active_member_ids(admin_client, tenant_id, {data.user_id}):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="PINが設定されていません"
+        )
 
     pin_res = (
         admin_client.table("member_pins")

--- a/backend/app/routers/tenant/members.py
+++ b/backend/app/routers/tenant/members.py
@@ -360,6 +360,13 @@ def delete_member(
         "tenant_id", tenant_id
     ).execute()
 
+    # member_pins を削除しておかないと、テナントから外れた後もPINハッシュが
+    # 残り続け、共有端末のPINログイン候補一覧に表示されたり、PINログインが
+    # 通ってしまう（Copilotレビュー指摘）
+    admin_client.table("member_pins").delete().eq("tenant_id", tenant_id).eq(
+        "user_id", user_id
+    ).execute()
+
 
 @member_router.patch("/me/pin", status_code=status.HTTP_204_NO_CONTENT)
 def set_my_pin(

--- a/backend/app/routers/tenant/members.py
+++ b/backend/app/routers/tenant/members.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.dependencies import (
@@ -8,7 +9,12 @@ from app.dependencies import (
     get_supabase_admin_client,
     get_supabase_client,
 )
-from app.models.tenant import MemberCreateSchema, MemberResponse, MemberUpdateSchema
+from app.models.tenant import (
+    MemberCreateSchema,
+    MemberResponse,
+    MemberUpdateSchema,
+    PinSetSchema,
+)
 from app.utils.logger import get_logger
 from supabase import Client  # type: ignore
 
@@ -352,4 +358,43 @@ def delete_member(
     # organization_members から削除（テナント紐付けを解除）
     admin_client.table("organization_members").delete().eq("user_id", user_id).eq(
         "tenant_id", tenant_id
+    ).execute()
+
+
+@member_router.patch("/me/pin", status_code=status.HTTP_204_NO_CONTENT)
+def set_my_pin(
+    data: PinSetSchema,
+    tenant_id: str = Depends(get_current_tenant_id),
+    current_user_id: str = Depends(get_current_user_id),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """信頼済み端末でのPINログイン用に、自分自身のPINを設定/変更する。"""
+    pin_hash = bcrypt.hashpw(data.pin.encode(), bcrypt.gensalt()).decode()
+    admin_client.table("member_pins").upsert(
+        {
+            "tenant_id": tenant_id,
+            "user_id": current_user_id,
+            "pin_hash": pin_hash,
+            "failed_attempts": 0,
+            "locked_until": None,
+        }
+    ).execute()
+
+
+@member_router.post("/{user_id}/pin/reset", status_code=status.HTTP_204_NO_CONTENT)
+def reset_member_pin(
+    user_id: str,
+    tenant_id: str = Depends(get_current_tenant_id),
+    current_user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
+    admin_client: Client = Depends(get_supabase_admin_client),
+):
+    """対象メンバーのPINを削除する（president / platform_admin のみ）。
+
+    本人が再度PINを設定するまでPINログインは利用できなくなる。
+    パスワードによる復旧経路を残すための操作。
+    """
+    _require_member_admin(current_user_id, tenant_id, client)
+    admin_client.table("member_pins").delete().eq("tenant_id", tenant_id).eq(
+        "user_id", user_id
     ).execute()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.0
 azure-functions==1.24.0
+bcrypt==5.0.0
 cachetools==5.5.2
 certifi==2025.11.12
 cffi==2.0.0

--- a/docs/features/device-trust-pin-auth.md
+++ b/docs/features/device-trust-pin-auth.md
@@ -1,0 +1,95 @@
+# 共有端末向けPIN認証・端末信頼（Issue #342）
+
+工場現場の共有端末（担当者ごとの専用PC・タブレットがない運用）を前提に、パスワードに代わる4桁PINを
+主要な本人識別手段とし、信頼済み端末上での操作者切り替えを軽量化する。パスワードは初期発行・アカウント
+復旧など例外的な操作にのみ残す。Issue #322（受注確認・承認ワークフロー）から派生し、前提Issue #343
+（`x-tenant-id` のサーバー側検証）の解消後に着手した。
+
+## 全体設計
+
+1. **端末信頼**: `president` / `platform_admin` が使用中の端末を「信頼済み端末」として登録する
+   （`POST /auth/device/register`）。発行された `device_id`（暗号乱数、`secrets.token_urlsafe(32)`）を
+   ブラウザの `localStorage` に保存する。信頼は1年で自動失効し、運営側（`president`/`platform_admin`）が
+   いつでも手動失効できる（`DELETE /auth/device/{device_id}`）。
+2. **PINログイン**: 信頼済み端末のログイン画面では、ログイン前でもテナントメンバーの名前一覧を表示し
+   （`GET /auth/device/status`）、名前を選んで4桁PINを入力するだけでログインできる
+   （`POST /auth/device/pin-login`）。各メンバーは事前に自分のPINを設定しておく必要がある
+   （`PATCH /tenant/members/me/pin`、`/settings/pin` 画面）。
+3. **セッション長期化**: `supabase/config.toml` の `jwt_expiry` を上限値の604800秒（1週間）に延長し、
+   共有端末でのリフレッシュ頻度を下げた。既存の `enable_refresh_token_rotation` によるリフレッシュ機構
+   （`frontend/src/utils/supabase/middleware.ts`）はそのまま使用しており、独自のセッション機構は導入していない。
+
+## PINログインのセッション発行方式
+
+`supabase-py==2.26.0` の Admin API には「パスワードなしで任意ユーザーのセッションを発行する」直接的な
+メソッドが存在しない。そこで以下の2段階で本物のSupabase JWTセッションを発行している
+（`backend/app/routers/auth/device.py` の `pin_login`）:
+
+1. `admin_client.auth.admin.generate_link({"type": "magiclink", "email": ...})` でハッシュ化トークンを生成
+   （メール送信は発生しない）
+2. `admin_client.auth.verify_otp({"token_hash": ..., "type": "magiclink"})` でセッション
+   （access_token / refresh_token）を取得
+
+発行されるのは通常のSupabase JWTであるため、`backend/app/dependencies.py` の `get_current_user_id` や
+既存のRLS、既存の監査ログ（Issue #326 `order_approval_log`）を一切変更せずにそのまま整合する。
+
+## データモデル
+
+`supabase/migrations/20260819000000_add_device_trust_and_member_pins.sql`
+
+- `device_trust_registrations`: 端末信頼レコード（`tenant_id`, `device_id`, `registered_by`, `created_at`,
+  `expires_at`＝登録から1年後, `revoked_at`）。RLSのSELECTポリシーは `president`/`platform_admin` の
+  端末管理画面用のみで、INSERT/UPDATEポリシーは設定せず全て service role（`admin_client`）経由に限定
+  （`notifications` テーブルと同じ default-deny パターン）。
+- `member_pins`: PINハッシュ（`tenant_id`, `user_id` 複合PK, `pin_hash`, `failed_attempts`,
+  `locked_until`）。SELECTポリシーを一切設けず、PINハッシュはクライアントJWTから直接読めない。全アクセスは
+  service role 経由のバックエンドロジックのみ。
+
+## PINのブルートフォース耐性
+
+4桁PIN（1万通り）は総当たりに弱いため、5回連続失敗で5分間ロックする
+（`_MAX_FAILED_ATTEMPTS` / `_LOCKOUT_DURATION`、`backend/app/routers/auth/device.py`）。ハッシュ化は
+`bcrypt` を使用。
+
+## セキュリティリスクと運用上の前提
+
+- **端末＝スキルトンキー化のリスク**: 信頼済み端末上ではPINのみでテナント内の任意メンバーとして
+  操作できるため、端末の盗難・不正利用時の影響範囲はテナント全体に及ぶ。設置場所の施錠管理など、
+  物理的なセキュリティ対策を運用側の前提とする。
+- **失効経路**: `president`/`platform_admin` が `/settings/devices` 画面からいつでも端末信頼を失効できる。
+  失効・期限切れの端末では、ID/パスワードによる既存のログインフローに自動的にフォールバックする
+  （`frontend/src/app/login/page.tsx`）ため、アクセス手段は失われない。
+- **PIN紛失時の復旧**: `president`/`platform_admin` が対象メンバーのPINを削除できる
+  （`POST /tenant/members/{user_id}/pin/reset`、`/settings/members` 画面のPINリセットボタン）。削除後は
+  本人が新しいPINを再設定するまでPINログインが使えず、ID/パスワードでのログインのみとなる。
+- **許容しているリスク**: 4桁PIN・5回失敗ロックはブルートフォース耐性より現場での記憶容易性・入力速度を
+  優先した設計判断であり、パスワードと同等の強度は意図していない。信頼済み端末という限定された経路
+  でのみ有効という前提のもとで許容している。
+
+## Backend
+
+- `backend/app/routers/auth/device.py`（`device_router`, prefix `/auth/device`）
+  - `POST /register`, `GET ""`, `DELETE /{device_id}`: 要JWT、`president`/`platform_admin` 限定
+  - `GET /status`, `POST /pin-login`: 認証不要（ログイン画面から呼び出す）
+- `backend/app/routers/tenant/members.py` に追加:
+  - `PATCH /tenant/members/me/pin`: 本人のみ、ロール制限なし
+  - `POST /tenant/members/{user_id}/pin/reset`: `president`/`platform_admin` 限定
+- スキーマ: `backend/app/models/auth/device_schemas.py`, `backend/app/models/tenant/pin_schemas.py`
+
+## Frontend
+
+- `frontend/src/app/login/page.tsx`: `localStorage` の `deviceId` を元に端末信頼状態を確認し、信頼済みなら
+  メンバー選択＋PIN入力を主表示にする。「パスワードでログイン」で既存フォームに切替可能。
+- `frontend/src/app/settings/devices/page.tsx`: 端末登録・一覧・失効（`president`/`platform_admin` のみ）
+- `frontend/src/app/settings/pin/page.tsx`: 自分のPIN設定（全ロール）
+- `frontend/src/app/settings/members/page.tsx`: メンバー行にPINリセットボタンを追加
+- `frontend/src/lib/device-auth-client.ts`: 未ログイン状態から呼び出す `/auth/device/status`,
+  `/auth/device/pin-login` 用の認証不要fetchラッパー（既存の `apiClient` はセッションJWT必須のため別実装）
+- `frontend/src/hooks/use-device-trust.ts`, `frontend/src/hooks/use-member-pin.ts`: 認証済みエンドポイント用
+  のTanStack Queryフック
+
+## テスト
+
+- `backend/__tests__/api/routers/auth/test_device.py`: 権限境界・端末信頼の有効/失効/期限切れ判定・PIN照合
+  （成功/失敗/ロックアウト）のFunctionalテスト
+- `backend/__tests__/api/routers/tenant/test_members.py`: PIN設定・PINリセットのFunctionalテストを追加

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -30,6 +30,7 @@ export default function LoginPage() {
 
     // 信頼済み端末・PINログイン関連の状態
     const [deviceId, setDeviceId] = useState<string | null>(null)
+    const [trustedTenantId, setTrustedTenantId] = useState<string | null>(null)
     const [trustedMembers, setTrustedMembers] = useState<DeviceMemberOption[] | null>(null)
     const [selectedMember, setSelectedMember] = useState<DeviceMemberOption | null>(null)
     const [pin, setPin] = useState('')
@@ -43,6 +44,7 @@ export default function LoginPage() {
         fetchDeviceStatus(storedDeviceId)
             .then((status) => {
                 if (status.trusted && status.members.length > 0) {
+                    setTrustedTenantId(status.tenant_id)
                     setTrustedMembers(status.members)
                 }
             })
@@ -51,14 +53,17 @@ export default function LoginPage() {
             })
     }, [])
 
-    const finishLogin = async (userId: string) => {
-        const tenantId = await fetchMyTenantId(userId)
+    // tenantId を明示的に渡さない場合は、ログインユーザーの所属テナント（先頭1件）を使う。
+    // PINログイン経路では、複数テナント所属ユーザーがいた場合に誤ったテナントが
+    // 選ばれないよう、信頼済み端末が紐づくテナントIDを明示的に渡す。
+    const finishLogin = async (userId: string, tenantId?: string) => {
+        const resolvedTenantId = tenantId ?? (await fetchMyTenantId(userId))
 
-        if (!tenantId) {
+        if (!resolvedTenantId) {
             throw new Error('所属するテナントが見つかりません。管理者に連絡してください。')
         }
 
-        localStorage.setItem('currentTenantId', tenantId)
+        localStorage.setItem('currentTenantId', resolvedTenantId)
 
         toast.success('ログイン成功', {
             description: 'ダッシュボードへ移動します',
@@ -69,7 +74,7 @@ export default function LoginPage() {
 
     const handlePinLogin = async (e: React.FormEvent) => {
         e.preventDefault()
-        if (!deviceId || !selectedMember) return
+        if (!deviceId || !selectedMember || !trustedTenantId) return
         setLoading(true)
 
         try {
@@ -82,7 +87,7 @@ export default function LoginPage() {
             })
             if (setSessionError) throw setSessionError
 
-            await finishLogin(selectedMember.user_id)
+            await finishLogin(selectedMember.user_id, trustedTenantId)
         } catch (error) {
             console.error(error)
             toast.error('ログイン失敗', {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,9 +1,11 @@
 /* frontend/src/app/login/page.tsx */
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createClient } from '@/utils/supabase/client'
 import { fetchMyTenantId } from '@/lib/auth-actions'
+import { fetchDeviceStatus, getStoredDeviceId, pinLogin } from '@/lib/device-auth-client'
+import type { DeviceMemberOption } from '@/types/device'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -19,12 +21,79 @@ const FEATURES = [
     { icon: BarChart3, label: 'ガントチャートで進捗を可視化' },
 ]
 
+const PIN_PATTERN = /^\d{4}$/
+
 export default function LoginPage() {
     const [email, setEmail] = useState(DEFAULT_USER || '')
     const [password, setPassword] = useState(DEFAULT_PASSWORD || '')
     const [loading, setLoading] = useState(false)
 
-    const handleLogin = async (e: React.FormEvent) => {
+    // 信頼済み端末・PINログイン関連の状態
+    const [deviceId, setDeviceId] = useState<string | null>(null)
+    const [trustedMembers, setTrustedMembers] = useState<DeviceMemberOption[] | null>(null)
+    const [selectedMember, setSelectedMember] = useState<DeviceMemberOption | null>(null)
+    const [pin, setPin] = useState('')
+    const [usePasswordFallback, setUsePasswordFallback] = useState(false)
+
+    useEffect(() => {
+        const storedDeviceId = getStoredDeviceId()
+        if (!storedDeviceId) return
+
+        setDeviceId(storedDeviceId)
+        fetchDeviceStatus(storedDeviceId)
+            .then((status) => {
+                if (status.trusted && status.members.length > 0) {
+                    setTrustedMembers(status.members)
+                }
+            })
+            .catch(() => {
+                // 端末状態の取得に失敗した場合はID/PWフォームにフォールバックする
+            })
+    }, [])
+
+    const finishLogin = async (userId: string) => {
+        const tenantId = await fetchMyTenantId(userId)
+
+        if (!tenantId) {
+            throw new Error('所属するテナントが見つかりません。管理者に連絡してください。')
+        }
+
+        localStorage.setItem('currentTenantId', tenantId)
+
+        toast.success('ログイン成功', {
+            description: 'ダッシュボードへ移動します',
+        })
+
+        window.location.href = '/'
+    }
+
+    const handlePinLogin = async (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!deviceId || !selectedMember) return
+        setLoading(true)
+
+        try {
+            const { access_token, refresh_token } = await pinLogin(deviceId, selectedMember.user_id, pin)
+
+            const supabase = createClient()
+            const { error: setSessionError } = await supabase.auth.setSession({
+                access_token,
+                refresh_token,
+            })
+            if (setSessionError) throw setSessionError
+
+            await finishLogin(selectedMember.user_id)
+        } catch (error) {
+            console.error(error)
+            toast.error('ログイン失敗', {
+                description: error instanceof Error ? error.message : 'PINが正しくありません',
+            })
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handlePasswordLogin = async (e: React.FormEvent) => {
         e.preventDefault()
         setLoading(true)
 
@@ -39,20 +108,7 @@ export default function LoginPage() {
             if (authError) throw authError
             if (!authData.user) throw new Error('ユーザー情報の取得に失敗しました')
 
-            const tenantId = await fetchMyTenantId(authData.user.id)
-
-            if (!tenantId) {
-                throw new Error('所属するテナントが見つかりません。管理者に連絡してください。')
-            }
-
-            localStorage.setItem('currentTenantId', tenantId)
-
-            toast.success('ログイン成功', {
-                description: 'ダッシュボードへ移動します',
-            })
-
-            window.location.href = '/'
-
+            await finishLogin(authData.user.id)
         } catch (error) {
             console.error(error)
             toast.error('ログイン失敗', {
@@ -62,6 +118,9 @@ export default function LoginPage() {
             setLoading(false)
         }
     }
+
+    // 信頼済み端末でPINログインを表示するかどうか
+    const showPinLogin = trustedMembers && trustedMembers.length > 0 && !usePasswordFallback
 
     return (
         <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
@@ -112,63 +171,153 @@ export default function LoginPage() {
                     </div>
 
                     <div className="w-full max-w-sm">
-                        <div className="mb-7">
-                            <h1 className="text-2xl font-bold text-gray-900">ログイン</h1>
-                            <p className="mt-1 text-sm text-gray-500">
-                                アカウント情報を入力してください
-                            </p>
-                        </div>
+                        {showPinLogin ? (
+                            <>
+                                <div className="mb-7">
+                                    <h1 className="text-2xl font-bold text-gray-900">ログイン</h1>
+                                    <p className="mt-1 text-sm text-gray-500">
+                                        名前を選択してPINを入力してください
+                                    </p>
+                                </div>
 
-                        <form onSubmit={handleLogin} className="space-y-5">
-                            <div className="space-y-1.5">
-                                <Label htmlFor="email" className="text-sm font-medium text-gray-700">
-                                    メールアドレス
-                                </Label>
-                                <Input
-                                    id="email"
-                                    type="email"
-                                    placeholder="example@company.com"
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                    className="bg-white border-gray-300 focus:border-[#1a2744] focus:ring-[#1a2744]"
-                                    required
-                                />
-                            </div>
-
-                            <div className="space-y-1.5">
-                                <Label htmlFor="password" className="text-sm font-medium text-gray-700">
-                                    パスワード
-                                </Label>
-                                <Input
-                                    id="password"
-                                    type="password"
-                                    placeholder="••••••••"
-                                    value={password}
-                                    onChange={(e) => setPassword(e.target.value)}
-                                    className="bg-white border-gray-300 focus:border-[#1a2744] focus:ring-[#1a2744]"
-                                    required
-                                />
-                            </div>
-
-                            <Button
-                                type="submit"
-                                className="w-full bg-[#1a2744] hover:bg-[#243460] text-white font-medium py-2.5 mt-2"
-                                disabled={loading}
-                            >
-                                {loading ? (
-                                    <span className="flex items-center gap-2">
-                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                        ログイン中...
-                                    </span>
+                                {!selectedMember ? (
+                                    <div className="space-y-2">
+                                        {trustedMembers!.map((member) => (
+                                            <button
+                                                key={member.user_id}
+                                                type="button"
+                                                onClick={() => setSelectedMember(member)}
+                                                className="w-full text-left px-4 py-3 rounded-md border border-gray-300 hover:border-[#1a2744] hover:bg-gray-50 transition-colors"
+                                            >
+                                                {member.full_name ?? '（氏名未設定）'}
+                                            </button>
+                                        ))}
+                                    </div>
                                 ) : (
-                                    'ログイン'
+                                    <form onSubmit={handlePinLogin} className="space-y-5">
+                                        <div className="space-y-1.5">
+                                            <Label htmlFor="pin" className="text-sm font-medium text-gray-700">
+                                                {selectedMember.full_name ?? '（氏名未設定）'} のPIN
+                                            </Label>
+                                            <Input
+                                                id="pin"
+                                                type="password"
+                                                inputMode="numeric"
+                                                maxLength={4}
+                                                placeholder="••••"
+                                                value={pin}
+                                                onChange={(e) => setPin(e.target.value.replace(/\D/g, ''))}
+                                                autoFocus
+                                                required
+                                            />
+                                        </div>
+                                        <Button
+                                            type="submit"
+                                            className="w-full bg-[#1a2744] hover:bg-[#243460] text-white font-medium py-2.5"
+                                            disabled={loading || !PIN_PATTERN.test(pin)}
+                                        >
+                                            {loading ? (
+                                                <span className="flex items-center gap-2">
+                                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                                    ログイン中...
+                                                </span>
+                                            ) : (
+                                                'ログイン'
+                                            )}
+                                        </Button>
+                                        <button
+                                            type="button"
+                                            className="w-full text-center text-sm text-gray-500 hover:text-gray-700"
+                                            onClick={() => { setSelectedMember(null); setPin('') }}
+                                        >
+                                            戻る
+                                        </button>
+                                    </form>
                                 )}
-                            </Button>
-                        </form>
 
-                        <p className="mt-7 text-center text-xs text-gray-400">
-                            アカウントをお持ちでない方は管理者にお問い合わせください
-                        </p>
+                                <p className="mt-7 text-center text-xs text-gray-400">
+                                    <button
+                                        type="button"
+                                        className="underline hover:text-gray-600"
+                                        onClick={() => setUsePasswordFallback(true)}
+                                    >
+                                        パスワードでログイン
+                                    </button>
+                                </p>
+                            </>
+                        ) : (
+                            <>
+                                <div className="mb-7">
+                                    <h1 className="text-2xl font-bold text-gray-900">ログイン</h1>
+                                    <p className="mt-1 text-sm text-gray-500">
+                                        アカウント情報を入力してください
+                                    </p>
+                                </div>
+
+                                <form onSubmit={handlePasswordLogin} className="space-y-5">
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="email" className="text-sm font-medium text-gray-700">
+                                            メールアドレス
+                                        </Label>
+                                        <Input
+                                            id="email"
+                                            type="email"
+                                            placeholder="example@company.com"
+                                            value={email}
+                                            onChange={(e) => setEmail(e.target.value)}
+                                            className="bg-white border-gray-300 focus:border-[#1a2744] focus:ring-[#1a2744]"
+                                            required
+                                        />
+                                    </div>
+
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="password" className="text-sm font-medium text-gray-700">
+                                            パスワード
+                                        </Label>
+                                        <Input
+                                            id="password"
+                                            type="password"
+                                            placeholder="••••••••"
+                                            value={password}
+                                            onChange={(e) => setPassword(e.target.value)}
+                                            className="bg-white border-gray-300 focus:border-[#1a2744] focus:ring-[#1a2744]"
+                                            required
+                                        />
+                                    </div>
+
+                                    <Button
+                                        type="submit"
+                                        className="w-full bg-[#1a2744] hover:bg-[#243460] text-white font-medium py-2.5 mt-2"
+                                        disabled={loading}
+                                    >
+                                        {loading ? (
+                                            <span className="flex items-center gap-2">
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                                ログイン中...
+                                            </span>
+                                        ) : (
+                                            'ログイン'
+                                        )}
+                                    </Button>
+                                </form>
+
+                                {trustedMembers && trustedMembers.length > 0 && (
+                                    <p className="mt-7 text-center text-xs text-gray-400">
+                                        <button
+                                            type="button"
+                                            className="underline hover:text-gray-600"
+                                            onClick={() => setUsePasswordFallback(false)}
+                                        >
+                                            PINでログイン
+                                        </button>
+                                    </p>
+                                )}
+
+                                <p className="mt-2 text-center text-xs text-gray-400">
+                                    アカウントをお持ちでない方は管理者にお問い合わせください
+                                </p>
+                            </>
+                        )}
                     </div>
                 </div>
             </div>

--- a/frontend/src/app/settings/devices/page.tsx
+++ b/frontend/src/app/settings/devices/page.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import { useState } from "react"
+import { Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+import {
+  useDeviceTrusts,
+  useRegisterDevice,
+  useRevokeDevice,
+} from "@/hooks/use-device-trust"
+import type { DeviceTrust } from "@/types/device"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+function isExpiredOrRevoked(device: DeviceTrust): boolean {
+  return !!device.revoked_at || new Date(device.expires_at) <= new Date()
+}
+
+/**
+ * 信頼済み端末管理ページ
+ * URL: /settings/devices
+ *
+ * 共有端末をこのテナントの信頼済み端末として登録・失効させる（president / platform_admin のみ）。
+ * 信頼済み端末上では、ログイン画面でPINによる操作者切り替えが可能になる。
+ */
+export default function DevicesPage() {
+  const [isRevokeDialogOpen, setIsRevokeDialogOpen] = useState(false)
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null)
+
+  const { data: devices, isLoading, error } = useDeviceTrusts()
+  const registerMutation = useRegisterDevice()
+  const revokeMutation = useRevokeDevice()
+
+  const handleRegister = () => {
+    registerMutation.mutate(undefined, {
+      onSuccess: () => {
+        toast.success("この端末を信頼済み端末として登録しました")
+      },
+      onError: (err) => {
+        toast.error(err.message || "端末の登録に失敗しました")
+      },
+    })
+  }
+
+  const handleOpenRevokeDialog = (deviceId: string) => {
+    setSelectedDeviceId(deviceId)
+    setIsRevokeDialogOpen(true)
+  }
+
+  const handleRevoke = () => {
+    if (!selectedDeviceId) return
+    revokeMutation.mutate(selectedDeviceId, {
+      onSuccess: () => {
+        setIsRevokeDialogOpen(false)
+        toast.success("端末信頼を失効させました")
+      },
+      onError: (err) => {
+        toast.error(err.message || "失効に失敗しました")
+      },
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">端末管理</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            信頼済み端末を管理します。信頼済み端末では、ログイン画面でPINによる操作者切り替えが可能になります
+          </p>
+        </div>
+        <Button onClick={handleRegister} disabled={registerMutation.isPending}>
+          <Plus className="mr-2 h-4 w-4" />
+          {registerMutation.isPending ? "登録中..." : "この端末を信頼済みにする"}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">読み込み中...</p>
+      ) : error ? (
+        <p className="text-destructive">
+          {error.message.includes("403")
+            ? "この画面は管理者のみアクセスできます"
+            : "端末情報の取得に失敗しました"}
+        </p>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>端末ID</TableHead>
+                <TableHead>登録日時</TableHead>
+                <TableHead>有効期限</TableHead>
+                <TableHead>状態</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {devices && devices.length > 0 ? (
+                devices.map((device) => {
+                  const expired = isExpiredOrRevoked(device)
+                  return (
+                    <TableRow key={device.device_id}>
+                      <TableCell className="font-mono text-xs">
+                        {device.device_id.slice(0, 12)}…
+                      </TableCell>
+                      <TableCell>
+                        {new Date(device.created_at).toLocaleString("ja-JP")}
+                      </TableCell>
+                      <TableCell>
+                        {new Date(device.expires_at).toLocaleDateString("ja-JP")}
+                      </TableCell>
+                      <TableCell>
+                        {device.revoked_at ? (
+                          <Badge variant="outline">失効済み</Badge>
+                        ) : expired ? (
+                          <Badge variant="outline">期限切れ</Badge>
+                        ) : (
+                          <Badge>有効</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {!device.revoked_at && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleOpenRevokeDialog(device.device_id)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-muted-foreground">
+                    信頼済み端末がありません
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <AlertDialog open={isRevokeDialogOpen} onOpenChange={setIsRevokeDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>端末信頼を失効させますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              この端末ではPINログインが使えなくなります。この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRevoke}
+              disabled={revokeMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {revokeMutation.isPending ? "失効中..." : "失効させる"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/app/settings/members/page.tsx
+++ b/frontend/src/app/settings/members/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Plus, Pencil, Trash2, Copy, RefreshCw } from "lucide-react"
+import { Plus, Pencil, Trash2, Copy, RefreshCw, KeyRound } from "lucide-react"
 import { toast } from "sonner"
 import {
   useTenantMembers,
@@ -9,6 +9,7 @@ import {
   useUpdateTenantMember,
   useDeleteTenantMember,
 } from "@/hooks/use-tenant-members"
+import { useResetMemberPin } from "@/hooks/use-member-pin"
 import type { TenantMember, MemberRole } from "@/types/member"
 import { Button } from "@/components/ui/button"
 import {
@@ -101,6 +102,7 @@ export default function MembersPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isPinResetDialogOpen, setIsPinResetDialogOpen] = useState(false)
   const [selectedMember, setSelectedMember] = useState<TenantMember | null>(null)
   const [createdPassword, setCreatedPassword] = useState<string | null>(null)
 
@@ -118,6 +120,7 @@ export default function MembersPage() {
   const createMutation = useCreateTenantMember()
   const updateMutation = useUpdateTenantMember()
   const deleteMutation = useDeleteTenantMember()
+  const resetPinMutation = useResetMemberPin()
 
   // 追加ダイアログを開く
   const handleOpenCreateDialog = () => {
@@ -141,6 +144,12 @@ export default function MembersPage() {
   const handleOpenDeleteDialog = (member: TenantMember) => {
     setSelectedMember(member)
     setIsDeleteDialogOpen(true)
+  }
+
+  // PINリセットダイアログを開く
+  const handleOpenPinResetDialog = (member: TenantMember) => {
+    setSelectedMember(member)
+    setIsPinResetDialogOpen(true)
   }
 
   // メンバー追加
@@ -193,6 +202,20 @@ export default function MembersPage() {
       },
       onError: (err) => {
         toast.error(err.message || "削除に失敗しました")
+      },
+    })
+  }
+
+  // PINリセット（共有端末でのPINログインを本人が再設定するまで無効化する）
+  const handleResetPin = () => {
+    if (!selectedMember) return
+    resetPinMutation.mutate(selectedMember.user_id, {
+      onSuccess: () => {
+        setIsPinResetDialogOpen(false)
+        toast.success("PINをリセットしました")
+      },
+      onError: (err) => {
+        toast.error(err.message || "PINのリセットに失敗しました")
       },
     })
   }
@@ -257,6 +280,14 @@ export default function MembersPage() {
                           onClick={() => handleOpenEditDialog(member)}
                         >
                           <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="PINをリセット"
+                          onClick={() => handleOpenPinResetDialog(member)}
+                        >
+                          <KeyRound className="h-4 w-4" />
                         </Button>
                         <Button
                           variant="ghost"
@@ -472,6 +503,28 @@ export default function MembersPage() {
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {deleteMutation.isPending ? "削除中..." : "削除"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* PINリセット確認ダイアログ */}
+      <AlertDialog open={isPinResetDialogOpen} onOpenChange={setIsPinResetDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>PINをリセットしますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              {selectedMember?.full_name ?? selectedMember?.email} の共有端末PINログインを無効化します。
+              本人が新しいPINを設定するまで、共有端末上でのPINログインは利用できなくなります（パスワードでのログインは引き続き可能です）。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleResetPin}
+              disabled={resetPinMutation.isPending}
+            >
+              {resetPinMutation.isPending ? "リセット中..." : "リセット"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/app/settings/pin/page.tsx
+++ b/frontend/src/app/settings/pin/page.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import { useSetMyPin } from "@/hooks/use-member-pin"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const PIN_PATTERN = /^\d{4}$/
+
+/**
+ * 自分自身のPIN設定ページ
+ * URL: /settings/pin
+ *
+ * 共有端末を信頼済み端末として登録した後、この端末上でPINログイン（パスワード不要）
+ * を使うために、各メンバーが自分自身のPINをここで設定する。ロール制限はない。
+ */
+export default function PinSettingsPage() {
+  const [pin, setPin] = useState("")
+  const [confirmPin, setConfirmPin] = useState("")
+  const setPinMutation = useSetMyPin()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!PIN_PATTERN.test(pin)) {
+      toast.error("PINは4桁の数字で入力してください")
+      return
+    }
+    if (pin !== confirmPin) {
+      toast.error("PINが一致しません")
+      return
+    }
+
+    setPinMutation.mutate(pin, {
+      onSuccess: () => {
+        toast.success("PINを設定しました")
+        setPin("")
+        setConfirmPin("")
+      },
+      onError: (err) => {
+        toast.error(err.message || "PINの設定に失敗しました")
+      },
+    })
+  }
+
+  return (
+    <div className="space-y-6 max-w-sm">
+      <div>
+        <h1 className="text-2xl font-bold">PIN設定</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          信頼済み端末（共有端末）でパスワードなしでログインするための4桁PINを設定します
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="pin">新しいPIN（4桁）</Label>
+          <Input
+            id="pin"
+            type="password"
+            inputMode="numeric"
+            maxLength={4}
+            placeholder="••••"
+            value={pin}
+            onChange={(e) => setPin(e.target.value.replace(/\D/g, ""))}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="confirm-pin">PIN（確認）</Label>
+          <Input
+            id="confirm-pin"
+            type="password"
+            inputMode="numeric"
+            maxLength={4}
+            placeholder="••••"
+            value={confirmPin}
+            onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, ""))}
+          />
+        </div>
+        <Button type="submit" disabled={setPinMutation.isPending}>
+          {setPinMutation.isPending ? "設定中..." : "PINを設定"}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -15,6 +15,8 @@ import {
   Users,
   Settings,
   ClipboardList,
+  Laptop,
+  KeyRound,
 } from "lucide-react"
 
 import {
@@ -92,6 +94,16 @@ const menuItems: MenuItem[] = [
         title: "メンバー管理",
         url: "/settings/members",
         icon: Users,
+      },
+      {
+        title: "端末管理",
+        url: "/settings/devices",
+        icon: Laptop,
+      },
+      {
+        title: "PIN設定",
+        url: "/settings/pin",
+        icon: KeyRound,
       },
     ],
   },

--- a/frontend/src/hooks/use-device-trust.ts
+++ b/frontend/src/hooks/use-device-trust.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api-client"
+import { DEVICE_ID_STORAGE_KEY } from "@/lib/device-auth-client"
+import type { DeviceRegisterResponse, DeviceTrust } from "@/types/device"
+
+const DEVICES_QUERY_KEY = ["device-trusts"]
+
+/**
+ * テナントの信頼済み端末一覧を取得するフック（president / platform_admin のみ）
+ */
+export function useDeviceTrusts() {
+  return useQuery<DeviceTrust[]>({
+    queryKey: DEVICES_QUERY_KEY,
+    queryFn: () => apiClient<DeviceTrust[]>("/auth/device"),
+  })
+}
+
+/**
+ * 現在使用中の端末をこのテナントの信頼済み端末として登録するフック。
+ * 成功時、発行された device_id を localStorage に保存する。
+ */
+export function useRegisterDevice() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () =>
+      apiClient<DeviceRegisterResponse>("/auth/device/register", {
+        method: "POST",
+      }),
+    onSuccess: (data) => {
+      localStorage.setItem(DEVICE_ID_STORAGE_KEY, data.device_id)
+      queryClient.invalidateQueries({ queryKey: DEVICES_QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * 端末信頼を失効させるフック
+ */
+export function useRevokeDevice() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (deviceId: string) =>
+      apiClient(`/auth/device/${deviceId}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: DEVICES_QUERY_KEY })
+    },
+  })
+}

--- a/frontend/src/hooks/use-member-pin.ts
+++ b/frontend/src/hooks/use-member-pin.ts
@@ -1,0 +1,28 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api-client"
+
+/**
+ * 自分自身のPINを設定/変更するフック
+ */
+export function useSetMyPin() {
+  return useMutation({
+    mutationFn: (pin: string) =>
+      apiClient("/tenant/members/me/pin", {
+        method: "PATCH",
+        body: JSON.stringify({ pin }),
+      }),
+  })
+}
+
+/**
+ * 対象メンバーのPINを削除する（president / platform_admin のみ）フック。
+ * 本人が再設定するまでPINログインは利用できなくなる（パスワードでの復旧経路を残す操作）。
+ */
+export function useResetMemberPin() {
+  return useMutation({
+    mutationFn: (userId: string) =>
+      apiClient(`/tenant/members/${userId}/pin/reset`, { method: "POST" }),
+  })
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -72,5 +72,11 @@ export async function apiClient<T>(endpoint: string, options: FetchOptions = {})
         throw new ApiError(response.status, errorData)
     }
 
+    // 204 No Content 等、ボディを持たないレスポンスは response.json() が
+    // "Unexpected end of JSON input" で失敗するため、先に空ボディを判定する
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+        return undefined as T
+    }
+
     return response.json()
 }

--- a/frontend/src/lib/device-auth-client.ts
+++ b/frontend/src/lib/device-auth-client.ts
@@ -25,6 +25,10 @@ async function deviceAuthFetch<T>(
     throw new ApiError(response.status, errorData)
   }
 
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined as T
+  }
+
   return response.json()
 }
 

--- a/frontend/src/lib/device-auth-client.ts
+++ b/frontend/src/lib/device-auth-client.ts
@@ -1,0 +1,51 @@
+/* frontend/src/lib/device-auth-client.ts */
+import type { DeviceStatusResponse, PinLoginResponse } from "@/types/device"
+import { ApiError } from "@/lib/api-client"
+
+export const DEVICE_ID_STORAGE_KEY = "deviceId"
+
+/**
+ * ログイン画面（未ログイン状態）から呼び出す端末認証系エンドポイント用のクライアント。
+ * apiClient とは異なり、セッションJWTの取得を前提としない（そもそもログイン前に使うため）。
+ */
+async function deviceAuthFetch<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${endpoint}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new ApiError(response.status, errorData)
+  }
+
+  return response.json()
+}
+
+export function getStoredDeviceId(): string | null {
+  if (typeof window === "undefined") return null
+  return localStorage.getItem(DEVICE_ID_STORAGE_KEY)
+}
+
+export function fetchDeviceStatus(deviceId: string): Promise<DeviceStatusResponse> {
+  return deviceAuthFetch<DeviceStatusResponse>(
+    `/auth/device/status?device_id=${encodeURIComponent(deviceId)}`
+  )
+}
+
+export function pinLogin(
+  deviceId: string,
+  userId: string,
+  pin: string
+): Promise<PinLoginResponse> {
+  return deviceAuthFetch<PinLoginResponse>("/auth/device/pin-login", {
+    method: "POST",
+    body: JSON.stringify({ device_id: deviceId, user_id: userId, pin }),
+  })
+}

--- a/frontend/src/types/device.ts
+++ b/frontend/src/types/device.ts
@@ -1,0 +1,28 @@
+export interface DeviceTrust {
+  device_id: string
+  registered_by: string
+  created_at: string
+  expires_at: string
+  revoked_at: string | null
+}
+
+export interface DeviceRegisterResponse {
+  device_id: string
+  expires_at: string
+}
+
+export interface DeviceMemberOption {
+  user_id: string
+  full_name: string | null
+}
+
+export interface DeviceStatusResponse {
+  trusted: boolean
+  tenant_id: string | null
+  members: DeviceMemberOption[]
+}
+
+export interface PinLoginResponse {
+  access_token: string
+  refresh_token: string
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,8 @@ site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
-jwt_expiry = 3600
+# 共有端末での運用を前提に、リフレッシュ頻度を下げるため上限値まで延長している (Issue #342)。
+jwt_expiry = 604800
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
 # jwt_issuer = ""
 # Path to JWT signing key. DO NOT commit your signing keys file to git.

--- a/supabase/migrations/20260819000000_add_device_trust_and_member_pins.sql
+++ b/supabase/migrations/20260819000000_add_device_trust_and_member_pins.sql
@@ -1,8 +1,10 @@
 -- 共有端末向けPIN認証・端末信頼基盤 (Issue #342)
 -- 端末を信頼済み端末として登録することで、その端末上に限りPINでの
--- 操作者識別・切り替えを許可する。PINハッシュ・端末信頼レコードは
--- いずれもクライアントJWTから直接読めないようにし、全アクセスを
--- service role (admin_client) 経由のバックエンドロジックに限定する。
+-- 操作者識別・切り替えを許可する。PINハッシュ (member_pins) はクライアント
+-- JWTから直接読めないようにし、全アクセスを service role (admin_client) 経由
+-- のバックエンドロジックに限定する。端末信頼レコード (device_trust_registrations)
+-- は書き込みのみ service role 限定とし、閲覧は端末管理画面向けに
+-- president / platform_admin のJWT経由でも許可する（後述のSELECTポリシー）。
 
 CREATE TABLE device_trust_registrations (
   id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/supabase/migrations/20260819000000_add_device_trust_and_member_pins.sql
+++ b/supabase/migrations/20260819000000_add_device_trust_and_member_pins.sql
@@ -1,0 +1,50 @@
+-- 共有端末向けPIN認証・端末信頼基盤 (Issue #342)
+-- 端末を信頼済み端末として登録することで、その端末上に限りPINでの
+-- 操作者識別・切り替えを許可する。PINハッシュ・端末信頼レコードは
+-- いずれもクライアントJWTから直接読めないようにし、全アクセスを
+-- service role (admin_client) 経由のバックエンドロジックに限定する。
+
+CREATE TABLE device_trust_registrations (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     uuid NOT NULL REFERENCES tenants(id),
+  device_id     text NOT NULL UNIQUE,
+  registered_by uuid NOT NULL REFERENCES auth.users(id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  expires_at    timestamptz NOT NULL DEFAULT (now() + interval '1 year'),
+  revoked_at    timestamptz
+);
+
+ALTER TABLE device_trust_registrations ENABLE ROW LEVEL SECURITY;
+
+-- 端末管理画面（president / platform_admin）からの閲覧用。
+-- notifications テーブルと同様、INSERT/UPDATE ポリシーは設定せず、
+-- 書き込みは全て service role 経由のバックエンドロジックに限定する
+-- (端末信頼の登録・失効はPIN認証の前提となる機微な操作のため)。
+CREATE POLICY "tenant admin can view device trusts" ON device_trust_registrations
+  FOR SELECT
+  USING (
+    is_tenant_member(tenant_id)
+    AND EXISTS (
+      SELECT 1 FROM organization_members om
+      WHERE om.tenant_id = device_trust_registrations.tenant_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('president', 'platform_admin')
+    )
+  );
+
+CREATE INDEX idx_device_trust_registrations_tenant ON device_trust_registrations (tenant_id);
+
+-- PINは端末未信頼の状態からでも照合できる必要があり(ログイン前)、
+-- ユーザーJWTを持たない状態でのアクセスが前提となるため、
+-- SELECTポリシーを一切設けず service role のみが読み書きできるようにする。
+CREATE TABLE member_pins (
+  tenant_id       uuid NOT NULL REFERENCES tenants(id),
+  user_id         uuid NOT NULL REFERENCES auth.users(id),
+  pin_hash        text NOT NULL,
+  failed_attempts integer NOT NULL DEFAULT 0,
+  locked_until    timestamptz,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, user_id)
+);
+
+ALTER TABLE member_pins ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- 信頼済み端末（`device_trust_registrations`、1年失効・手動失効可）を導入し、共有PC/タブレット上でパスワードに代わる4桁PINでの操作者識別・切り替えを実装（`member_pins`）
- PINログイン成功時は `generate_link` + `verify_otp` で本物のSupabase JWTセッションを発行するため、既存のRLS・監査ログ（#326）を一切変更せずに整合させた
- `supabase/config.toml` の `jwt_expiry` を上限値（1週間）まで延長し、共有端末でのリフレッシュ頻度を下げた
- フロント: ログイン画面に信頼済み端末向けPINログインUI（パスワードへのフォールバック付き）、`/settings/devices`（端末登録・一覧・失効、president/platform_admin限定）、`/settings/pin`（自分のPIN設定）、メンバー管理画面へのPINリセットボタンを追加

Closes #342
前提Issue #343（`x-tenant-id`サーバー側検証）は解消済み

## Test plan
- [x] `pytest __tests__/unit/ __tests__/api/`（106件）全通過、`--run-integration` 込みで既存分462件も通過（無関係な既存fixtureの2件のみ事前からエラー）
- [x] `ruff check .` / `mypy .` クリーン
- [x] フロント `tsc --noEmit`, `eslint`, `next build` 通過
- [x] ローカルSupabase（Docker）でマイグレーション適用・シード投入・実機ブラウザ確認まで実施済み:
  - curlでの全エンドポイント確認（端末登録→PIN設定→端末状態確認→PINログイン成功→発行JWTで通常API疎通→ロックアウト→端末失効→失効後403→ID/PWフォールバック確認、権限境界のorder_handler 403確認）
  - Playwrightでのブラウザ実機確認: パスワードログイン→端末登録→PIN設定→ログアウト→ログイン画面がPIN選択UIに切り替わる→PIN入力→ダッシュボードに遷移、をエンドツーエンドで確認
  - 実機確認中に発見した既存バグ（`apiClient` が204レスポンスで`.json()`に失敗しトースト誤表示になる不具合）も本PRで修正済み
- [x] セキュリティリスクと運用前提を `docs/features/device-trust-pin-auth.md` に文書化

🤖 Generated with [Claude Code](https://claude.com/claude-code)