### PR TITLE
製品名の表記ゆれを別名辞書として蓄積・履歴管理する

### DIFF
--- a/backend/__tests__/api/routers/master/test_products_router.py
+++ b/backend/__tests__/api/routers/master/test_products_router.py
@@ -3,7 +3,12 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from app.dependencies import get_current_user_id, get_product_repo, get_supabase_client
+from app.dependencies import (
+    get_current_user_id,
+    get_product_name_alias_history_repo,
+    get_product_repo,
+    get_supabase_client,
+)
 
 # テスト対象のAPIインスタンス
 from app.main import app
@@ -35,8 +40,14 @@ class TestProductRouter:
         """Supabaseクライアントのモックを作成するフィクスチャ"""
         return MagicMock()
 
+    @pytest.fixture
+    def mock_alias_history_repo(self):
+        """製品名別名履歴リポジトリのモックを作成するフィクスチャ"""
+        mock = MagicMock()
+        return mock
+
     @pytest.fixture(autouse=True)
-    def override_dependency(self, mock_repo, mock_client):
+    def override_dependency(self, mock_repo, mock_client, mock_alias_history_repo):
         """
         テスト実行中だけ get_product_repo / get_current_user_id / get_supabase_client を差し替える。
         PATCH は is_active 更新時にロールチェックのため get_current_user_id
@@ -45,6 +56,9 @@ class TestProductRouter:
         app.dependency_overrides[get_product_repo] = lambda: mock_repo
         app.dependency_overrides[get_current_user_id] = lambda: "test-user-id"
         app.dependency_overrides[get_supabase_client] = lambda: mock_client
+        app.dependency_overrides[get_product_name_alias_history_repo] = (
+            lambda: mock_alias_history_repo
+        )
         yield
         # テスト終了後に元に戻す（重要）
         app.dependency_overrides = {}
@@ -195,6 +209,49 @@ class TestProductRouter:
 
         assert response.status_code == 403
         mock_repo.update.assert_not_called()
+
+    def test_get_product_name_alias_history_empty(self, mock_alias_history_repo):
+        """GET /{id}/aliases: 履歴が0件の場合は空配列を返すこと"""
+        product_id = 1
+        mock_alias_history_repo.get_by_product_id.return_value = []
+
+        response = client.get(f"/products/{product_id}/aliases")
+
+        assert response.status_code == 200
+        assert response.json() == []
+        mock_alias_history_repo.get_by_product_id.assert_called_with(product_id)
+
+    def test_get_product_name_alias_history_resolves_actor_name(
+        self, mock_alias_history_repo, mock_client
+    ):
+        """GET /{id}/aliases: changed_by を担当者の表示名に解決した集約レスポンスを返すこと"""
+        product_id = 1
+        mock_alias_history_repo.get_by_product_id.return_value = [
+            {
+                "id": "hist-1",
+                "product_id": product_id,
+                "product_name_snapshot": "製品A",
+                "raw_text": "セイヒンA",
+                "changed_by": "user-1",
+                "action": "created",
+                "source_order_id": 42,
+                "source_order_label_snapshot": "ORD-042",
+                "changed_at": "2026-08-19T00:00:00Z",
+            }
+        ]
+        mock_client.table.return_value.select.return_value.in_.return_value.execute.return_value.data = [
+            {"id": "user-1", "full_name": "山田太郎"}
+        ]
+
+        response = client.get(f"/products/{product_id}/aliases")
+
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result) == 1
+        assert result[0]["raw_text"] == "セイヒンA"
+        assert result[0]["changed_by_full_name"] == "山田太郎"
+        assert result[0]["source_order_id"] == 42
+        assert result[0]["source_order_label_snapshot"] == "ORD-042"
 
     def test_delete_product_success(self, mock_repo):
         """DELETE /{id}: 削除成功時のテスト"""

--- a/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
+++ b/backend/__tests__/unit/services/test_pdf_order_parsing_service.py
@@ -8,6 +8,19 @@ from app.services.pdf_order_parsing_service import (
 from app.services.pdf_text_service import PdfTextResult
 
 
+@pytest.fixture(autouse=True)
+def _no_alias_match():
+    """product_name_aliases による完全一致（Issue #347）を既定で無効化し、
+    既存テストが pg_trgm・品番一致のフォールバック経路を検証できるようにする。
+    別名一致自体を検証するテストでは個別に return_value を上書きする。
+    """
+    with patch(
+        "app.services.pdf_order_parsing_service.match_product_by_alias",
+        return_value=None,
+    ) as mock_alias:
+        yield mock_alias
+
+
 @pytest.mark.unit
 class TestParsePendingOrderPdfs:
     def _staging_row(self, **overrides):
@@ -398,6 +411,38 @@ class TestProcessLineItem:
         assert rpc_params["p_product_id"] is None
         # extracted_product_name は TRIM() のみ行い、それ以外の正規化はしない
         assert rpc_params["p_extracted_product_name"] == "謎の製品"
+
+    def test_alias_exact_match_takes_priority_over_code_and_trgm(self, _no_alias_match):
+        """product_name_aliases の完全一致（Issue #347）は products.code の完全一致
+        や pg_trgm 検索より優先され、一致すればそれらはスキップされること。"""
+        mock_db = MagicMock()
+        mock_db.rpc().execute.return_value = MagicMock(
+            data=[{"order_id": 555, "action": "inserted"}]
+        )
+        _no_alias_match.return_value = 4242
+        line = {
+            "product_name_raw": "謎の表記ゆれ製品",
+            "product_number_raw": None,
+            "quantity": 10,
+            "delivery_date": "2026-08-01",
+            "certainty": "confirmed",
+        }
+
+        with (
+            patch(
+                "app.services.pdf_order_parsing_service.match_product_by_code",
+            ) as mock_code,
+            patch(
+                "app.services.pdf_order_parsing_service.match_products",
+            ) as mock_trgm,
+        ):
+            created = _process_line_item(mock_db, self._staging_row(), line)
+
+        assert created is True
+        mock_code.assert_not_called()
+        mock_trgm.assert_not_called()
+        rpc_params = mock_db.rpc.call_args_list[-1].args[1]
+        assert rpc_params["p_product_id"] == 4242
 
     def test_falls_back_to_name_search_using_product_number_raw(self):
         """

--- a/backend/__tests__/unit/services/test_product_alias_service.py
+++ b/backend/__tests__/unit/services/test_product_alias_service.py
@@ -129,9 +129,7 @@ class TestRecordCorrectionIfApplicable:
         )
 
         mock_db._tables[_ALIASES].insert.assert_not_called()
-        mock_db._tables[_ALIASES].update.assert_called_with(
-            {"product_id": 2, "created_by": "user-1"}
-        )
+        mock_db._tables[_ALIASES].update.assert_called_with({"product_id": 2})
 
         history_insert_call = mock_db._tables[_HISTORY].insert.call_args
         assert history_insert_call.args[0]["action"] == "updated"
@@ -153,9 +151,7 @@ class TestRecordCorrectionIfApplicable:
             mock_db, "tenant-1", order_before, order_after, "user-1"
         )
 
-        mock_db._tables[_ALIASES].update.assert_called_with(
-            {"product_id": 2, "created_by": "user-1"}
-        )
+        mock_db._tables[_ALIASES].update.assert_called_with({"product_id": 2})
         history_insert_call = mock_db._tables[_HISTORY].insert.call_args
         assert history_insert_call.args[0]["action"] == "updated"
 
@@ -176,3 +172,40 @@ class TestRecordCorrectionIfApplicable:
         history_insert_call = mock_db._tables[_HISTORY].insert.call_args
         assert history_insert_call.args[0]["action"] == "created"
         assert history_insert_call.args[0]["source_order_label_snapshot"] == "注文 #5"
+
+    def test_updating_existing_alias_does_not_overwrite_created_by(self):
+        """created_by は最初の登録者を表す監査カラムのため、再修正時に
+        上書きしないこと（PRレビュー指摘対応）。"""
+        mock_db = self._mock_db(existing_alias_rows=[{"id": "alias-1"}])
+        order_before = {"id": 1, "product_id": 3}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": "セイヒンA",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-2"
+        )
+
+        update_call_args = mock_db._tables[_ALIASES].update.call_args.args[0]
+        assert "created_by" not in update_call_args
+
+    def test_unexpected_error_is_logged_and_not_raised(self):
+        """記録処理は注文更新とは別トランザクションのベストエフォート処理のため、
+        例外を送出せずログに記録するのみとする（PRレビュー指摘対応: これにより
+        呼び出し元 update_order/split_order のレスポンスが誤って500にならない）。"""
+        mock_db = self._mock_db(existing_alias_rows=[])
+        mock_db._tables[_HISTORY].insert.side_effect = RuntimeError("boom")
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": "セイヒンA",
+        }
+
+        # 例外が外へ伝播しないこと
+        record_correction_if_applicable(
+            mock_db, "tenant-1", None, order_after, "user-1"
+        )

