### PR TITLE
docs: docs/features と Wiki の使い分け方針をCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,8 @@ cd backend && ruff check . && mypy .
 ### Pull Requestのルール
 - 作業が完了したらプルリクエストを作成すること
 - プルリクエストを作成したら必ず `docs/features` ディレクトリ内の該当ドキュメントを更新すること
+
+### ドキュメントの配置方針（`docs/features` と Wiki の使い分け）
+- `docs/features/`: 開発者向けドキュメント。実装（エンドポイント・ファイルパス・データモデル等）と結びつく内容はここに書き、コード変更と同じPRでレビュー・更新する
+- [Wiki](https://github.com/HyperGenius/product-planner/wiki): 顧客・現場担当者向けの運用マニュアル（操作手順書等）。`docs/features` は開発者が読むには数が多くなりすぎるため、対象読者が非エンジニアの手順書はWikiに分離する。PRレビュー対象外のため、コードと無関係に随時更新してよい
+- 機能追加時に両方の対象読者向けドキュメントが必要な場合は、`docs/features/` 側に該当Wikiページへのリンクを記載すること（例: [docs/features/device-trust-pin-auth.md](docs/features/device-trust-pin-auth.md)）

--- a/docs/features/tenant-onboarding-script.md
+++ b/docs/features/tenant-onboarding-script.md
@@ -4,39 +4,8 @@
 
 `backend/scripts/create_tenant.py` は、新規顧客テナントを本番 Supabase へコマンド一発で作成する CLI スクリプト。
 
-## 使い方
-
-```bash
-cd backend
-python scripts/create_tenant.py \
-  --company-name "株式会社〇〇" \
-  --owner-email "xxx@example.com" \
-  --owner-name "山田太郎"
-```
-
-### 出力例
-
-```
-=== テナント作成完了 ===
-テナント名  : 株式会社〇〇
-テナント ID : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-ユーザー ID : yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
-メール     : xxx@example.com
-初期パスワード: Xy7#mK2pQ9!rNvLw
-======================
-※ 初期パスワードを安全に顧客へ伝達してください
-```
-
-初期パスワードは **標準出力のみ** に表示される。ファイルには保存されない。
-
-## 必要な環境変数
-
-| 変数名 | 説明 |
-|---|---|
-| `SUPABASE_URL` | 本番 Supabase の URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | Service Role Key |
-
-`backend/.env` に設定するか、環境変数として渡す。
+使い方・出力例・必要な環境変数などの運用手順は Wiki にまとめている:
+[新規テナントオンボーディング手順](https://github.com/HyperGenius/product-planner/wiki/新規テナントオンボーディング手順)
 
 ## 処理フロー
 


### PR DESCRIPTION
## Summary
- Issue #342 対応時、`docs/features` 配下のドキュメントが多く読みにくいという指摘を受け、顧客向け運用マニュアルを[Wiki](https://github.com/HyperGenius/product-planner/wiki)へ分離した
- 今後同様の判断を迷わず行えるよう、開発者向け(`docs/features`)と顧客向け(Wiki)の使い分け方針をCLAUDE.mdに明文化

## Test plan
- ドキュメントのみの変更のため動作確認不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)