--- a/backend/__tests__/unit/services/test_product_alias_service.py
+++ b/backend/__tests__/unit/services/test_product_alias_service.py
@@ -1,0 +1,178 @@
+from unittest.mock import MagicMock
+
+import pytest
+from app.services.product_alias_service import record_correction_if_applicable
+from postgrest.exceptions import APIError
+
+_ALIASES = "product_name_aliases"
+_HISTORY = "product_name_alias_history"
+_PRODUCTS = "products"
+
+
+@pytest.mark.unit
+class TestRecordCorrectionIfApplicable:
+    def _mock_db(self, existing_alias_rows=None, product_name="製品A"):
+        """テーブル名ごとに独立したモックを返す db クライアント。
+
+        MagicMock().table("x") と .table("y") は既定では同一の子モックを
+        返してしまい、テーブルを跨いだ呼び出し（product_name_aliases /
+        product_name_alias_history / products）を区別できないため、
+        テーブル名で分岐する side_effect を設定する。
+        """
+        tables: dict[str, MagicMock] = {
+            _ALIASES: MagicMock(),
+            _HISTORY: MagicMock(),
+            _PRODUCTS: MagicMock(),
+        }
+
+        tables[_ALIASES].select().eq().eq().execute.return_value = MagicMock(
+            data=existing_alias_rows or []
+        )
+        tables[_PRODUCTS].select().eq().single().execute.return_value = MagicMock(
+            data={"name": product_name}
+        )
+
+        mock_db = MagicMock()
+        mock_db.table.side_effect = lambda name: tables[name]
+        mock_db._tables = tables
+        return mock_db
+
+    def test_skips_when_source_type_is_not_email(self):
+        mock_db = self._mock_db()
+        order_before = {"id": 1, "product_id": 1}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "manual",
+            "extracted_product_name": "製品A",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        mock_db._tables[_HISTORY].insert.assert_not_called()
+
+    def test_skips_when_extracted_product_name_missing(self):
+        mock_db = self._mock_db()
+        order_before = {"id": 1, "product_id": 1}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": None,
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        mock_db._tables[_HISTORY].insert.assert_not_called()
+
+    def test_skips_when_product_id_unchanged(self):
+        mock_db = self._mock_db()
+        order_before = {"id": 1, "product_id": 2}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": "製品A",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        mock_db._tables[_HISTORY].insert.assert_not_called()
+
+    def test_creates_alias_and_history_when_new(self):
+        mock_db = self._mock_db(existing_alias_rows=[])
+        order_before = {"id": 1, "product_id": None}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "order_number": "ORD-001",
+            "source_type": "email",
+            "extracted_product_name": "  セイヒンA  ",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        alias_insert_call = mock_db._tables[_ALIASES].insert.call_args
+        assert alias_insert_call.args[0]["raw_text"] == "セイヒンA"
+        assert alias_insert_call.args[0]["product_id"] == 2
+        assert alias_insert_call.args[0]["created_by"] == "user-1"
+
+        history_insert_call = mock_db._tables[_HISTORY].insert.call_args
+        history_data = history_insert_call.args[0]
+        assert history_data["action"] == "created"
+        assert history_data["raw_text"] == "セイヒンA"
+        assert history_data["product_name_snapshot"] == "製品A"
+        assert history_data["source_order_id"] == 1
+        assert history_data["source_order_label_snapshot"] == "ORD-001"
+        assert history_data["changed_by"] == "user-1"
+
+    def test_updates_existing_alias_when_raw_text_already_registered(self):
+        mock_db = self._mock_db(existing_alias_rows=[{"id": "alias-1"}])
+        order_before = {"id": 1, "product_id": 3}
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": "セイヒンA",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        mock_db._tables[_ALIASES].insert.assert_not_called()
+        mock_db._tables[_ALIASES].update.assert_called_with(
+            {"product_id": 2, "created_by": "user-1"}
+        )
+
+        history_insert_call = mock_db._tables[_HISTORY].insert.call_args
+        assert history_insert_call.args[0]["action"] == "updated"
+
+    def test_concurrent_insert_conflict_falls_back_to_update(self):
+        mock_db = self._mock_db(existing_alias_rows=[])
+        mock_db._tables[_ALIASES].insert.side_effect = APIError(
+            {"code": "23505", "message": "duplicate key"}
+        )
+        order_before = None
+        order_after = {
+            "id": 1,
+            "product_id": 2,
+            "source_type": "email",
+            "extracted_product_name": "セイヒンA",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", order_before, order_after, "user-1"
+        )
+
+        mock_db._tables[_ALIASES].update.assert_called_with(
+            {"product_id": 2, "created_by": "user-1"}
+        )
+        history_insert_call = mock_db._tables[_HISTORY].insert.call_args
+        assert history_insert_call.args[0]["action"] == "updated"
+
+    def test_order_before_none_records_created_action(self):
+        """split_order のような新規作成経路（order_before なし）でも記録されること"""
+        mock_db = self._mock_db(existing_alias_rows=[])
+        order_after = {
+            "id": 5,
+            "product_id": 9,
+            "source_type": "email",
+            "extracted_product_name": "セイヒンB",
+        }
+
+        record_correction_if_applicable(
+            mock_db, "tenant-1", None, order_after, "user-1"
+        )
+
+        history_insert_call = mock_db._tables[_HISTORY].insert.call_args
+        assert history_insert_call.args[0]["action"] == "created"
+        assert history_insert_call.args[0]["source_order_label_snapshot"] == "注文 #5"

--- a/backend/__tests__/unit/services/test_product_matching_service.py
+++ b/backend/__tests__/unit/services/test_product_matching_service.py
@@ -1,7 +1,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from app.services.product_matching_service import match_product_by_code, match_products
+from app.services.product_matching_service import (
+    match_product_by_alias,
+    match_product_by_code,
+    match_products,
+)
 
 
 @pytest.mark.unit
@@ -33,6 +37,33 @@ class TestMatchProductByCode:
         )
 
         result = match_product_by_code(mock_db, "tenant-1", "ambiguous-code")
+
+        assert result is None
+
+
+@pytest.mark.unit
+class TestMatchProductByAlias:
+    def test_match_returns_product_id(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[{"product_id": 4242}]
+        )
+
+        result = match_product_by_alias(mock_db, "tenant-1", "  謎の表記ゆれ製品  ")
+
+        assert result == 4242
+        # raw_text は TRIM() のみ行った値で検索する
+        mock_db.table().select().eq().eq.assert_called_with(
+            "raw_text", "謎の表記ゆれ製品"
+        )
+
+    def test_no_match_returns_none(self):
+        mock_db = MagicMock()
+        mock_db.table().select().eq().eq().limit().execute.return_value = MagicMock(
+            data=[]
+        )
+
+        result = match_product_by_alias(mock_db, "tenant-1", "未登録の製品名")
 
         assert result is None
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -10,6 +10,7 @@ from app.repositories.supa_infra import (
     EquipmentRepository,
     OrderApprovalLogRepository,
     OrderRepository,
+    ProductNameAliasHistoryRepository,
     ProductRepository,
     ScheduleRepository,
 )
@@ -144,6 +145,13 @@ def get_product_repo(
 ) -> ProductRepository:
     """プロダクトリポジトリを取得する。"""
     return ProductRepository(client)
+
+
+def get_product_name_alias_history_repo(
+    client: Client = Depends(get_supabase_client),
+) -> ProductNameAliasHistoryRepository:
+    """製品名の表記ゆれ修正履歴リポジトリを取得する。"""
+    return ProductNameAliasHistoryRepository(client)
 
 
 def get_equipment_repo(

--- a/backend/app/models/master/__init__.py
+++ b/backend/app/models/master/__init__.py
@@ -6,11 +6,16 @@ from .process_routings import (
     RoutingResponse,
     RoutingUpdate,
 )
-from .product_schemas import ProductCreateSchema, ProductUpdateSchema
+from .product_schemas import (
+    ProductCreateSchema,
+    ProductNameAliasHistoryResponse,
+    ProductUpdateSchema,
+)
 
 __all__ = [
     "ProductCreateSchema",
     "ProductUpdateSchema",
+    "ProductNameAliasHistoryResponse",
     "RoutingCreate",
     "RoutingUpdate",
     "RoutingResponse",

--- a/backend/app/models/master/product_schemas.py
+++ b/backend/app/models/master/product_schemas.py
@@ -1,6 +1,6 @@
 # models/master/product.py
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from app.models.common.base_schema import BaseSchema
 
@@ -37,3 +37,23 @@ class ProductUpdateSchema(BaseSchema):
     code: str | None = Field(default=None, description="製品コード")
     type: str | None = Field(default=None, description="製品種別")
     is_active: bool | None = Field(default=None, description="有効/無効フラグ")
+
+
+# --- Product Name Aliases（Issue #347） ---
+class ProductNameAliasHistoryResponse(BaseModel):
+    """製品名の表記ゆれ修正履歴のレスポンススキーマ
+
+    product_name_alias_history の生データではなく、登録者の表示名・
+    トリガーとなった注文情報を解決した集約レスポンスとする。
+    """
+
+    id: str
+    product_id: int | None
+    product_name_snapshot: str
+    raw_text: str
+    changed_by: str
+    changed_by_full_name: str | None
+    action: str
+    source_order_id: int | None
+    source_order_label_snapshot: str
+    changed_at: str

--- a/backend/app/repositories/supa_infra/__init__.py
+++ b/backend/app/repositories/supa_infra/__init__.py
@@ -3,6 +3,7 @@ from app.repositories.supa_infra.common import CalendarRepository, SupabaseTable
 from app.repositories.supa_infra.master import (
     CustomerRepository,
     EquipmentRepository,
+    ProductNameAliasHistoryRepository,
     ProductRepository,
 )
 from app.repositories.supa_infra.transaction import (
@@ -19,6 +20,7 @@ __all__ = [
     "EquipmentRepository",
     "ProductRepository",
     "CustomerRepository",
+    "ProductNameAliasHistoryRepository",
     # transaction
     "ScheduleRepository",
     "OrderRepository",

--- a/backend/app/repositories/supa_infra/common/table_name.py
+++ b/backend/app/repositories/supa_infra/common/table_name.py
@@ -21,3 +21,5 @@ class SupabaseTableName(Enum):
     ORDER_PARSE_LOG = "order_parse_log"
     NOTIFICATIONS = "notifications"
     ORDER_APPROVAL_LOG = "order_approval_log"
+    PRODUCT_NAME_ALIASES = "product_name_aliases"
+    PRODUCT_NAME_ALIAS_HISTORY = "product_name_alias_history"

--- a/backend/app/repositories/supa_infra/master/__init__.py
+++ b/backend/app/repositories/supa_infra/master/__init__.py
@@ -1,6 +1,12 @@
 # repositories/supabase/master/__init__.py
 from .customer_repo import CustomerRepository
 from .equipment_repo import EquipmentRepository
+from .product_name_alias_repo import ProductNameAliasHistoryRepository
 from .product_repo import ProductRepository
 
-__all__ = ["EquipmentRepository", "ProductRepository", "CustomerRepository"]
+__all__ = [
+    "EquipmentRepository",
+    "ProductRepository",
+    "CustomerRepository",
+    "ProductNameAliasHistoryRepository",
+]

--- a/backend/app/repositories/supa_infra/master/product_name_alias_repo.py
+++ b/backend/app/repositories/supa_infra/master/product_name_alias_repo.py
@@ -1,0 +1,27 @@
+# repositories/supa_infra/master/product_name_alias_repo.py
+from typing import Any, TypeVar, cast
+
+from app.repositories.supa_infra.common import BaseRepository, SupabaseTableName
+
+T = TypeVar("T", bound=dict[str, Any])
+
+
+class ProductNameAliasHistoryRepository(BaseRepository[T]):
+    """製品名の表記ゆれ修正履歴 (product_name_alias_history) のリポジトリ（Issue #347）。
+
+    追記のみのテーブルのため create/get 系のみを提供する。
+    """
+
+    def __init__(self, client):
+        super().__init__(client, SupabaseTableName.PRODUCT_NAME_ALIAS_HISTORY.value)
+
+    def get_by_product_id(self, product_id: int) -> list[T]:
+        """製品IDに紐づく修正履歴を新しい順に取得"""
+        res = (
+            self.client.table(self.table_name)
+            .select("*")
+            .eq("product_id", product_id)
+            .order("changed_at", desc=True)
+            .execute()
+        )
+        return cast(list[T], res.data or [])

--- a/backend/app/routers/master/products.py
+++ b/backend/app/routers/master/products.py
@@ -1,14 +1,24 @@
 # routers/master/products.py
+from typing import Any, cast
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.dependencies import (
     get_current_tenant_id,
     get_current_user_id,
     get_current_user_role,
+    get_product_name_alias_history_repo,
     get_product_repo,
     get_supabase_client,
 )
-from app.models.master import ProductCreateSchema, ProductUpdateSchema
+from app.models.master import (
+    ProductCreateSchema,
+    ProductNameAliasHistoryResponse,
+    ProductUpdateSchema,
+)
+from app.repositories.supa_infra.master.product_name_alias_repo import (
+    ProductNameAliasHistoryRepository,
+)
 from app.repositories.supa_infra.master.product_repo import ProductRepository
 from app.utils.logger import get_logger
 from supabase import Client  # type: ignore
@@ -41,6 +51,52 @@ def get_product(product_id: int, repo: ProductRepository = Depends(get_product_r
     """製品を1件取得"""
     logger.info(f"Fetching product {product_id}")
     return repo.get_by_id(product_id)
+
+
+@product_router.get(
+    "/{product_id}/aliases", response_model=list[ProductNameAliasHistoryResponse]
+)
+def get_product_name_alias_history(
+    product_id: int,
+    client: Client = Depends(get_supabase_client),
+    alias_history_repo: ProductNameAliasHistoryRepository = Depends(
+        get_product_name_alias_history_repo
+    ),
+):
+    """製品名の表記ゆれ修正履歴を取得する（Issue #347）。
+
+    登録者（changed_by）を表示名に、トリガーとなった注文（source_order_id）を
+    注文番号に解決した集約レスポンスを返す（生の product_name_alias_history
+    ダンプではない）。
+    """
+    logger.info(f"Fetching product name alias history for product {product_id}")
+    history = alias_history_repo.get_by_product_id(product_id)
+    if not history:
+        return []
+
+    actor_ids = list({h["changed_by"] for h in history})
+    profiles_res = (
+        client.table("profiles").select("id, full_name").in_("id", actor_ids).execute()
+    )
+    profiles_map = {
+        p["id"]: p for p in cast(list[dict[str, Any]], profiles_res.data or [])
+    }
+
+    return [
+        ProductNameAliasHistoryResponse(
+            id=str(h["id"]),
+            product_id=h.get("product_id"),
+            product_name_snapshot=h["product_name_snapshot"],
+            raw_text=h["raw_text"],
+            changed_by=h["changed_by"],
+            changed_by_full_name=profiles_map.get(h["changed_by"], {}).get("full_name"),
+            action=h["action"],
+            source_order_id=h.get("source_order_id"),
+            source_order_label_snapshot=h["source_order_label_snapshot"],
+            changed_at=str(h["changed_at"]),
+        )
+        for h in history
+    ]
 
 
 @product_router.patch("/{product_id}")

--- a/backend/app/routers/transaction/orders.py
+++ b/backend/app/routers/transaction/orders.py
@@ -48,6 +48,7 @@ from app.services.order_status_service import (
     InvalidOrderStatusTransitionError,
     validate_order_status_transition,
 )
+from app.services.product_alias_service import record_correction_if_applicable
 from app.services.simulation_service import build_simulate_response
 from app.utils.logger import get_logger
 from supabase import Client
@@ -327,6 +328,9 @@ def get_order_attachments(
 def update_order(
     order_id: int,
     order_data: OrderUpdate,
+    tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
+    client: Client = Depends(get_supabase_client),
     repo: OrderRepository = Depends(get_order_repo),
 ):
     """注文を更新
@@ -335,11 +339,18 @@ def update_order(
     メール/PDF起票のステージング行の双方）は、orders.customer_id の UPDATE と
     同一トランザクションで実行される DB トリガー
     (sync_order_attachments_customer_id, Issue #315) が担う。
+
+    メール起票の下書きで product_id が修正された場合は、その対応を製品別名辞書
+    （product_name_aliases）へ記録する（Issue #347）。
     """
     logger.info(f"Updating order {order_id}")
+    order_before = repo.get_by_id(order_id)
     result = repo.update(order_id, order_data.model_dump(exclude_unset=True))
     if not result:
         raise HTTPException(status_code=404, detail="Not found")
+
+    record_correction_if_applicable(client, tenant_id, order_before, result, user_id)
+
     return _map_order_response(result)
 
 
@@ -358,6 +369,7 @@ def split_order(
     order_id: int,
     split_data: OrderSplitRequest,
     tenant_id: str = Depends(get_current_tenant_id),
+    user_id: str = Depends(get_current_user_id),
     repo: OrderRepository = Depends(get_order_repo),
     client: Client = Depends(get_supabase_client),
 ):
@@ -432,6 +444,8 @@ def split_order(
                 }
             )
             created_orders.append(new_order)
+
+            record_correction_if_applicable(client, tenant_id, None, new_order, user_id)
 
             client.table(SupabaseTableName.ORDER_ATTACHMENTS.value).insert(
                 {

--- a/backend/app/services/pdf_order_parsing_service.py
+++ b/backend/app/services/pdf_order_parsing_service.py
@@ -8,7 +8,11 @@ from app.services.email_extraction_service import extract_email_order_lines
 from app.services.notification_service import create_notification
 from app.services.pdf_order_extraction_service import extract_order_lines
 from app.services.pdf_text_service import extract_text
-from app.services.product_matching_service import match_product_by_code, match_products
+from app.services.product_matching_service import (
+    match_product_by_alias,
+    match_product_by_code,
+    match_products,
+)
 from app.utils.logger import get_logger
 from supabase import Client
 
@@ -288,12 +292,21 @@ def _resolve_product_id(
     product_name_raw: str | None,
 ) -> int | None:
     """
+    0. product_name_aliases（過去に担当者が確定させた表記ゆれ辞書）の完全一致
+       （Issue #347。extracted_product_name と同じ値 = product_name_raw or
+       product_number_raw で検索する）
     1. products.code の完全一致
     2. products.name に対する品番文字列でのpg_trgm検索
        （code列が未整備で、name列に品番文字列が入っているテナントに対応するため）
     3. products.name に対する品名文字列でのpg_trgm検索
     の順にフォールバックして product_id を解決する。
     """
+    alias_raw_text = product_name_raw or product_number_raw
+    if alias_raw_text:
+        alias_product_id = match_product_by_alias(db, tenant_id, alias_raw_text)
+        if alias_product_id is not None:
+            return alias_product_id
+
     product_id: int | None = None
     if product_number_raw:
         product_id = match_product_by_code(db, tenant_id, product_number_raw)

--- a/backend/app/services/product_alias_service.py
+++ b/backend/app/services/product_alias_service.py
@@ -1,0 +1,137 @@
+# services/product_alias_service.py
+"""メール起票の下書き注文で product_id が修正された場合に、
+raw_text（extracted_product_name）→ product_id の対応を製品別名辞書
+（product_name_aliases）へ蓄積し、修正履歴（product_name_alias_history）に
+追記するサービス（Issue #347）。
+
+orders.product_id を更新する経路は今後も増えうるため、更新箇所ごとに個別実装
+するのではなく、必ず record_correction_if_applicable() を通すこと。現在の
+呼び出し元は以下の2経路（backend/app/routers/transaction/orders.py）:
+
+- PATCH /orders/{id}（update_order）: 修正前後の product_id が異なる場合
+- POST /orders/{id}/split（split_order）: 分割後の各明細に product_id が
+  設定される場合（元の下書きの extracted_product_name を明細ごとに引き継ぐ）
+"""
+
+from typing import Any, cast
+
+from postgrest.exceptions import APIError
+
+from app.repositories.supa_infra.common.table_name import SupabaseTableName
+from app.utils.logger import get_logger
+from supabase import Client
+
+logger = get_logger(__name__)
+
+
+def record_correction_if_applicable(
+    client: Client,
+    tenant_id: str,
+    order_before: dict[str, Any] | None,
+    order_after: dict[str, Any],
+    changed_by: str,
+) -> None:
+    """注文の product_id 修正を別名候補として記録する。
+
+    以下のいずれかに該当する場合は何もしない（発火しない）:
+    - order_after["source_type"] が "email" 以外（手動起票等）
+    - order_after["extracted_product_name"] が未設定
+    - order_after["product_id"] が未設定
+    - 変更前後の product_id が同一（実質的な修正でない）
+    """
+    if order_after.get("source_type") != "email":
+        return
+
+    raw_text = order_after.get("extracted_product_name")
+    if not raw_text or not raw_text.strip():
+        return
+    raw_text = raw_text.strip()
+
+    new_product_id = order_after.get("product_id")
+    if new_product_id is None:
+        return
+
+    before_product_id = order_before.get("product_id") if order_before else None
+    if before_product_id == new_product_id:
+        return
+
+    product_res = (
+        client.table(SupabaseTableName.PRODUCTS.value)
+        .select("name")
+        .eq("id", new_product_id)
+        .single()
+        .execute()
+    )
+    product_name = cast(dict[str, Any] | None, product_res.data) or {}
+    product_name_snapshot = product_name.get("name") or "不明"
+
+    order_id = order_after.get("id")
+    order_label_snapshot = order_after.get("order_number") or (
+        f"注文 #{order_id}" if order_id is not None else "不明"
+    )
+
+    action = _upsert_alias(client, tenant_id, raw_text, new_product_id, changed_by)
+
+    client.table(SupabaseTableName.PRODUCT_NAME_ALIAS_HISTORY.value).insert(
+        {
+            "tenant_id": tenant_id,
+            "product_id": new_product_id,
+            "product_name_snapshot": product_name_snapshot,
+            "raw_text": raw_text,
+            "changed_by": changed_by,
+            "action": action,
+            "source_order_id": order_id,
+            "source_order_label_snapshot": order_label_snapshot,
+        }
+    ).execute()
+
+    logger.info(
+        f"product_alias_service: {action} alias raw_text={raw_text!r} "
+        f"-> product_id={new_product_id} (order_id={order_id})"
+    )
+
+
+def _upsert_alias(
+    client: Client,
+    tenant_id: str,
+    raw_text: str,
+    product_id: int,
+    changed_by: str,
+) -> str:
+    """product_name_aliases を UPSERT する。postgrest-py の on_conflict は条件付き
+    ロジックを表現できないため使わず、既存有無を確認した上で insert/update を
+    分岐する（docs/features/pdf-order-parsing.md の同種の議論を参照）。
+    """
+    existing_res = (
+        client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value)
+        .select("id")
+        .eq("tenant_id", tenant_id)
+        .eq("raw_text", raw_text)
+        .execute()
+    )
+    existing_rows = cast(list[dict[str, Any]], existing_res.data or [])
+
+    if existing_rows:
+        client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value).update(
+            {"product_id": product_id, "created_by": changed_by}
+        ).eq("tenant_id", tenant_id).eq("raw_text", raw_text).execute()
+        return "updated"
+
+    try:
+        client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value).insert(
+            {
+                "tenant_id": tenant_id,
+                "raw_text": raw_text,
+                "product_id": product_id,
+                "created_by": changed_by,
+            }
+        ).execute()
+        return "created"
+    except APIError as e:
+        if e.code != "23505":
+            raise
+        # 同時リクエストによる競合挿入: 既に存在するので更新として扱う
+        client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value).update(
+            {"product_id": product_id, "created_by": changed_by}
+        ).eq("tenant_id", tenant_id).eq("raw_text", raw_text).execute()
+        return "updated"

--- a/backend/app/services/product_alias_service.py
+++ b/backend/app/services/product_alias_service.py
@@ -38,7 +38,30 @@ def record_correction_if_applicable(
     - order_after["extracted_product_name"] が未設定
     - order_after["product_id"] が未設定
     - 変更前後の product_id が同一（実質的な修正でない）
+
+    注文本体の更新（呼び出し元の repo.update() / repo.create()）とは別トランザクション
+    のベストエフォート処理。ここで例外が発生しても、既に完了している注文更新自体を
+    失敗として扱わせない（クライアントの誤ったリトライによる二重更新を防ぐ）ため、
+    例外を送出せずログに記録するのみとする（PRレビュー指摘対応）。
     """
+    try:
+        _record_correction(client, tenant_id, order_before, order_after, changed_by)
+    except Exception:
+        order_id = order_after.get("id")
+        logger.error(
+            f"product_alias_service: failed to record alias correction "
+            f"for order_id={order_id}",
+            exc_info=True,
+        )
+
+
+def _record_correction(
+    client: Client,
+    tenant_id: str,
+    order_before: dict[str, Any] | None,
+    order_after: dict[str, Any],
+    changed_by: str,
+) -> None:
     if order_after.get("source_type") != "email":
         return
 
@@ -112,8 +135,11 @@ def _upsert_alias(
     existing_rows = cast(list[dict[str, Any]], existing_res.data or [])
 
     if existing_rows:
+        # created_by は「最初に登録したユーザー」を表す監査カラムのため、
+        # 再修正（UPSERT の上書き）時にも書き換えない。誰が今回の修正を
+        # 行ったかは product_name_alias_history.changed_by 側に記録される。
         client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value).update(
-            {"product_id": product_id, "created_by": changed_by}
+            {"product_id": product_id}
         ).eq("tenant_id", tenant_id).eq("raw_text", raw_text).execute()
         return "updated"
 
@@ -132,6 +158,6 @@ def _upsert_alias(
             raise
         # 同時リクエストによる競合挿入: 既に存在するので更新として扱う
         client.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value).update(
-            {"product_id": product_id, "created_by": changed_by}
+            {"product_id": product_id}
         ).eq("tenant_id", tenant_id).eq("raw_text", raw_text).execute()
         return "updated"

--- a/backend/app/services/product_matching_service.py
+++ b/backend/app/services/product_matching_service.py
@@ -41,6 +41,28 @@ def match_product_by_code(db: Client, tenant_id: str, code: str) -> int | None:
     return None
 
 
+def match_product_by_alias(db: Client, tenant_id: str, raw_text: str) -> int | None:
+    """
+    製品別名辞書 (product_name_aliases) の完全一致で製品を検索する（Issue #347）。
+
+    過去に担当者が確定させた「生テキスト → 製品」の対応を pg_trgm の曖昧マッチング
+    より優先して使うことで、表記ゆれの再発による未マッチ・誤マッチを減らす。
+    raw_text の正規化は orders.extracted_product_name と同様 TRIM() のみ。
+    """
+    result = (
+        db.table(SupabaseTableName.PRODUCT_NAME_ALIASES.value)
+        .select("product_id")
+        .eq("tenant_id", tenant_id)
+        .eq("raw_text", raw_text.strip())
+        .limit(1)
+        .execute()
+    )
+    rows = cast(list[dict[str, Any]], result.data or [])
+    if rows:
+        return int(rows[0]["product_id"])
+    return None
+
+
 def match_products(db: Client, tenant_id: str, product_name: str) -> dict[str, Any]:
     """
     pg_trgm で製品名を類似度検索する。

--- a/docs/features/email-order-intake.md
+++ b/docs/features/email-order-intake.md
@@ -289,6 +289,11 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
   を参照。なお `orders.product_candidates`（複数候補のjsonb保存）カラム自体は存在するが、
   実際の自動起票パイプラインからは未使用（デモ用シードスクリプトのみが書き込む）で
   あり、候補提示UIは本Issueのスコープ外として別Issueに切り出されている
+- 担当者が下書きの `product_id` を選び直して表記ゆれを修正すると、その対応
+  （`extracted_product_name` → `product_id`）は別名辞書（`product_name_aliases`）
+  へ自動的にフィードバックされ、以後の同じ表記ゆれは pg_trgm 曖昧検索より優先して
+  即マッチする。詳細は [pdf-order-parsing.md](pdf-order-parsing.md) の
+  「製品名の表記ゆれ辞書による自動補完（Issue #347）」を参照
 - 顧客が特定できない場合でも `customer_id` は必ず設定される（下書き顧客の自動作成）。
   詳細は [customer-draft-auto-create.md](customer-draft-auto-create.md) を参照
 - PDF添付メール経由で起票された注文は、PDF文面から抽出した顧客側の確度（確定/内示/内々示）
@@ -317,3 +322,4 @@ Gmail ラベルの `{テナント名}` 部分と `tenant_id` の対応は `gmail
 | 手動分割UI（`POST /orders/{id}/split`、詳細は[pdf-order-parsing.md](pdf-order-parsing.md)） | ✅ #280 |
 | `gmail-poll` / `parse-order-pdfs` の高頻度スケジューリング（Supabase Edge Function + pg_cron、詳細は[supabase-pgcron-parse-order-pdfs.md](../infra/supabase-pgcron-parse-order-pdfs.md)） | ✅ #261 |
 | 製品未マッチ明細のNULL product_id下書き起票（詳細は[pdf-order-parsing.md](pdf-order-parsing.md)） | ✅ #296 |
+| 製品名の表記ゆれ辞書による自動補完・修正履歴管理（詳細は[pdf-order-parsing.md](pdf-order-parsing.md)、[product-master.md](product-master.md#別名辞書-product_name_aliasesissue-347)） | ✅ #347 |

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -274,6 +274,30 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
 - `extracted_product_name` または `deadline_date` が NULL で重複判定に使える
   情報が無い場合は、常に新規行として挿入する（重複を許容する）
 
+### 製品名の表記ゆれ辞書による自動補完（Issue #347）
+
+製品未マッチ（Issue #296）や誤マッチの原因の多くは、メール本文中の製品名表記が
+`products.name`/`products.code` と完全一致しない「表記ゆれ」であり、担当者が
+下書きの `product_id` を選び直すことで都度手動修正されていた。この修正結果を
+「生テキスト（`raw_text` = `extracted_product_name` と同じ値）→ 製品」の対応と
+して `product_name_aliases` テーブルへ蓄積し、以後の自動マッチングに活用する。
+
+- `_resolve_product_id()`（`pdf_order_parsing_service.py`）は
+  `match_product_by_alias()`（`product_matching_service.py`）による別名辞書の
+  完全一致検索を、`products.code` 完全一致・pg_trgm 曖昧検索よりも前段で行う。
+  一致すればそれを最上位の確度として即採用し、以降の照合はスキップする
+- 別名の記録は `backend/app/services/product_alias_service.py` の
+  `record_correction_if_applicable()` が担い、`PATCH /orders/{id}` と
+  `POST /orders/{id}/split` の両経路（`orders.py`）から呼ばれる。対象注文が
+  `source_type='email'` かつ `extracted_product_name` が設定されている場合のみ、
+  修正前後で `product_id` が変化したときに発火する（手動起票の注文編集では
+  発火しない）
+- 別名登録自体は承認不要（`order_handler` 権限で完結）だが、
+  `product_name_alias_history` に「いつ・誰が・どの注文をトリガに」修正したかを
+  追記のみで記録する。詳細なテーブル定義・履歴閲覧APIは
+  [product-master.md](./product-master.md#別名辞書-product_name_aliasesissue-347)
+  を参照
+
 ---
 
 ## DB スキーマ変更
@@ -316,6 +340,17 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
 | `completed`  | 完了                 |
 | `canceled`   | キャンセル           |
 
+`supabase/migrations/20260819000001_add_product_name_aliases.sql`（Issue #347）:
+
+- 新規テーブル `product_name_aliases`: `id, tenant_id, product_id (FK, ON DELETE
+  CASCADE), raw_text, created_by, created_at, updated_at`。`(tenant_id, raw_text)`
+  UNIQUE。同一 `raw_text` への再修正は UPSERT（上書き）する
+- 新規テーブル `product_name_alias_history`: `id, tenant_id, product_id (FK, ON
+  DELETE SET NULL), product_name_snapshot, raw_text, changed_by, changed_at,
+  action ('created'/'updated'), source_order_id (FK, ON DELETE SET NULL),
+  source_order_label_snapshot`。追記のみ（UPDATE/DELETEしない）
+- 両テーブルとも RLS (`is_tenant_member(tenant_id)`) を設定
+
 `supabase/migrations/20260712000000_add_orders_dedupe_key_unmatched_product.sql`（Issue #296）:
 
 - 部分UNIQUE制約 `orders_dedupe_key_unmatched_product`（`product_id IS NULL` の行専用）を追加
@@ -352,12 +387,22 @@ dedupeキーに一致する既存orderが見つかった場合、以下のルー
   - `validate_cron_secret(request)`（`gmail_poll.py` と共通化）
 - `backend/app/routers/cron/parse_order_pdfs.py`
   - `GET /api/cron/parse-order-pdfs`
+- `supabase/migrations/20260819000001_add_product_name_aliases.sql`（Issue #347）
+- `backend/app/services/product_alias_service.py`（Issue #347）
+  - `record_correction_if_applicable(client, tenant_id, order_before, order_after, changed_by)`
+- `backend/app/repositories/supa_infra/master/product_name_alias_repo.py`（Issue #347）
+  - `ProductNameAliasHistoryRepository`
 
 ### 既存ファイルへの追加
 
-- `backend/app/services/product_matching_service.py`: `match_product_by_code()` を追加
+- `backend/app/services/product_matching_service.py`: `match_product_by_code()` を追加。
+  `match_product_by_alias()` を追加（Issue #347）
 - `backend/app/services/attachment_service.py`: `download_attachment()` を追加
-- `backend/app/repositories/supa_infra/common/table_name.py`: `ORDER_PARSE_LOG` を追加
+- `backend/app/repositories/supa_infra/common/table_name.py`: `ORDER_PARSE_LOG` を追加。
+  `PRODUCT_NAME_ALIASES` / `PRODUCT_NAME_ALIAS_HISTORY` を追加（Issue #347）
+- `backend/app/routers/transaction/orders.py`: `update_order` / `split_order` に
+  `record_correction_if_applicable()` の呼び出しを追加（Issue #347）
+- `backend/app/routers/master/products.py`: `GET /products/{product_id}/aliases` を追加（Issue #347）
 - `backend/requirements.txt`: `pdfplumber==0.11.10`
 
 Issue #252 での追加:
@@ -502,6 +547,16 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
 - [x] 暗号化PDF・画像PDFで解析自体に失敗した場合も、顧客IDのみで
       `product_id`/`quantity`/`deadline_date` が `NULL` の下書き order が起票される
       （Issue #304）
+- [x] `product_name_aliases` / `product_name_alias_history` テーブルがマイグレーションで
+      追加され、RLS が設定されている（Issue #347）
+- [x] メール起票下書きの `product_id` 修正時（`PATCH /orders/{id}` /
+      `POST /orders/{id}/split` の両方）に、共通サービス関数経由で別名が
+      自動記録される。手動起票の注文編集では記録されない（Issue #347）
+- [x] 同一 `raw_text` への再修正時に履歴が追記され、`product_name_aliases` には
+      最新の対応が反映される（Issue #347）
+- [x] `product_matching_service` が別名辞書を pg_trgm より優先的に参照する（Issue #347）
+- [x] `GET /master/products/{product_id}/aliases` が登録者表示名・トリガー注文情報を
+      含む集約レスポンスを返す（Issue #347）
 
 ### 手動分割UI（Issue #280 Phase3）
 
@@ -652,3 +707,4 @@ order-attachments バケットに事前アップロード済みの実PDF（飯�
 - [order-attachments.md](order-attachments.md): PDFステージング保存基盤（Issue #248、前提）
 - Issue #252: 既存orderのupsert処理（内示→確定の昇格・数量更新対応）。本ドキュメントに統合
 - [notifications.md](notifications.md): 処理ログの通知UI（Issue #254、`order_parse_log` を利用）
+- [product-master.md](product-master.md#別名辞書-product_name_aliasesissue-347): 製品名の表記ゆれ辞書・修正履歴管理（Issue #347）

--- a/docs/features/pdf-order-parsing.md
+++ b/docs/features/pdf-order-parsing.md
@@ -555,7 +555,7 @@ MULTI_ORDER_SUSPECTED_QUANTITY_THRESHOLD=100000  # 1明細の数量がこれを�
 - [x] 同一 `raw_text` への再修正時に履歴が追記され、`product_name_aliases` には
       最新の対応が反映される（Issue #347）
 - [x] `product_matching_service` が別名辞書を pg_trgm より優先的に参照する（Issue #347）
-- [x] `GET /master/products/{product_id}/aliases` が登録者表示名・トリガー注文情報を
+- [x] `GET /products/{product_id}/aliases` が登録者表示名・トリガー注文情報を
       含む集約レスポンスを返す（Issue #347）
 
 ### 手動分割UI（Issue #280 Phase3）

--- a/docs/features/product-master.md
+++ b/docs/features/product-master.md
@@ -63,6 +63,7 @@ const displayName = product.code ? product.name : null  // 製品名として表
 |---|---|---|
 | 編集 | 全員 | 品番・製品名を変更するダイアログ |
 | 工程管理 | 全員 | 製造工程ルーティングを管理（`ProductRoutingsDialog`） |
+| 表記ゆれ履歴 | 全員 | メール起票時の製品名表記ゆれ修正履歴を表示（`ProductNameAliasHistoryDialog`、#347） |
 | 有効化 / 無効化 | admin のみ | 確認モーダル経由で状態変更 |
 | 削除 | admin のみ | 確認ダイアログ付き（取り消し不可） |
 
@@ -82,8 +83,10 @@ const displayName = product.code ? product.name : null  // 製品名として表
 | `frontend/src/hooks/use-tenant-members.ts` | `useCurrentMember()` フック（権限制御） |
 | `frontend/src/components/master-pagination.tsx` | 共通ページネーション |
 | `frontend/src/components/product-routings-dialog.tsx` | 工程管理ダイアログ |
+| `frontend/src/components/product-name-alias-history-dialog.tsx` | 表記ゆれ履歴ダイアログ（#347） |
 | `frontend/src/components/product-selector.tsx` | 受注入力の製品選択（有効製品のみ表示） |
-| `backend/app/routers/master/products.py` | REST API エンドポイント |
+| `backend/app/routers/master/products.py` | REST API エンドポイント（`GET /products/{id}/aliases` を含む） |
+| `backend/app/services/product_alias_service.py` | 製品名別名の記録サービス（#347） |
 
 ## 工程ルーティング (process_routings)
 
@@ -123,6 +126,57 @@ admin ロール限定の確定 UI はダイアログに実装済み（✅ Issue 
 
 ---
 
+## 別名辞書 (product_name_aliases)（Issue #347）
+
+メールから受注下書きを自動起票する際に製品名の表記ゆれで未マッチ・誤マッチと
+なった明細を、担当者（`order_handler`）が下書きの `product_id` を選び直すことで
+修正するフローがある（詳細: [email-order-intake.md](./email-order-intake.md)）。
+この修正結果を「生テキスト（`raw_text`）→ 製品」の対応として蓄積し、以後の
+自動マッチングで pg_trgm 曖昧検索より優先して使う。別名登録自体は
+`president` の承認を必要とせず、`order_handler` 権限で完結する。
+
+### データモデル
+
+| テーブル | カラム | 説明 |
+|---|---|---|
+| `product_name_aliases` | `id`, `tenant_id`, `product_id` (FK, `ON DELETE CASCADE`), `raw_text`, `created_by`, `created_at`, `updated_at` | `raw_text`（`extracted_product_name` と同じ `TRIM()` のみの正規化）ごとに最新の対応を1件保持。`(tenant_id, raw_text)` UNIQUE。同一 `raw_text` への再修正は UPSERT（上書き） |
+| `product_name_alias_history` | `id`, `tenant_id`, `product_id` (FK, `ON DELETE SET NULL`), `product_name_snapshot`, `raw_text`, `changed_by`, `changed_at`, `action` (`created`/`updated`), `source_order_id` (FK, `ON DELETE SET NULL`), `source_order_label_snapshot` | 追記のみの修正履歴。製品削除・注文削除で行が消えないよう `ON DELETE SET NULL` とし、削除後も文脈が読めるようスナップショット列（製品表示名・注文ラベル）を保持する |
+
+### 記録経路
+
+`backend/app/services/product_alias_service.py` の
+`record_correction_if_applicable(client, tenant_id, order_before, order_after, changed_by)`
+が唯一の記録経路。以下の2箇所（`backend/app/routers/transaction/orders.py`）から
+呼ばれる。今後 `orders.product_id` を更新する処理を追加する場合も、この関数を
+通すこと（登録漏れ防止のため個別実装しない）。
+
+- `PATCH /orders/{id}`（`update_order`）: 修正前後の `product_id` が異なる場合
+- `POST /orders/{id}/split`（`split_order`）: 分割後の各明細に `product_id` が
+  設定される場合（元の下書きの `extracted_product_name` を明細ごとに引き継ぐ）
+
+発火条件（いずれかに該当する場合は記録しない）:
+
+- 対象注文の `source_type` が `email` 以外（手動起票の注文編集では発火しない）
+- `extracted_product_name` が未設定
+- 変更前後の `product_id` が同一（実質的な修正でない）
+
+### マッチングへの反映
+
+`backend/app/services/product_matching_service.py` の `match_product_by_alias()` が
+`product_name_aliases` の完全一致検索を行う。`pdf_order_parsing_service.py` の
+`_resolve_product_id()` はこれを `products.code` 完全一致・pg_trgm 曖昧検索より
+前段で呼び出し、一致すればそれらをスキップして即採用する。
+
+### 履歴の閲覧
+
+`GET /products/{product_id}/aliases` が `product_name_alias_history` の生データ
+ではなく、`changed_by` を担当者の表示名に、`source_order_id` を注文へのリンクに
+解決した集約レスポンスを返す。フロントエンドは製品マスタのケバブメニュー
+「表記ゆれ履歴」から `ProductNameAliasHistoryDialog`（`useProductNameAliasHistory`
+フック）で一覧表示する。
+
+---
+
 ## 変更履歴
 
 | PR | 内容 |
@@ -133,3 +187,4 @@ admin ロール限定の確定 UI はダイアログに実装済み（✅ Issue 
 | #226 | 製品マスタ画面に工程登録状況（`has_process`）を表示（Issue #223） |
 | #227 | 新規注文フォームの製品プルダウンに工程未登録警告を表示（Issue #224） |
 | #310 | フィルタ変更時に `page` を1にリセットするよう修正（Issue #309） |
+| #347 | メール起票の製品名修正結果を別名辞書（`product_name_aliases`）として蓄積・履歴管理する機能を追加（Issue #347） |

--- a/frontend/src/app/master/products/page.tsx
+++ b/frontend/src/app/master/products/page.tsx
@@ -48,6 +48,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { ProductRoutingsDialog } from "@/components/product-routings-dialog"
+import { ProductNameAliasHistoryDialog } from "@/components/product-name-alias-history-dialog"
 import { MasterPagination } from "@/components/master-pagination"
 
 const PAGE_SIZE = 20
@@ -72,6 +73,7 @@ export default function ProductsPage() {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const [isRoutingsDialogOpen, setIsRoutingsDialogOpen] = useState(false)
+  const [isAliasHistoryDialogOpen, setIsAliasHistoryDialogOpen] = useState(false)
   const [isToggleActiveDialogOpen, setIsToggleActiveDialogOpen] = useState(false)
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null)
   const [toggleActiveTarget, setToggleActiveTarget] = useState<Product | null>(null)
@@ -178,6 +180,11 @@ export default function ProductsPage() {
   const handleOpenRoutingsDialog = (product: Product) => {
     setSelectedProduct(product)
     setIsRoutingsDialogOpen(true)
+  }
+
+  const handleOpenAliasHistoryDialog = (product: Product) => {
+    setSelectedProduct(product)
+    setIsAliasHistoryDialogOpen(true)
   }
 
   const handleOpenToggleActiveDialog = (product: Product) => {
@@ -405,6 +412,9 @@ export default function ProductsPage() {
                             <DropdownMenuItem onClick={() => handleOpenRoutingsDialog(product)}>
                               工程管理
                             </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => handleOpenAliasHistoryDialog(product)}>
+                              表記ゆれ履歴
+                            </DropdownMenuItem>
                             {isAdmin && (
                               <DropdownMenuItem onClick={() => handleOpenToggleActiveDialog(product)}>
                                 {product.is_active ? "無効化" : "有効化"}
@@ -593,6 +603,13 @@ export default function ProductsPage() {
         product={selectedProduct}
         open={isRoutingsDialogOpen}
         onOpenChange={setIsRoutingsDialogOpen}
+      />
+
+      {/* 表記ゆれ履歴ダイアログ */}
+      <ProductNameAliasHistoryDialog
+        product={selectedProduct}
+        open={isAliasHistoryDialogOpen}
+        onOpenChange={setIsAliasHistoryDialogOpen}
       />
     </div>
   )

--- a/frontend/src/components/product-name-alias-history-dialog.tsx
+++ b/frontend/src/components/product-name-alias-history-dialog.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+import Link from "next/link"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useProductNameAliasHistory } from "@/hooks/use-products"
+import type { Product } from "@/types/product"
+
+interface ProductNameAliasHistoryDialogProps {
+  product: Product | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  created: "新規登録",
+  updated: "上書き修正",
+}
+
+/**
+ * 製品名の表記ゆれ修正履歴ダイアログ（Issue #347）
+ *
+ * メール起票の下書きで担当者が product_id を修正した際に記録される
+ * 別名（raw_text → product_id）の対応履歴を、いつ・誰が・どの注文を
+ * トリガに登録したかとあわせて一覧表示する。
+ */
+export function ProductNameAliasHistoryDialog({
+  product,
+  open,
+  onOpenChange,
+}: ProductNameAliasHistoryDialogProps) {
+  const { data: history, isLoading } = useProductNameAliasHistory(product?.id ?? null)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>表記ゆれ履歴</DialogTitle>
+          <DialogDescription>
+            {product?.name}
+            （{product?.code}）について、メール起票時の製品名の表記ゆれを
+            担当者が修正した履歴です。
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            読み込み中...
+          </div>
+        ) : !history || history.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            表記ゆれの修正履歴はありません
+          </p>
+        ) : (
+          <div className="max-h-[60vh] overflow-y-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>メール上の表記</TableHead>
+                  <TableHead>区分</TableHead>
+                  <TableHead>登録者</TableHead>
+                  <TableHead>トリガー注文</TableHead>
+                  <TableHead>登録日時</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.map((entry) => (
+                  <TableRow key={entry.id}>
+                    <TableCell className="font-medium">{entry.raw_text}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {ACTION_LABELS[entry.action] ?? entry.action}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{entry.changed_by_full_name ?? "不明"}</TableCell>
+                    <TableCell>
+                      {entry.source_order_id ? (
+                        <Link
+                          href={`/orders/${entry.source_order_id}`}
+                          className="text-primary underline underline-offset-2"
+                        >
+                          {entry.source_order_label_snapshot}
+                        </Link>
+                      ) : (
+                        entry.source_order_label_snapshot
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {new Date(entry.changed_at).toLocaleString("ja-JP")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/hooks/use-products.ts
+++ b/frontend/src/hooks/use-products.ts
@@ -2,7 +2,12 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { apiClient } from "@/lib/api-client"
-import type { Product, ProductCreate, ProductUpdate } from "@/types/product"
+import type {
+  Product,
+  ProductCreate,
+  ProductNameAliasHistoryEntry,
+  ProductUpdate,
+} from "@/types/product"
 
 // クエリキーを定数化
 export const PRODUCTS_QUERY_KEY = ["products"]
@@ -70,6 +75,18 @@ export function useDeleteProduct() {
       // 製品一覧を再取得
       queryClient.invalidateQueries({ queryKey: PRODUCTS_QUERY_KEY })
     },
+  })
+}
+
+/**
+ * 製品名の表記ゆれ修正履歴を取得するフック（Issue #347）
+ */
+export function useProductNameAliasHistory(productId: number | null) {
+  return useQuery<ProductNameAliasHistoryEntry[]>({
+    queryKey: ["products", productId, "aliases"],
+    queryFn: () =>
+      apiClient<ProductNameAliasHistoryEntry[]>(`/products/${productId}/aliases`),
+    enabled: productId !== null,
   })
 }
 

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -32,3 +32,22 @@ export interface ProductUpdate {
   type?: string
   is_active?: boolean
 }
+
+/**
+ * 製品名の表記ゆれ修正履歴（Issue #347）
+ *
+ * product_name_alias_history の生データではなく、登録者の表示名・
+ * トリガーとなった注文情報を解決した集約レスポンス。
+ */
+export interface ProductNameAliasHistoryEntry {
+  id: string
+  product_id: number | null
+  product_name_snapshot: string
+  raw_text: string
+  changed_by: string
+  changed_by_full_name: string | null
+  action: "created" | "updated"
+  source_order_id: number | null
+  source_order_label_snapshot: string
+  changed_at: string
+}

--- a/supabase/migrations/20260819000001_add_product_name_aliases.sql
+++ b/supabase/migrations/20260819000001_add_product_name_aliases.sql
@@ -1,0 +1,65 @@
+-- 製品名の表記ゆれ辞書（メールから起票された下書き注文の product_id 修正結果を
+-- 別名として蓄積し、以後の自動マッチングに活用する。Issue #347）
+
+-- product_name_aliases: raw_text（メール抽出時の extracted_product_name）から
+-- 製品への最新の対応を保持する。同一 raw_text への再修正は UPSERT（上書き）する。
+CREATE TABLE product_name_aliases (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   uuid NOT NULL REFERENCES tenants(id),
+  product_id  bigint NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  raw_text    text NOT NULL,
+  created_by  uuid NOT NULL REFERENCES auth.users(id),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, raw_text)
+);
+
+ALTER TABLE product_name_aliases ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant members can manage product_name_aliases"
+  ON product_name_aliases
+  FOR ALL
+  USING (is_tenant_member(tenant_id))
+  WITH CHECK (is_tenant_member(tenant_id));
+
+-- backend/app/dependencies.py の get_supabase_admin_client 経由（cron によるメール/PDF
+-- 起票パイプライン）は Service Role Key で RLS をバイパスするため、上記ポリシーは
+-- ユーザーJWT経由の呼び出し（別名の登録・履歴閲覧）のみに適用される。
+CREATE TRIGGER product_name_aliases_set_updated_at
+  BEFORE UPDATE ON product_name_aliases
+  FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+CREATE INDEX idx_product_name_aliases_tenant_raw_text
+  ON product_name_aliases (tenant_id, raw_text);
+
+-- product_name_alias_history: 追記のみの監査履歴。product_id / source_order_id は
+-- 製品削除・注文削除で行ごと消えないよう ON DELETE SET NULL とし、削除後も文脈が
+-- 読めるようスナップショット列（製品表示名・注文ラベル）を保持する。
+CREATE TABLE product_name_alias_history (
+  id                          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id                   uuid NOT NULL REFERENCES tenants(id),
+  product_id                  bigint REFERENCES products(id) ON DELETE SET NULL,
+  product_name_snapshot       text NOT NULL,
+  raw_text                    text NOT NULL,
+  changed_by                  uuid NOT NULL REFERENCES auth.users(id),
+  changed_at                  timestamptz NOT NULL DEFAULT now(),
+  action                      text NOT NULL CHECK (action IN ('created', 'updated')),
+  source_order_id             bigint REFERENCES orders(id) ON DELETE SET NULL,
+  source_order_label_snapshot text NOT NULL
+);
+
+ALTER TABLE product_name_alias_history ENABLE ROW LEVEL SECURITY;
+
+-- 追記のみの監査履歴のため UPDATE/DELETE ポリシーは設けない
+CREATE POLICY "tenant members can view product_name_alias_history"
+  ON product_name_alias_history
+  FOR SELECT
+  USING (is_tenant_member(tenant_id));
+
+CREATE POLICY "tenant members can insert product_name_alias_history"
+  ON product_name_alias_history
+  FOR INSERT
+  WITH CHECK (is_tenant_member(tenant_id) AND changed_by = auth.uid());
+
+CREATE INDEX idx_product_name_alias_history_tenant_product
+  ON product_name_alias_history (tenant_id, product_id, changed_at DESC);

--- a/supabase/migrations/20260819000001_add_product_name_aliases.sql
+++ b/supabase/migrations/20260819000001_add_product_name_aliases.sql
@@ -16,18 +16,48 @@ CREATE TABLE product_name_aliases (
 
 ALTER TABLE product_name_aliases ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "tenant members can manage product_name_aliases"
+-- backend/app/dependencies.py の get_supabase_admin_client 経由（cron によるメール/PDF
+-- 起票パイプライン）は Service Role Key で RLS をバイパスするため、以下のポリシーは
+-- ユーザーJWT経由の呼び出し（別名の登録・履歴閲覧）のみに適用される。
+CREATE POLICY "tenant members can view product_name_aliases"
   ON product_name_aliases
-  FOR ALL
+  FOR SELECT
+  USING (is_tenant_member(tenant_id));
+
+-- created_by は「最初に登録したユーザー」を表す監査カラム。クライアントが任意の
+-- created_by を指定して他人になりすませないよう、INSERT時は auth.uid() と一致する
+-- ことを強制する（PRレビュー指摘対応）。UPDATE（別名の上書き）では created_by を
+-- 変更させない（下の product_name_aliases_preserve_created_by トリガー参照）。
+CREATE POLICY "tenant members can insert product_name_aliases"
+  ON product_name_aliases
+  FOR INSERT
+  WITH CHECK (is_tenant_member(tenant_id) AND created_by = auth.uid());
+
+CREATE POLICY "tenant members can update product_name_aliases"
+  ON product_name_aliases
+  FOR UPDATE
   USING (is_tenant_member(tenant_id))
   WITH CHECK (is_tenant_member(tenant_id));
 
--- backend/app/dependencies.py の get_supabase_admin_client 経由（cron によるメール/PDF
--- 起票パイプライン）は Service Role Key で RLS をバイパスするため、上記ポリシーは
--- ユーザーJWT経由の呼び出し（別名の登録・履歴閲覧）のみに適用される。
 CREATE TRIGGER product_name_aliases_set_updated_at
   BEFORE UPDATE ON product_name_aliases
   FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+-- created_by（最初の登録者）はUPDATEでは変更させない。誰が今回の修正を行ったかは
+-- product_name_alias_history.changed_by 側に記録される（PRレビュー指摘対応）。
+CREATE OR REPLACE FUNCTION public.preserve_product_name_alias_created_by()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.created_by := OLD.created_by;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER product_name_aliases_preserve_created_by
+  BEFORE UPDATE ON product_name_aliases
+  FOR EACH ROW EXECUTE PROCEDURE public.preserve_product_name_alias_created_by();
 
 CREATE INDEX idx_product_name_aliases_tenant_raw_text
   ON product_name_aliases (tenant_id, raw_text);
@@ -61,5 +91,8 @@ CREATE POLICY "tenant members can insert product_name_alias_history"
   FOR INSERT
   WITH CHECK (is_tenant_member(tenant_id) AND changed_by = auth.uid());
 
-CREATE INDEX idx_product_name_alias_history_tenant_product
-  ON product_name_alias_history (tenant_id, product_id, changed_at DESC);
+-- 取得クエリ（ProductNameAliasHistoryRepository.get_by_product_id）は product_id の
+-- みで絞り込む（tenant分離はRLSに委譲）ため、そのクエリ形に合わせたインデックスとする
+-- （PRレビュー指摘対応）。
+CREATE INDEX idx_product_name_alias_history_product_changed_at
+  ON product_name_alias_history (product_id, changed_at DESC);


### PR DESCRIPTION
## Summary
- メール起票の下書きで担当者が `product_id` を修正した際、`raw_text`（`extracted_product_name`）→ `product_id` の対応を新設の `product_name_aliases` へ UPSERT し、`product_name_alias_history`（追記のみ）に修正履歴を記録する
- 記録経路は共通サービス関数 `product_alias_service.record_correction_if_applicable()` に集約し、`PATCH /orders/{id}` と `POST /orders/{id}/split` の両方から呼ぶ（今後の更新経路追加時もこの関数を通す前提）
- `product_matching_service.match_product_by_alias()` を追加し、`pdf_order_parsing_service._resolve_product_id()` で `products.code` 完全一致・pg_trgm 曖昧検索より前段に、別名辞書の完全一致を優先して参照する
- `GET /products/{product_id}/aliases` を追加。生の履歴テーブルダンプではなく、登録者の表示名・トリガー注文情報を解決した集約レスポンスを返す
- フロントエンドは製品マスタのケバブメニューに「表記ゆれ履歴」を追加し、`ProductNameAliasHistoryDialog` で一覧表示（トリガー注文へのリンク付き）

## Test plan
- [x] `cd backend && pytest __tests__/unit __tests__/api` — 全件成功（別名記録サービス・別名完全一致マッチ・履歴API・pg_trgmフォールバック優先順位のテストを追加）
- [x] `cd backend && ruff check app/ && mypy .` — 変更ファイルはクリーン（未着手の既存lint債務は対象外）
- [x] `cd frontend && npx tsc --noEmit` / `npx eslint` — 変更ファイルはエラーなし
- [x] マイグレーション適用は未実施（`supabase/migrations/20260819000001_add_product_name_aliases.sql`）。本番適用はレビュー後、別途 `supabase db push` で実施予定
- [ ] フロントエンドのブラウザ動作確認は未実施（dev server起動なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
